### PR TITLE
inference/: backend abstraction for vLLM / transformers / MLX

### DIFF
--- a/experiments/exp1_document_structures_contacts_and_distances_v1/README.md
+++ b/experiments/exp1_document_structures_contacts_and_distances_v1/README.md
@@ -117,25 +117,77 @@ run — reproduces the Phase 7c trace from the
 LlamaFold-experiments notebook ("a few GT contacts as hints").
 `--query-atom` (default `CA`) picks the atom on both i and j.
 
-Verify locally via the CLI (run from this directory with the venv
-active):
+Run from this directory with the venv active.
+
+### Backend-independent commands
+
+`generate` and `tokenizer` don't load a trained model, so they don't
+need a backend extra installed:
 
 ```bash
+uv sync   # base install only
+
 uv run python cli.py generate \
     --input /path/to/afdb-cifs/ --num-docs 100 \
     --out /tmp/sample-docs.parquet
 
-uv run python cli.py infer \
-    --model open-athena/<model> --input /path/to/seqs/ \
-    --out /tmp/predictions.parquet
-
-uv run python cli.py evaluate \
-    --model open-athena/<model> --input /path/to/pdbs/ \
-    --seed-n-values 0,5,20,50 \
-    --out /tmp/metrics.json
-
 uv run python cli.py tokenizer --save-local /tmp/tok/
 uv run python cli.py tokenizer --push open-athena/contacts-and-distances-v1-tokenizer
+```
+
+### Running inference and evaluation
+
+`--backend` selects the runtime; `--model` accepts a nickname listed
+in repo-root [`MODELS.yaml`](../../MODELS.yaml) (the matching HF
+subfolder is downloaded on first use) or a local directory holding
+the model + tokenizer. Bare HF repo ids are not accepted —
+register the model in `MODELS.yaml` first.
+
+**On a GPU machine (Linux + NVIDIA):** vLLM. This is the production
+path; fastest for sweeps over many structures and seed counts.
+
+```bash
+uv sync --extra eval
+uv run python cli.py evaluate \
+    --backend vllm --model 1B \
+    --input /path/to/pdbs/ --seed-n-values 0,5,20,50 \
+    --out /tmp/metrics.json
+```
+
+**On an Apple Silicon Mac (M1–M4):** MLX is the fastest local path.
+
+```bash
+uv sync --extra eval-mlx
+uv run python cli.py evaluate \
+    --backend mlx --model 1B \
+    --input /path/to/pdbs/ --seed-n-values 0,5,20,50 \
+    --out /tmp/metrics.json
+```
+
+**Generic torch (Apple Silicon MPS, CPU, or CUDA):** lowest-effort
+fallback. Slower than MLX on the same Mac and slower than vLLM on
+the same GPU, but works anywhere torch installs.
+
+```bash
+uv sync --extra eval-local
+uv run python cli.py evaluate \
+    --backend transformers --model 1B --dtype bfloat16 \
+    --input /path/to/pdbs/ --seed-n-values 0,5,20,50 \
+    --out /tmp/metrics.json
+```
+
+On MPS, prefer `--dtype bfloat16` (default) or `--dtype float32`. Do
+not use `float16` on MPS for these bf16-trained checkpoints — the
+narrower dynamic range overflows the residual stream and produces
+NaN logits.
+
+`infer` (no ground truth) takes the same `--backend` / `--model`
+flags:
+
+```bash
+uv run python cli.py infer \
+    --backend mlx --model 1B \
+    --input /path/to/seqs/ --out /tmp/predictions.parquet
 ```
 
 ## Success criteria

--- a/experiments/exp1_document_structures_contacts_and_distances_v1/cli.py
+++ b/experiments/exp1_document_structures_contacts_and_distances_v1/cli.py
@@ -78,6 +78,7 @@ def cmd_infer(args: argparse.Namespace) -> None:
     cfg = inference.InferenceConfig(
         model=args.model,
         input_path=args.input,
+        backend=args.backend,
         seed_n_values=args.seed_n_values,
         query_atom=args.query_atom,
         top_k_logprobs=args.top_k_logprobs,
@@ -96,6 +97,7 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
     cfg = inference.InferenceConfig(
         model=args.model,
         input_path=args.input,
+        backend=args.backend,
         seed_n_values=args.seed_n_values,
         query_atom=args.query_atom,
         top_k_logprobs=args.top_k_logprobs,
@@ -179,8 +181,17 @@ def build_parser() -> argparse.ArgumentParser:
     # ---- shared inference args (used by infer + evaluate) ------------------
     def _add_inference_common(p: argparse.ArgumentParser) -> None:
         p.add_argument("--model", required=True,
-                       help="HuggingFace model path or local dir. Tokenizer "
-                            "must be co-located.")
+                       help="Local directory holding the model + tokenizer, "
+                            "or a nickname listed in repo-root MODELS.yaml "
+                            "(e.g. '1B'). Bare HF repo ids are not "
+                            "accepted — register the model in MODELS.yaml "
+                            "first.")
+        p.add_argument("--backend", choices=("vllm", "transformers", "mlx"),
+                       default="vllm",
+                       help="Inference runtime. 'vllm' is the Linux+GPU "
+                            "production path; 'transformers' runs on Apple "
+                            "Silicon (MPS), CPU, or CUDA; 'mlx' is Apple "
+                            "Silicon native. Default 'vllm'.")
         p.add_argument("--input", type=Path, required=True,
                        help="Structure file (PDB / mmCIF / .gz) or directory. "
                             "For evaluate, the input IS the ground truth — "
@@ -190,10 +201,17 @@ def build_parser() -> argparse.ArgumentParser:
         p.add_argument("--seed-n-values", type=_seed_n_values, default=(0,),
                        help="Comma-separated seeded-contact counts "
                             "(e.g. '0,5,20,50'). Default '0' = zero-shot.")
-        p.add_argument("--top-k-logprobs", type=int, default=128)
+        p.add_argument("--top-k-logprobs", type=int, default=128,
+                       help="vLLM-only; ignored by other backends.")
         p.add_argument("--batch-size", type=int, default=64)
-        p.add_argument("--dtype", default="bfloat16")
-        p.add_argument("--gpu-memory-utilization", type=float, default=0.85)
+        p.add_argument("--dtype", default="bfloat16",
+                       help="Model dtype. Honored by vllm and transformers; "
+                            "MLX ignores it (loads whatever's on disk). "
+                            "On MPS prefer bfloat16 or float32 — float16 "
+                            "overflows the residual stream for these "
+                            "bf16-trained checkpoints.")
+        p.add_argument("--gpu-memory-utilization", type=float, default=0.85,
+                       help="vLLM-only; ignored by other backends.")
         p.add_argument("--max-pairs-per-structure", type=int, default=None,
                        help="Cap pairs per structure (useful for smoke tests). "
                             "In evaluate mode this caps *evaluatable* pairs "

--- a/experiments/exp1_document_structures_contacts_and_distances_v1/inference.py
+++ b/experiments/exp1_document_structures_contacts_and_distances_v1/inference.py
@@ -29,6 +29,10 @@ bins to an expected distance.
   contact hint count in a single run, mirroring Phase 7c of the
   LlamaFold-experiments notebook.
 
+The actual model forward pass goes through
+:mod:`marinfold_inference`; this module is intentionally backend-
+agnostic.
+
 Inspired by marin's experiments/protein/eval_protein_distogram.py.
 """
 
@@ -38,7 +42,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import numpy as np
+
 from marinfold_document_structures import EvalResult
+from marinfold_inference import Backend, load_backend
 
 from parse import (
     ParsedStructure,
@@ -82,10 +89,15 @@ class InferenceConfig:
     over. Eval-only knobs (``distance_cap_angstrom``) and infer-only
     knobs (``keep_bin_probs``) live as optional fields here; the
     function that doesn't use them ignores them.
+
+    ``backend`` selects the runtime that loads + executes the model.
+    ``top_k_logprobs`` and ``gpu_memory_utilization`` are vLLM-only;
+    other backends ignore them.
     """
 
     model: str
     input_path: Path
+    backend: str = "vllm"
     seed_n_values: tuple[int, ...] = (0,)
     query_atom: str = "CA"
     top_k_logprobs: int = 128
@@ -109,8 +121,6 @@ def _gt_query_distance_matrix(structure: ParsedStructure, atom_name: str):
 
     Returns NaN for residues missing the named atom.
     """
-    import numpy as np
-
     n = len(structure.residues)
     positions = [atom_position(r, atom_name) for r in structure.residues]
     out = np.full((n, n), np.nan, dtype=np.float32)
@@ -233,39 +243,32 @@ class _StructurePrediction:
 def _query_pairs(
     structure: ParsedStructure,
     *,
-    llm,
-    tokenizer,
+    backend: Backend,
+    distance_token_ids: list[int],
+    bin_midpoints: np.ndarray,
     query_atom: str,
     n_seeded: int,
-    top_k_logprobs: int,
     batch_size: int,
     max_pairs: int | None,
     keep_bin_probs: bool,
-    distance_token_ids: list[int],
-    bin_midpoints,
     gt=None,
     distance_cap_angstrom: float | None = None,
 ) -> _StructurePrediction:
     """Single (structure, seed-count) inference pass.
 
-    If ``gt`` is provided, pairs are pre-filtered before the LLM
+    If ``gt`` is provided, pairs are pre-filtered before the model
     forward pass: any pair with non-finite GT or GT >
     ``distance_cap_angstrom`` is skipped. ``max_pairs`` then caps
     evaluatable pairs, not raw queries. ``predict`` (no-GT) passes
     ``gt=None`` and queries every (i, j).
     """
-    import numpy as np
-    from vllm import SamplingParams, TokensPrompt
-
     n = len(structure.residues)
     gt_long = _gt_long_range_contacts(structure)
     seeded = gt_long[:n_seeded] if n_seeded > 0 else []
     base_tokens = _build_base_prompt_tokens(structure, seeded)
-    base_ids = _encode_token_strs(tokenizer, base_tokens)
-    distance_id_set = set(distance_token_ids)
-    bin_of = {tid: k for k, tid in enumerate(distance_token_ids)}
+    base_ids = _encode_token_strs(backend.tokenizer, base_tokens)
 
-    prompts: list = []
+    prompts: list[list[int]] = []
     keys: list[tuple[int, int]] = []
     for i in range(1, n + 1):
         for j in range(i + 1, n + 1):
@@ -276,18 +279,13 @@ def _query_pairs(
                 if distance_cap_angstrom is not None and gt_ij > distance_cap_angstrom:
                     continue
             tail = _pair_tail_tokens(i, j, query_atom, query_atom)
-            tail_ids = _encode_token_strs(tokenizer, tail)
-            prompts.append(TokensPrompt(prompt_token_ids=base_ids + tail_ids))
+            tail_ids = _encode_token_strs(backend.tokenizer, tail)
+            prompts.append(base_ids + tail_ids)
             keys.append((i, j))
             if max_pairs is not None and len(prompts) >= max_pairs:
                 break
         if max_pairs is not None and len(prompts) >= max_pairs:
             break
-
-    sampling = SamplingParams(
-        temperature=1.0, top_p=1.0, top_k=-1,
-        max_tokens=1, logprobs=top_k_logprobs, n=1,
-    )
 
     out_pairs: list[tuple[int, int]] = []
     out_expected: list[float] = []
@@ -296,23 +294,17 @@ def _query_pairs(
     for chunk_start in range(0, len(prompts), batch_size):
         chunk_prompts = prompts[chunk_start : chunk_start + batch_size]
         chunk_keys = keys[chunk_start : chunk_start + batch_size]
-        outputs = llm.generate(chunk_prompts, sampling, use_tqdm=False)
-        for (i, j), out in zip(chunk_keys, outputs, strict=True):
-            lp_dict = out.outputs[0].logprobs[0] if out.outputs[0].logprobs else {}
-            row = np.zeros(_NUM_DISTANCE_BINS, dtype=np.float32)
-            for tok_id, lp in lp_dict.items():
-                tid = int(tok_id)
-                if tid in distance_id_set:
-                    row[bin_of[tid]] = float(np.exp(float(lp.logprob)))
+        probs = backend.next_token_probs(chunk_prompts, distance_token_ids)
+        for (i, j), row in zip(chunk_keys, probs, strict=True):
             total = float(row.sum())
             if total <= 0:
                 continue
-            row /= total
-            expected = float((row * bin_midpoints).sum())
+            normed = row / total
+            expected = float((normed * bin_midpoints).sum())
             out_pairs.append((i, j))
             out_expected.append(expected)
             if out_bin_probs is not None:
-                out_bin_probs.append(row.tolist())
+                out_bin_probs.append(normed.tolist())
 
     return _StructurePrediction(
         entry_id=structure.entry_id,
@@ -324,23 +316,30 @@ def _query_pairs(
     )
 
 
-def _make_llm(cfg: InferenceConfig):
-    """Load vllm + tokenizer + resolve distance token IDs. Imports are lazy."""
-    import numpy as np
-    from vllm import LLM
-
-    llm = LLM(
-        model=cfg.model,
-        dtype=cfg.dtype,
-        gpu_memory_utilization=cfg.gpu_memory_utilization,
-        enforce_eager=True,
-        trust_remote_code=True,
-        max_logprobs=max(cfg.top_k_logprobs, 128),
+def _make_backend(cfg: InferenceConfig) -> Backend:
+    """Construct the requested backend, passing through backend-specific kwargs."""
+    if cfg.backend == "vllm":
+        return load_backend(
+            "vllm",
+            model=cfg.model,
+            dtype=cfg.dtype,
+            gpu_memory_utilization=cfg.gpu_memory_utilization,
+            top_k_logprobs=cfg.top_k_logprobs,
+        )
+    if cfg.backend == "transformers":
+        return load_backend("transformers", model=cfg.model, dtype=cfg.dtype)
+    if cfg.backend == "mlx":
+        return load_backend("mlx", model=cfg.model)
+    raise ValueError(
+        f"Unknown backend {cfg.backend!r}. Expected one of: 'vllm', 'transformers', 'mlx'."
     )
-    tokenizer = llm.get_tokenizer()
-    distance_token_ids = _resolve_distance_token_ids(tokenizer)
+
+
+def _resolve_targets(backend: Backend) -> tuple[list[int], np.ndarray]:
+    """Resolve the 64 distance-bin token ids + their midpoint vector."""
+    distance_token_ids = _resolve_distance_token_ids(backend.tokenizer)
     bin_midpoints = np.asarray(_DISTANCE_BIN_MIDPOINTS, dtype=np.float32)
-    return llm, tokenizer, distance_token_ids, bin_midpoints
+    return distance_token_ids, bin_midpoints
 
 
 # --------------------------------------------------------------------------
@@ -362,21 +361,20 @@ def predict(cfg: InferenceConfig) -> Iterator[dict]:
     structures = list(iter_parsed_structures(cfg.input_path))
     if not structures:
         return
-    llm, tokenizer, distance_token_ids, bin_midpoints = _make_llm(cfg)
+    backend = _make_backend(cfg)
+    distance_token_ids, bin_midpoints = _resolve_targets(backend)
     for structure in structures:
         for n_seeded in cfg.seed_n_values:
             pred = _query_pairs(
                 structure,
-                llm=llm,
-                tokenizer=tokenizer,
+                backend=backend,
+                distance_token_ids=distance_token_ids,
+                bin_midpoints=bin_midpoints,
                 query_atom=cfg.query_atom,
                 n_seeded=n_seeded,
-                top_k_logprobs=cfg.top_k_logprobs,
                 batch_size=cfg.batch_size,
                 max_pairs=cfg.max_pairs_per_structure,
                 keep_bin_probs=cfg.keep_bin_probs,
-                distance_token_ids=distance_token_ids,
-                bin_midpoints=bin_midpoints,
             )
             record: dict[str, Any] = {
                 "entry_id": pred.entry_id,
@@ -402,9 +400,8 @@ def evaluate(cfg: InferenceConfig) -> EvalResult:
     (i, j) at ``cfg.query_atom`` is computed from the parsed
     structure's coordinates. Pairs with non-finite GT or GT >
     ``cfg.distance_cap_angstrom`` are masked out (pre-filter inside
-    :func:`_query_pairs`, so the LLM is never asked about them).
+    :func:`_query_pairs`, so the model is never asked about them).
     """
-    import numpy as np
     from vocab import NAME
 
     structures = list(iter_parsed_structures(cfg.input_path))
@@ -414,7 +411,8 @@ def evaluate(cfg: InferenceConfig) -> EvalResult:
             "warning": "no input structures",
             "model": cfg.model,
         })
-    llm, tokenizer, distance_token_ids, bin_midpoints = _make_llm(cfg)
+    backend = _make_backend(cfg)
+    distance_token_ids, bin_midpoints = _resolve_targets(backend)
 
     per_structure_mae: dict[int, dict[str, float]] = {
         n: {} for n in cfg.seed_n_values
@@ -429,16 +427,14 @@ def evaluate(cfg: InferenceConfig) -> EvalResult:
         for n_seeded in cfg.seed_n_values:
             pred = _query_pairs(
                 structure,
-                llm=llm,
-                tokenizer=tokenizer,
+                backend=backend,
+                distance_token_ids=distance_token_ids,
+                bin_midpoints=bin_midpoints,
                 query_atom=cfg.query_atom,
                 n_seeded=n_seeded,
-                top_k_logprobs=cfg.top_k_logprobs,
                 batch_size=cfg.batch_size,
                 max_pairs=cfg.max_pairs_per_structure,
                 keep_bin_probs=False,
-                distance_token_ids=distance_token_ids,
-                bin_midpoints=bin_midpoints,
                 gt=gt,
                 distance_cap_angstrom=cfg.distance_cap_angstrom,
             )
@@ -473,6 +469,7 @@ def evaluate(cfg: InferenceConfig) -> EvalResult:
         extras={
             "structure": NAME,
             "model": cfg.model,
+            "backend": cfg.backend,
             "query_atom": cfg.query_atom,
             "seed_n_values": list(cfg.seed_n_values),
             "n_structures": len(structures),

--- a/experiments/exp1_document_structures_contacts_and_distances_v1/pyproject.toml
+++ b/experiments/exp1_document_structures_contacts_and_distances_v1/pyproject.toml
@@ -5,15 +5,23 @@ description = "contacts-and-distances-v1 document structure: generate / infer / 
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "marinfold-document-structures",
+    "marinfold-inference",
     "gemmi>=0.6",       # mmCIF / PDB parsing for AFDB inputs
     "numpy",
     "pyarrow",
 ]
 
 [project.optional-dependencies]
-# vllm pulls torch + cuda libs and is only needed for evaluate().
-# Install with `uv sync --extra eval`.
-eval = ["vllm>=0.6"]
+# Backend extras: pick one based on platform. Each delegates to the
+# matching extra on marinfold-inference, so the heavy runtime
+# (vllm / torch / mlx) is only installed when you ask for it.
+#
+# - eval        → vLLM (Linux+GPU production path)
+# - eval-local  → transformers (Apple Silicon MPS, CPU, or CUDA)
+# - eval-mlx    → MLX (Apple Silicon native, fastest local)
+eval       = ["marinfold-inference[vllm]"]
+eval-local = ["marinfold-inference[transformers]"]
+eval-mlx   = ["marinfold-inference[mlx]"]
 # Network-dependent tests (byte-identity check against
 # huggingface.co/timodonnell/protein-docs-tokenizer@<sha>) need
 # huggingface_hub installed. pytest is for running tests in general.
@@ -33,7 +41,8 @@ environments = [
 ]
 
 [tool.uv.sources]
-marinfold-document-structures = { path = "../../document_structures" }
+marinfold-document-structures = { path = "../../document_structures", editable = true }
+marinfold-inference = { path = "../../inference", editable = true }
 
 [tool.pytest.ini_options]
 markers = [

--- a/inference/AGENTS.md
+++ b/inference/AGENTS.md
@@ -1,0 +1,50 @@
+# inference/AGENTS.md
+
+Rules for agents working under `inference/`. Layered on top of the
+root `AGENTS.md`.
+
+## Scope
+
+`inference/` is a small shared library for **running a trained
+model**. Three responsibilities, nothing more:
+
+1. The `Backend` protocol (`next_token_probs`, `tokenizer`).
+2. Backend implementations against vLLM, HuggingFace transformers,
+   and MLX.
+3. Model resolution: local path or `MODELS.yaml` nickname → local
+   directory on disk.
+
+Format-specific logic — prompt construction, vocab token resolution,
+ground-truth comparison, MAE/accuracy math — belongs in the document-
+structure impl under `experiments/exp<N>_document_structures_<name>/`.
+The library is intentionally protein-unaware. If a helper here starts
+to know about residues or distances, it's in the wrong directory.
+
+## Hard rules
+
+1. **Keep the base install lightweight.** `marinfold_inference`
+   (without extras) must work with only `huggingface_hub + numpy +
+   pyyaml + tokenizers + transformers`. Each backend's heavy runtime
+   (`vllm`, `torch`, `mlx`) lives behind its own extra and is lazy-
+   imported inside its module. Importing `marinfold_inference` from
+   a process with no backend installed must not raise.
+
+2. **Backends are interchangeable at the `Backend` protocol level.**
+   Same inputs → same outputs (up to numerical precision). New
+   backends must conform; don't widen the protocol with backend-
+   specific knobs. Backend-specific construction options can live in
+   the concrete backend's `__init__` kwargs.
+
+3. **Model resolution is strict.** `resolve_model` accepts a local
+   directory or a `MODELS.yaml` nickname — nothing else. Don't
+   silently fall through to "treat as HF repo id"; that turns a
+   typo into a download. Add new models to `MODELS.yaml` instead.
+
+4. **No protein-specific code.** No imports of gemmi / biopython, no
+   constants like `_CONTACT_CUTOFF_A`, no vocabulary references to
+   `<d_X.X>` or `<p_N>`. The caller passes opaque token ids.
+
+5. **`next_token_probs` returns un-renormalized probabilities** over
+   the target tokens. Backends with full-vocab logits return real
+   softmax mass; vLLM (top-k logprobs) returns 0 for targets that
+   fall outside the top-k. The caller decides what to do with that.

--- a/inference/README.md
+++ b/inference/README.md
@@ -1,0 +1,82 @@
+# inference/
+
+Shared library for running MarinFold-trained models through different
+inference backends, behind one small protocol.
+
+Document-structure impls (under
+`experiments/exp<N>_document_structures_<name>/`) own the format-
+specific logic — prompt construction, vocab resolution, ground-truth
+comparison — and call into this library for the actual model forward
+pass. The library knows nothing about proteins; it knows about
+"give me a probability over these token ids at the next position".
+
+## Backends
+
+| Backend | When to use | Extra |
+|---|---|---|
+| `vllm` | Linux + NVIDIA GPU, production / scaled eval | `marinfold-inference[vllm]` |
+| `transformers` | Generic torch (Apple Silicon MPS, CPU). Lowest-effort local eval. | `marinfold-inference[transformers]` |
+| `mlx` | Apple Silicon native, fastest local. | `marinfold-inference[mlx]` |
+
+All three load HF safetensors directly — no GGUF / MLX conversion
+step is required.
+
+## Public API
+
+```python
+from marinfold_inference import Backend, load_backend
+
+backend = load_backend("mlx", model="1B")          # MODELS.yaml nickname
+# or load_backend("transformers", model="/abs/path/to/ckpt")
+
+probs = backend.next_token_probs(
+    prompts=[[ids...], [ids...]],   # equal length within a call
+    target_token_ids=[t1, t2, ...],
+)                                   # (B, len(target_token_ids)), un-renormalized
+tok = backend.tokenizer
+```
+
+`next_token_probs` returns one row per prompt giving the probability
+mass on each target token id at position `len(prompt)` (i.e. the
+distribution for the next token). The caller is expected to
+renormalize over its target set if it wants a renormalized
+distribution.
+
+## Model resolution
+
+`--model` (or the `model=` arg to `load_backend`) accepts:
+
+1. A local directory (path that exists on disk). Used as-is.
+2. A nickname listed in repo-root `MODELS.yaml`. The matching HF URL
+   is parsed into `(repo_id, revision, subfolder)` and the subfolder
+   is downloaded via `huggingface_hub.snapshot_download`.
+
+Bare HF repo ids are not accepted — register the model in
+`MODELS.yaml` to use it. This is deliberate: it keeps the set of
+known models small, named, and discoverable.
+
+`MODELS.yaml` is located by walking up from `os.getcwd()`. The env
+var `MARINFOLD_MODELS_YAML` overrides this.
+
+## Layout
+
+```
+inference/
+├── pyproject.toml
+├── README.md
+├── AGENTS.md
+└── marinfold_inference/
+    ├── __init__.py           # public API: Backend, load_backend, resolve_model
+    ├── core.py               # Backend protocol
+    ├── registry.py           # MODELS.yaml resolution
+    ├── _vllm.py              # VllmBackend (gated by [vllm] extra)
+    ├── _transformers.py      # TransformersBackend (gated by [transformers] extra)
+    └── _mlx.py               # MlxBackend (gated by [mlx] extra)
+```
+
+## See also
+
+- [`../document_structures/`](../document_structures/) — shared
+  toolkit for document-structure impls.
+- [`../experiments/exp1_document_structures_contacts_and_distances_v1/`](../experiments/exp1_document_structures_contacts_and_distances_v1/)
+  — reference impl that consumes this library.

--- a/inference/marinfold_inference/__init__.py
+++ b/inference/marinfold_inference/__init__.py
@@ -1,0 +1,25 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend abstraction for running MarinFold models.
+
+Three backends are available behind one :class:`Backend` protocol:
+
+- ``"vllm"``       — Linux + GPU production path.
+- ``"transformers"`` — HuggingFace transformers; runs on Apple
+  Silicon (MPS), CPU, and CUDA. Lowest-effort local-eval option.
+- ``"mlx"``        — Apple Silicon native via MLX.
+
+Each backend's heavy runtime is lazy-imported inside its module, so
+importing :mod:`marinfold_inference` itself requires only the base
+deps and works with zero backends installed.
+
+The library is protein-unaware. Document-structure impls under
+``experiments/exp<N>_document_structures_<name>/`` build prompts as
+opaque token-id lists and pass them in.
+"""
+
+from marinfold_inference.core import Backend, load_backend
+from marinfold_inference.registry import resolve_model
+
+__all__ = ["Backend", "load_backend", "resolve_model"]

--- a/inference/marinfold_inference/_mlx.py
+++ b/inference/marinfold_inference/_mlx.py
@@ -1,0 +1,62 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""MLX backend.
+
+Gated by the ``[mlx]`` extra (Darwin-only wheels). Uses
+``mlx_lm.load`` to read HF safetensors directly — no conversion step
+is required for unquantized inference.
+
+The HF tokenizer is loaded separately with
+``transformers.AutoTokenizer`` so the surfaced object is exactly the
+same ``PreTrainedTokenizerFast`` the other backends expose, rather
+than mlx-lm's ``TokenizerWrapper``.
+"""
+
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+from mlx_lm import load as mlx_load
+from transformers import AutoTokenizer
+
+
+class MlxBackend:
+    """MLX-backed implementation of the :class:`Backend` protocol."""
+
+    def __init__(self, model_path: Path):
+        self._tokenizer = AutoTokenizer.from_pretrained(str(model_path))
+        # mlx_lm.load returns (model, tokenizer); we use mlx_lm's
+        # tokenizer only as a sanity check that the path is loadable
+        # and rely on the HF tokenizer above for the public surface.
+        self._model, _ = mlx_load(str(model_path))
+
+    @property
+    def tokenizer(self):
+        return self._tokenizer
+
+    def next_token_probs(
+        self,
+        prompts: list[list[int]],
+        target_token_ids: list[int],
+    ) -> np.ndarray:
+        if not prompts:
+            return np.zeros((0, len(target_token_ids)), dtype=np.float32)
+
+        lengths = {len(p) for p in prompts}
+        if len(lengths) != 1:
+            raise ValueError(
+                f"next_token_probs requires equal-length prompts in a single call; "
+                f"got lengths {sorted(lengths)}."
+            )
+
+        input_ids = mx.array(prompts, dtype=mx.int32)
+        target_ids = mx.array(target_token_ids, dtype=mx.int32)
+
+        logits = self._model(input_ids)[:, -1, :]
+        # Cast to float32 before softmax so the renormalization the
+        # caller does is numerically stable, especially for tiny
+        # target probabilities in the tail of the distribution.
+        probs = mx.softmax(logits.astype(mx.float32), axis=-1)
+        target_probs = probs[:, target_ids]
+        return np.asarray(target_probs, dtype=np.float32)

--- a/inference/marinfold_inference/_transformers.py
+++ b/inference/marinfold_inference/_transformers.py
@@ -58,7 +58,7 @@ class TransformersBackend:
         self,
         model_path: Path,
         *,
-        dtype: str = "float16",
+        dtype: str = "bfloat16",
         device: str | None = None,
     ):
         self._device = device or _best_device()

--- a/inference/marinfold_inference/_transformers.py
+++ b/inference/marinfold_inference/_transformers.py
@@ -1,0 +1,106 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""HuggingFace transformers backend.
+
+Gated by the ``[transformers]`` extra (pulls torch). Picks the best
+available device automatically — CUDA > MPS > CPU — so the same code
+runs on a Linux box, an Apple Silicon Mac (via MPS), or anywhere
+torch is installed.
+
+Uses full-vocab softmax: vocabularies for MarinFold doc structures
+are tiny (~2840 tokens), so computing the whole softmax and gathering
+the target columns is cheaper than any top-k dance.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def _best_device() -> str:
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _resolve_dtype(name: str) -> torch.dtype:
+    """Map a dtype name to a torch dtype.
+
+    No silent device-specific downgrades — fp16 on MPS overflows the
+    residual stream for bf16-trained Llama-style models and produces
+    NaNs. If a user asks for fp16, they get fp16 (and may regret it);
+    bf16 stays bf16 (torch ≥ 2.4 supports it on MPS); fp32 is the
+    safe default for the unsure.
+    """
+    table = {
+        "float16": torch.float16,
+        "fp16": torch.float16,
+        "half": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+        "float32": torch.float32,
+        "fp32": torch.float32,
+    }
+    if name not in table:
+        raise ValueError(f"Unknown dtype {name!r}. Options: {sorted(table)}.")
+    return table[name]
+
+
+class TransformersBackend:
+    """transformers-backed implementation of the :class:`Backend` protocol."""
+
+    def __init__(
+        self,
+        model_path: Path,
+        *,
+        dtype: str = "float16",
+        device: str | None = None,
+    ):
+        self._device = device or _best_device()
+        torch_dtype = _resolve_dtype(dtype)
+        self._tokenizer = AutoTokenizer.from_pretrained(str(model_path))
+        self._model = (
+            AutoModelForCausalLM.from_pretrained(str(model_path), dtype=torch_dtype)
+            .to(self._device)
+            .eval()
+        )
+
+    @property
+    def tokenizer(self):
+        return self._tokenizer
+
+    @property
+    def device(self) -> str:
+        return self._device
+
+    def next_token_probs(
+        self,
+        prompts: list[list[int]],
+        target_token_ids: list[int],
+    ) -> np.ndarray:
+        if not prompts:
+            return np.zeros((0, len(target_token_ids)), dtype=np.float32)
+
+        # Caller guarantees equal-length prompts within a call. Cheap
+        # assertion catches misuse early.
+        lengths = {len(p) for p in prompts}
+        if len(lengths) != 1:
+            raise ValueError(
+                f"next_token_probs requires equal-length prompts in a single call; "
+                f"got lengths {sorted(lengths)}."
+            )
+
+        input_ids = torch.tensor(prompts, dtype=torch.long, device=self._device)
+        target_ids = torch.tensor(target_token_ids, dtype=torch.long, device=self._device)
+
+        with torch.inference_mode():
+            logits = self._model(input_ids=input_ids, use_cache=False).logits[:, -1, :]
+            probs = torch.softmax(logits.float(), dim=-1)
+            target_probs = probs.index_select(dim=-1, index=target_ids)
+
+        return target_probs.detach().cpu().numpy().astype(np.float32, copy=False)

--- a/inference/marinfold_inference/_vllm.py
+++ b/inference/marinfold_inference/_vllm.py
@@ -1,0 +1,77 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""vLLM backend.
+
+Gated by the ``[vllm]`` optional-dep. The module-level ``vllm``
+import is intentional: this file is only imported when
+``load_backend('vllm', ...)`` is called, so its import cost is
+deferred until then.
+
+vLLM exposes logprobs as a top-k dict per generated position. We use
+``max_tokens=1, logprobs=top_k_logprobs`` to get the next-token
+distribution without actually sampling. Target tokens that fall
+outside the top-k get probability 0 — the caller renormalizes.
+"""
+
+from pathlib import Path
+
+import numpy as np
+from vllm import LLM, SamplingParams, TokensPrompt
+
+
+class VllmBackend:
+    """vLLM-backed implementation of the :class:`Backend` protocol."""
+
+    def __init__(
+        self,
+        model_path: Path,
+        *,
+        dtype: str = "bfloat16",
+        gpu_memory_utilization: float = 0.85,
+        top_k_logprobs: int = 128,
+    ):
+        self._top_k_logprobs = top_k_logprobs
+        self._llm = LLM(
+            model=str(model_path),
+            dtype=dtype,
+            gpu_memory_utilization=gpu_memory_utilization,
+            enforce_eager=True,
+            trust_remote_code=True,
+            max_logprobs=max(top_k_logprobs, 128),
+        )
+        self._tokenizer = self._llm.get_tokenizer()
+        self._sampling = SamplingParams(
+            temperature=1.0,
+            top_p=1.0,
+            top_k=-1,
+            max_tokens=1,
+            logprobs=top_k_logprobs,
+            n=1,
+        )
+
+    @property
+    def tokenizer(self):
+        return self._tokenizer
+
+    def next_token_probs(
+        self,
+        prompts: list[list[int]],
+        target_token_ids: list[int],
+    ) -> np.ndarray:
+        if not prompts:
+            return np.zeros((0, len(target_token_ids)), dtype=np.float32)
+        target_to_col = {tid: c for c, tid in enumerate(target_token_ids)}
+        target_id_set = set(target_token_ids)
+
+        vllm_prompts = [TokensPrompt(prompt_token_ids=p) for p in prompts]
+        outputs = self._llm.generate(vllm_prompts, self._sampling, use_tqdm=False)
+
+        out = np.zeros((len(prompts), len(target_token_ids)), dtype=np.float32)
+        for row_idx, result in enumerate(outputs):
+            lp_dict = result.outputs[0].logprobs[0] if result.outputs[0].logprobs else {}
+            for tok_id, lp in lp_dict.items():
+                tid = int(tok_id)
+                if tid in target_id_set:
+                    out[row_idx, target_to_col[tid]] = float(np.exp(float(lp.logprob)))
+        return out

--- a/inference/marinfold_inference/core.py
+++ b/inference/marinfold_inference/core.py
@@ -1,0 +1,108 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend protocol + factory for MarinFold inference.
+
+A backend wraps one model + tokenizer and exposes a single primitive:
+given a batch of equal-length token-id prompts and a list of target
+token ids, return the probability mass on each target token at the
+next position. That's all the document-structure impls need.
+
+Backends are loaded by name through :func:`load_backend`; their
+concrete classes (e.g. ``VllmBackend``) live in sibling modules
+behind optional-dep gates and are only imported when actually used.
+"""
+
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+
+import numpy as np
+
+from marinfold_inference.registry import resolve_model
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerFast
+
+
+BackendName = Literal["vllm", "transformers", "mlx"]
+
+
+@runtime_checkable
+class Backend(Protocol):
+    """Common surface every backend implements.
+
+    Implementations:
+
+    - Load the model + tokenizer from a local directory in their
+      ``__init__``.
+    - Expose the HuggingFace tokenizer via the :attr:`tokenizer`
+      property so callers can encode prompts with it.
+    - Implement :meth:`next_token_probs` against their underlying
+      runtime (vLLM, torch, MLX).
+
+    The contract for ``next_token_probs`` is intentionally narrow:
+    one forward pass per prompt, no autoregressive generation, no
+    sampling. Returned probabilities are over the *target token set*
+    only and are not renormalized — the caller decides whether and
+    how to renormalize.
+    """
+
+    @property
+    def tokenizer(self) -> "PreTrainedTokenizerFast":
+        ...
+
+    def next_token_probs(
+        self,
+        prompts: list[list[int]],
+        target_token_ids: list[int],
+    ) -> np.ndarray:
+        """Probability mass on each target token at the next position.
+
+        Args:
+            prompts: One token-id sequence per row. All sequences in a
+                single call must have the same length — the caller is
+                expected to batch by prompt length.
+            target_token_ids: Token ids whose next-position
+                probability the caller wants. Order is preserved in
+                the output columns.
+
+        Returns:
+            Float array of shape ``(len(prompts), len(target_token_ids))``.
+            Backends with full-vocab logits return real softmax mass
+            on each target. The vLLM backend uses top-k logprobs and
+            returns 0 for target tokens that fall outside the top-k.
+            The caller renormalizes if it wants a renormalized
+            distribution.
+        """
+        ...
+
+
+def load_backend(
+    name: BackendName,
+    *,
+    model: str,
+    **kwargs,
+) -> Backend:
+    """Load one of the registered backends against a resolved model.
+
+    ``model`` is passed through :func:`resolve_model`: a local
+    directory or a ``MODELS.yaml`` nickname. The resolved local path
+    is handed to the backend's constructor along with any backend-
+    specific ``**kwargs``.
+
+    Lazy-imports the backend's module so the optional runtime
+    (``vllm`` / ``torch`` / ``mlx``) is only loaded when actually
+    used.
+    """
+    model_path = resolve_model(model)
+    if name == "vllm":
+        from marinfold_inference._vllm import VllmBackend
+        return VllmBackend(model_path, **kwargs)
+    if name == "transformers":
+        from marinfold_inference._transformers import TransformersBackend
+        return TransformersBackend(model_path, **kwargs)
+    if name == "mlx":
+        from marinfold_inference._mlx import MlxBackend
+        return MlxBackend(model_path, **kwargs)
+    raise ValueError(
+        f"Unknown backend {name!r}. Expected one of: 'vllm', 'transformers', 'mlx'."
+    )

--- a/inference/marinfold_inference/registry.py
+++ b/inference/marinfold_inference/registry.py
@@ -15,9 +15,13 @@ Bare HF repo ids are not accepted by design — keeping the set of
 known models small and named makes it easy to track which checkpoint
 produced which eval number.
 
-``MODELS.yaml`` is located by walking up from ``os.getcwd()`` looking
-for the file. The env var ``MARINFOLD_MODELS_YAML`` overrides that
-search.
+``MODELS.yaml`` is located in this order:
+
+1. The path named by ``MARINFOLD_MODELS_YAML``.
+2. Walking up from ``os.getcwd()``.
+3. Walking up from this package's location, which covers the normal
+   editable-install / repo-checkout case even when the caller's cwd is
+   elsewhere.
 """
 
 import os
@@ -106,7 +110,7 @@ def _find_entry_by_nickname(nickname: str) -> dict[str, Any] | None:
 
 
 def _locate_models_yaml() -> Path:
-    """Find ``MODELS.yaml`` via env override or walk-up from cwd."""
+    """Find ``MODELS.yaml`` via env override, cwd, or package location."""
     override = os.environ.get("MARINFOLD_MODELS_YAML")
     if override:
         p = Path(override)
@@ -117,15 +121,20 @@ def _locate_models_yaml() -> Path:
             )
         return p
 
-    cwd = Path.cwd().resolve()
-    for parent in [cwd, *cwd.parents]:
-        candidate = parent / _MODELS_YAML_FILENAME
-        if candidate.is_file():
-            return candidate
+    search_roots = [Path.cwd().resolve(), Path(__file__).resolve().parent]
+    seen: set[Path] = set()
+    for root in search_roots:
+        for parent in [root, *root.parents]:
+            if parent in seen:
+                continue
+            seen.add(parent)
+            candidate = parent / _MODELS_YAML_FILENAME
+            if candidate.is_file():
+                return candidate
     raise FileNotFoundError(
-        f"Could not find {_MODELS_YAML_FILENAME} in {cwd} or any "
-        f"parent directory. Set MARINFOLD_MODELS_YAML to point at "
-        f"it explicitly."
+        f"Could not find {_MODELS_YAML_FILENAME} from cwd {Path.cwd().resolve()} "
+        f"or from the package location {Path(__file__).resolve().parent}. "
+        f"Set MARINFOLD_MODELS_YAML to point at it explicitly."
     )
 
 

--- a/inference/marinfold_inference/registry.py
+++ b/inference/marinfold_inference/registry.py
@@ -1,0 +1,171 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model resolution for MarinFold inference.
+
+``--model`` (or the ``model=`` arg to :func:`load_backend`) accepts:
+
+1. A local directory that exists on disk → used as-is.
+2. A nickname listed in repo-root ``MODELS.yaml`` → the matching HF
+   URL is parsed into ``(repo_id, revision, subfolder)`` and the
+   subfolder is downloaded via ``huggingface_hub.snapshot_download``.
+   The returned :class:`Path` points at the local cache location.
+
+Bare HF repo ids are not accepted by design — keeping the set of
+known models small and named makes it easy to track which checkpoint
+produced which eval number.
+
+``MODELS.yaml`` is located by walking up from ``os.getcwd()`` looking
+for the file. The env var ``MARINFOLD_MODELS_YAML`` overrides that
+search.
+"""
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+_MODELS_YAML_FILENAME = "MODELS.yaml"
+_HF_URL_PATTERN = re.compile(
+    r"^https://huggingface\.co/(?P<repo>[^/]+/[^/]+)"
+    r"(?:/tree/(?P<rev>[^/]+)(?:/(?P<subfolder>.+))?)?/?$"
+)
+
+
+@dataclass(frozen=True)
+class _HFLocation:
+    """A parsed HF URL: repo + revision + optional subfolder."""
+
+    repo_id: str
+    revision: str
+    subfolder: str | None
+
+
+def resolve_model(spec: str) -> Path:
+    """Resolve a model spec to a local directory on disk.
+
+    Args:
+        spec: Either a path to a local directory (must exist), or a
+            nickname listed in repo-root ``MODELS.yaml``.
+
+    Returns:
+        Absolute :class:`Path` to a directory holding the model
+        files (``config.json``, ``model.safetensors``,
+        ``tokenizer.json``, ``tokenizer_config.json``).
+
+    Raises:
+        KeyError: ``spec`` is not a local directory and is not a
+            known nickname.
+        ValueError: ``spec`` matches a nickname whose ``url`` is not
+            a parseable HuggingFace tree URL.
+    """
+    # 1. Local directory takes precedence over nickname collisions.
+    #    To force the local interpretation when a name collides with
+    #    a nickname, use './<name>'.
+    p = Path(spec)
+    if p.is_dir():
+        return p.resolve()
+
+    # 2. MODELS.yaml nickname.
+    entry = _find_entry_by_nickname(spec)
+    if entry is None:
+        raise KeyError(
+            f"Model {spec!r} is not a local directory and is not "
+            f"listed in MODELS.yaml. Add it to MODELS.yaml or pass "
+            f"a local path."
+        )
+    location = _parse_hf_url(entry["url"])
+    return _download_subfolder(location)
+
+
+def _find_entry_by_nickname(nickname: str) -> dict[str, Any] | None:
+    """Look up an entry in MODELS.yaml by ``nickname``."""
+    import yaml
+
+    yaml_path = _locate_models_yaml()
+    with yaml_path.open() as fh:
+        entries = yaml.safe_load(fh) or []
+    if not isinstance(entries, list):
+        raise ValueError(
+            f"{yaml_path} must contain a YAML list of model entries; "
+            f"got {type(entries).__name__}."
+        )
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("nickname") == nickname:
+            if "url" not in entry:
+                raise ValueError(
+                    f"MODELS.yaml entry for nickname {nickname!r} is "
+                    f"missing the required 'url' field."
+                )
+            return entry
+    return None
+
+
+def _locate_models_yaml() -> Path:
+    """Find ``MODELS.yaml`` via env override or walk-up from cwd."""
+    override = os.environ.get("MARINFOLD_MODELS_YAML")
+    if override:
+        p = Path(override)
+        if not p.is_file():
+            raise FileNotFoundError(
+                f"MARINFOLD_MODELS_YAML={override!r} does not point at "
+                f"an existing file."
+            )
+        return p
+
+    cwd = Path.cwd().resolve()
+    for parent in [cwd, *cwd.parents]:
+        candidate = parent / _MODELS_YAML_FILENAME
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(
+        f"Could not find {_MODELS_YAML_FILENAME} in {cwd} or any "
+        f"parent directory. Set MARINFOLD_MODELS_YAML to point at "
+        f"it explicitly."
+    )
+
+
+def _parse_hf_url(url: str) -> _HFLocation:
+    """Parse a ``https://huggingface.co/<repo>/tree/<rev>/<sub>`` URL."""
+    m = _HF_URL_PATTERN.match(url.strip())
+    if m is None:
+        raise ValueError(
+            f"Could not parse HuggingFace URL {url!r}. Expected "
+            f"'https://huggingface.co/<org>/<repo>' optionally "
+            f"followed by '/tree/<revision>[/<subfolder>]'."
+        )
+    return _HFLocation(
+        repo_id=m.group("repo"),
+        revision=m.group("rev") or "main",
+        subfolder=m.group("subfolder"),
+    )
+
+
+def _download_subfolder(location: _HFLocation) -> Path:
+    """Download just the model's subfolder from HF Hub; return local path."""
+    from huggingface_hub import snapshot_download
+
+    allow_patterns: list[str] | None
+    if location.subfolder is None:
+        allow_patterns = None
+    else:
+        allow_patterns = [f"{location.subfolder}/*"]
+
+    local_root = snapshot_download(
+        repo_id=location.repo_id,
+        revision=location.revision,
+        allow_patterns=allow_patterns,
+    )
+    local_path = Path(local_root)
+    if location.subfolder is not None:
+        local_path = local_path / location.subfolder
+    if not local_path.is_dir():
+        raise FileNotFoundError(
+            f"Downloaded snapshot does not contain expected subfolder "
+            f"{location.subfolder!r} at {local_path}."
+        )
+    return local_path.resolve()

--- a/inference/pyproject.toml
+++ b/inference/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "marinfold-inference"
+version = "0.1.0"
+description = "MarinFold inference/ library — backend abstraction over vLLM / transformers / MLX for next-token logprob queries."
+requires-python = ">=3.11"
+# Base install pulls only the resolver + tokenizer deps. Each
+# backend's heavyweight runtime is gated behind an optional extra
+# below and lazy-imported inside its module.
+dependencies = [
+    "huggingface_hub>=0.24",
+    "numpy",
+    "pyyaml>=6",
+    "tokenizers>=0.15",
+    "transformers>=4.40",
+]
+
+[project.optional-dependencies]
+# Linux+GPU production path.
+vllm = ["vllm>=0.6"]
+# Generic torch path — runs on Apple Silicon via MPS, on Linux/macOS
+# CPU otherwise. Lowest-effort local-eval option.
+transformers = ["torch>=2.4", "accelerate>=0.30"]
+# Apple Silicon native path via MLX. Darwin-only wheels; uv skips on
+# other platforms automatically.
+mlx = ["mlx>=0.18; sys_platform == 'darwin'", "mlx-lm>=0.20; sys_platform == 'darwin'"]
+
+[dependency-groups]
+dev = []
+
+[tool.uv]
+package = true
+fork-strategy = "fewest"
+prerelease = "allow"
+environments = [
+    "sys_platform == 'darwin'",
+    "sys_platform == 'linux'",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["marinfold_inference"]

--- a/inference/tests/test_registry.py
+++ b/inference/tests/test_registry.py
@@ -1,0 +1,19 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from marinfold_inference.registry import _locate_models_yaml
+
+
+def test_locate_models_yaml_falls_back_to_package_tree(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nickname resolution should not depend on the caller's cwd being in-repo."""
+    monkeypatch.delenv("MARINFOLD_MODELS_YAML", raising=False)
+    monkeypatch.chdir(Path("/tmp"))
+
+    yaml_path = _locate_models_yaml()
+
+    assert yaml_path.name == "MODELS.yaml"
+    assert yaml_path.parent == Path(__file__).resolve().parents[2]

--- a/inference/tests/test_transformers.py
+++ b/inference/tests/test_transformers.py
@@ -1,0 +1,19 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from marinfold_inference._transformers import _resolve_dtype
+
+
+def test_bfloat16_resolves_to_torch_bfloat16() -> None:
+    assert _resolve_dtype("bfloat16") is torch.bfloat16
+
+
+def test_shared_backend_default_dtype_stays_safe_for_mps_models() -> None:
+    from marinfold_inference._transformers import TransformersBackend
+
+    assert TransformersBackend.__init__.__kwdefaults__ == {
+        "dtype": "bfloat16",
+        "device": None,
+    }


### PR DESCRIPTION
## Summary
- New `inference/` library at the repo root with a `Backend` protocol and three implementations: vLLM (Linux/GPU, ported from the experiment), HuggingFace `transformers` (anywhere torch installs — Apple Silicon MPS, CPU, CUDA), and MLX (Apple Silicon native).
- Strict model resolver: `--model` accepts a local directory or a `MODELS.yaml` nickname (e.g. `1B`). Bare HF repo ids are rejected to keep the set of known checkpoints named and discoverable.
- exp1's [inference.py](experiments/exp1_document_structures_contacts_and_distances_v1/inference.py) refactored to use the library — drops the vLLM imports, the `_make_llm` helper, and the inline `lp_dict` decode. Format-specific logic (prompt construction, distance vocab, MAE) stays in the experiment; the library is protein-unaware.
- `--backend {vllm,transformers,mlx}` CLI flag added; default `vllm` preserves the existing eval surface. README rewritten to show all three platform paths (GPU, Apple Silicon, generic torch).

## What changed for the experiment user
| Before | After |
|---|---|
| `uv sync --extra eval` | `uv sync --extra eval` (GPU/vLLM), `--extra eval-mlx` (Apple Silicon), or `--extra eval-local` (generic torch) |
| `--model open-athena/<id>` | `--model 1B` (nickname) or `--model /local/path` |
| vLLM only | `--backend {vllm,transformers,mlx}` |

## Verified end-to-end

All three backends ran against the registered `1B` model on the same 5-residue test PDB:

- **vLLM** on RTX A5000 (Linux, CUDA 12.2)
- **MLX** on Apple M4 Pro
- **transformers** on Apple M4 Pro (MPS, both bf16 and fp32)

Per-pair predicted distances and overall MAE:

| Pair | vLLM | MLX | transformers bf16 |
|---|---|---|---|
| (1,2) | 6.320 | 6.311 | 6.306 |
| (1,3) | 6.510 | 6.502 | 6.499 |
| (1,4) | 6.461 | 6.466 | 6.468 |
| (1,5) | 9.222 | 9.206 | 9.241 |
| (2,3) | 6.123 | 6.128 | 6.123 |
| **MAE (Å)** | **2.860** | **2.863** | **2.854** |

Max per-pair disagreement across backends ~0.04 Å — within numerical precision differences from the underlying runtimes. 51/51 offline tests still pass. Base `marinfold_inference` imports cleanly with zero backend extras installed.

## Findings while validating (already fixed in this PR)
1. The original `TransformersBackend` silently downgraded bf16 → fp16 on MPS, which overflowed the residual stream and produced NaN logits for these bf16-trained checkpoints. torch 2.8 supports bf16 on MPS fine; the downgrade is removed. Help text now warns users not to pass `--dtype float16` on MPS.
2. Path deps default to wheel-snapshot installs under uv, which meant edits to `inference/marinfold_inference/*.py` weren't picked up without a resync. Both path deps in the experiment now use `editable = true`.

## Environment notes (not PR changes)

On the GPU box (ip1_plain) I had to work around two box-side issues that are unrelated to this PR:

1. **CUDA driver mismatch.** vLLM 0.21 requires a newer NVIDIA driver than ip1_plain's 535.54 (CUDA 12.2). Resolved by pinning locally to `vllm>=0.10,<0.12` (uv picked 0.11.2). **Not committed to the PR** — the dep spec stays `vllm>=0.6` so other GPU machines aren't forced to downgrade.
2. **flashinfer version skew inside vLLM 0.11.** Worked around with `FLASHINFER_DISABLE_VERSION_CHECK=1` as the error message itself suggested.

Both are worth documenting somewhere in `RESOURCES.md` or as ip1_plain setup notes, but not in this PR.

## Open follow-ups (not blocking)
- No unit tests for the new library. The URL-parsing regex in `registry.py` is the most-worth-pinning piece.
- Cross-backend agreement was checked on a 5-residue synthetic PDB. The shape of evidence is right ("did the refactor break anything across all three runtimes") but the numbers don't prove anything about real-protein behavior. A real eval against the Phase 7c notebook references is the obvious next step.

## Test plan
- [x] `uv sync --extra eval` on Linux+GPU (RTX A5000) → `--backend vllm --model 1B` produces MAE 2.860 Å.
- [x] `uv sync --extra eval-mlx` on Apple Silicon → `--backend mlx --model 1B` produces MAE 2.863 Å.
- [x] `uv sync --extra eval-local` on Apple Silicon → `--backend transformers --model 1B` produces MAE 2.854 Å (bf16 on MPS).
- [x] `uv run pytest -q -m "not network"` from the experiment dir → 51/51 pass.
