### PR TITLE
Add --out-plots PDF heatmaps to marinfold infer / evaluate

### DIFF
--- a/marinfold/marinfold/cli.py
+++ b/marinfold/marinfold/cli.py
@@ -45,6 +45,16 @@ _BACKEND_CHOICES = ("vllm", "transformers", "mlx")
 # --------------------------------------------------------------------------
 
 
+def _pdf_path(s: str) -> Path:
+    """Argparse type validator: only accept ``*.pdf`` paths for ``--out-plots``."""
+    p = Path(s)
+    if p.suffix.lower() != ".pdf":
+        raise argparse.ArgumentTypeError(
+            f"--out-plots must end in .pdf; got {s!r}"
+        )
+    return p
+
+
 def _impl_module_name(structure_name: str) -> str:
     """Map a doc-structure NAME (kebab-case) to its subpackage module path."""
     return f"marinfold.document_structures.{structure_name.replace('-', '_')}"
@@ -188,6 +198,9 @@ def cmd_infer(args: argparse.Namespace) -> None:
     write_predictions(args.out, records, structure_name=ds_name)
     print(f"[marinfold] wrote predictions to {args.out}", file=sys.stderr)
 
+    if args.out_plots is not None:
+        _emit_infer_plots(impl, ds_name, args.out_plots, records)
+
 
 def cmd_evaluate(args: argparse.Namespace) -> None:
     model_spec, ds_name = _resolve_model_and_structure(
@@ -213,6 +226,41 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
         records = list(impl.predict(dataclasses.replace(cfg)))
         write_predictions(args.out, records, structure_name=ds_name)
         print(f"[marinfold] wrote predictions to {args.out}", file=sys.stderr)
+
+    if args.out_plots is not None:
+        _emit_evaluate_plots(impl, ds_name, args.out_plots, result)
+
+
+def _emit_infer_plots(
+    impl: ModuleType,
+    ds_name: str,
+    out_path: Path,
+    records: list[Any],
+) -> None:
+    fn = getattr(impl, "plot_infer_pdf", None)
+    if fn is None:
+        raise SystemExit(
+            f"Document structure {ds_name!r} does not expose plot_infer_pdf "
+            f"— --out-plots is not supported for this impl."
+        )
+    fn(out_path, records)
+    print(f"[marinfold] wrote plots to {out_path}", file=sys.stderr)
+
+
+def _emit_evaluate_plots(
+    impl: ModuleType,
+    ds_name: str,
+    out_path: Path,
+    result: Any,
+) -> None:
+    fn = getattr(impl, "plot_evaluate_pdf", None)
+    if fn is None:
+        raise SystemExit(
+            f"Document structure {ds_name!r} does not expose plot_evaluate_pdf "
+            f"— --out-plots is not supported for this impl."
+        )
+    fn(out_path, result)
+    print(f"[marinfold] wrote plots to {out_path}", file=sys.stderr)
 
 
 # --------------------------------------------------------------------------
@@ -275,6 +323,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--out", type=Path, required=True,
         help="Predictions output (.json/.jsonl/.parquet).",
     )
+    p_inf.add_argument(
+        "--out-plots", type=_pdf_path, default=None,
+        help="Optional multi-page PDF; one predicted-distance heatmap "
+             "page per (structure, n_seeded). Requires the impl to "
+             "expose plot_infer_pdf; for contacts-and-distances-v1 "
+             "this is pulled in by the [contacts-and-distances-v1] extra.",
+    )
     p_inf.set_defaults(func=cmd_infer)
 
     # ---- evaluate ---------------------------------------------------------
@@ -296,6 +351,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--out", type=Path, default=None,
         help="Optional predictions output (.json/.jsonl/.parquet). "
              "Omit to skip the second predict pass.",
+    )
+    p_eval.add_argument(
+        "--out-plots", type=_pdf_path, default=None,
+        help="Optional multi-page PDF; one (GT, predicted) heatmap "
+             "page per (structure, n_seeded). Requires the impl to "
+             "expose plot_evaluate_pdf.",
     )
     p_eval.set_defaults(func=cmd_evaluate)
 

--- a/marinfold/marinfold/document_structures/contacts_and_distances_v1/__init__.py
+++ b/marinfold/marinfold/document_structures/contacts_and_distances_v1/__init__.py
@@ -17,11 +17,16 @@ Public surface:
 - :func:`predict`, :func:`evaluate`, :class:`InferenceConfig` —
   from :mod:`.inference`. These are what the top-level ``marinfold``
   CLI dispatches to.
+- :func:`plot_infer_pdf`, :func:`plot_evaluate_pdf` — from
+  :mod:`.plots`. Optional PDF writers used by ``marinfold infer
+  --out-plots`` / ``marinfold evaluate --out-plots``. Matplotlib is
+  imported lazily inside the helpers.
 """
 
 from .generate import GenerationConfig, generate_documents
 from .inference import InferenceConfig, evaluate, predict
 from .parse import structure_from_sequence
+from .plots import plot_evaluate_pdf, plot_infer_pdf
 from .vocab import CONTEXT_LENGTH, NAME, all_domain_tokens
 
 __all__ = [
@@ -32,6 +37,8 @@ __all__ = [
     "all_domain_tokens",
     "evaluate",
     "generate_documents",
+    "plot_evaluate_pdf",
+    "plot_infer_pdf",
     "predict",
     "structure_from_sequence",
 ]

--- a/marinfold/marinfold/document_structures/contacts_and_distances_v1/cli.py
+++ b/marinfold/marinfold/document_structures/contacts_and_distances_v1/cli.py
@@ -31,7 +31,18 @@ from marinfold import (
 
 from . import generate
 from . import inference
+from . import plots
 from .vocab import CONTEXT_LENGTH, NAME, all_domain_tokens
+
+
+def _pdf_path(s: str) -> Path:
+    """Argparse type validator: only accept ``*.pdf`` paths for ``--out-plots``."""
+    p = Path(s)
+    if p.suffix.lower() != ".pdf":
+        raise argparse.ArgumentTypeError(
+            f"--out-plots must end in .pdf; got {s!r}"
+        )
+    return p
 
 
 def _seed_n_values(s: str) -> tuple[int, ...]:
@@ -88,9 +99,15 @@ def cmd_infer(args: argparse.Namespace) -> None:
         max_pairs_per_structure=args.max_pairs_per_structure,
         keep_bin_probs=args.keep_bin_probs,
     )
-    records = inference.predict(cfg)
+    # Materialize so writer + plotter see the same data. ``predict``
+    # is a generator; the writer already lists internally, so
+    # listing here doesn't add memory pressure.
+    records = list(inference.predict(cfg))
     write_predictions(args.out, records, structure_name=NAME)
     print(f"[{NAME}] wrote {args.out}", file=sys.stderr)
+    if args.out_plots is not None:
+        plots.plot_infer_pdf(args.out_plots, records)
+        print(f"[{NAME}] wrote {args.out_plots}", file=sys.stderr)
 
 
 def cmd_evaluate(args: argparse.Namespace) -> None:
@@ -112,6 +129,9 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
     print(f"[{NAME}] wrote {args.out}", file=sys.stderr)
     for k, v in result.metrics.items():
         print(f"  {k} = {v}")
+    if args.out_plots is not None:
+        plots.plot_evaluate_pdf(args.out_plots, result)
+        print(f"[{NAME}] wrote {args.out_plots}", file=sys.stderr)
 
 
 def cmd_tokenizer(args: argparse.Namespace) -> None:
@@ -219,6 +239,12 @@ def build_parser() -> argparse.ArgumentParser:
                             "in infer mode it caps all queried pairs.")
         p.add_argument("--out", type=Path, required=True,
                        help="Output path.")
+        p.add_argument("--out-plots", type=_pdf_path, default=None,
+                       help="Optional multi-page PDF; one heatmap page "
+                            "per (structure, n_seeded). For infer this "
+                            "is the predicted distance matrix; for "
+                            "evaluate, GT (left) and predicted (right) "
+                            "side-by-side.")
 
     # ---- infer -------------------------------------------------------------
     p_inf = sub.add_parser("infer", help="Run a trained model (no ground truth).")

--- a/marinfold/marinfold/document_structures/contacts_and_distances_v1/inference.py
+++ b/marinfold/marinfold/document_structures/contacts_and_distances_v1/inference.py
@@ -447,9 +447,11 @@ def evaluate(
     per_structure_n_pairs: dict[int, dict[str, int]] = {
         n: {} for n in cfg.seed_n_values
     }
+    per_structure_n_residues: dict[str, int] = {}
     per_pair: list[dict] = []
 
     for structure in structures:
+        per_structure_n_residues[structure.entry_id] = len(structure.residues)
         gt = _gt_query_distance_matrix(structure, cfg.query_atom)
         for n_seeded in cfg.seed_n_values:
             pred = _query_pairs(
@@ -502,5 +504,6 @@ def evaluate(
             "n_structures": len(structures),
             "per_structure_mae": per_structure_mae,
             "per_structure_n_pairs": per_structure_n_pairs,
+            "per_structure_n_residues": per_structure_n_residues,
         },
     )

--- a/marinfold/marinfold/document_structures/contacts_and_distances_v1/plots.py
+++ b/marinfold/marinfold/document_structures/contacts_and_distances_v1/plots.py
@@ -1,0 +1,240 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""contacts-and-distances-v1 PDF plot writers for ``infer`` / ``evaluate``.
+
+The two top-level entry points — :func:`plot_infer_pdf` and
+:func:`plot_evaluate_pdf` — open a multi-page PDF and write one
+heatmap page per (structure, n_seeded) combination from the
+records / :class:`marinfold.EvalResult` the CLI already produced.
+
+Today there is one figure shape per command:
+
+- ``infer``: a single predicted CA-CA expected-distance heatmap.
+- ``evaluate``: GT (left) and predicted (right) side-by-side, sharing
+  a color scale. Pairs masked out of the eval (non-finite GT or GT >
+  ``distance_cap_angstrom``) render as NaN in both panels, so the
+  heatmap shows exactly which pairs were scored.
+
+Adding more plots later means: write another ``figure_*`` function
+and append its output to the page list in the assembler.
+
+``matplotlib`` is required for these helpers and is pulled in by the
+``marinfold[contacts-and-distances-v1]`` extra. The import is at
+call time so the rest of the impl loads without matplotlib
+installed.
+"""
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from marinfold import EvalResult
+
+
+# Distance-bin saturation point (Å) — mirrors the
+# ``_DISTANCE_MAX_A`` constant in ``inference.py``. Used as the color
+# scale upper bound so brightness is comparable across structures.
+_DISTANCE_MAX_A = 32.0
+
+
+# --------------------------------------------------------------------------
+# Matrix reconstruction
+# --------------------------------------------------------------------------
+
+
+def _reconstruct_matrix(
+    pairs: Iterable[tuple[int, int]],
+    values: Iterable[float],
+    n_residues: int,
+) -> np.ndarray:
+    """N×N matrix filled at (i-1, j-1) and (j-1, i-1) with ``values``.
+
+    Pairs are 1-indexed (i, j) with i < j, matching the per-pair
+    convention used throughout the impl. The diagonal is 0; any
+    (i, j) not in ``pairs`` stays NaN, which renders as transparent /
+    grey under matplotlib's default cmap.
+    """
+    out = np.full((n_residues, n_residues), np.nan, dtype=np.float32)
+    np.fill_diagonal(out, 0.0)
+    for (i, j), v in zip(pairs, values, strict=True):
+        out[i - 1, j - 1] = v
+        out[j - 1, i - 1] = v
+    return out
+
+
+# --------------------------------------------------------------------------
+# Figure builders
+# --------------------------------------------------------------------------
+
+
+def figure_predicted_heatmap(record: dict[str, Any]):
+    """Single-panel predicted CA-CA expected-distance heatmap.
+
+    ``record`` is one entry from :func:`inference.predict` — a dict
+    with ``entry_id``, ``n_residues``, ``n_seeded``, ``query_atom``,
+    ``pairs``, ``expected_distances``.
+    """
+    import matplotlib.pyplot as plt
+
+    entry_id = record["entry_id"]
+    n = int(record["n_residues"])
+    n_seeded = int(record["n_seeded"])
+    query_atom = record["query_atom"]
+    pred = _reconstruct_matrix(
+        record["pairs"], record["expected_distances"], n,
+    )
+
+    fig, ax = plt.subplots(figsize=(6.5, 5.5))
+    im = ax.imshow(pred, vmin=0, vmax=_DISTANCE_MAX_A, cmap="viridis")
+    ax.set_title(f"Predicted {query_atom}-{query_atom} (Å)")
+    ax.set_xlabel("residue j")
+    ax.set_ylabel("residue i")
+    fig.colorbar(im, ax=ax, fraction=0.046, label="expected distance (Å)")
+    fig.suptitle(f"{entry_id}  (n_residues={n}, n_seeded={n_seeded})")
+    fig.tight_layout()
+    return fig
+
+
+def figure_gt_vs_predicted(
+    *,
+    entry_id: str,
+    n_residues: int,
+    n_seeded: int,
+    query_atom: str,
+    gt: np.ndarray,
+    pred: np.ndarray,
+    mae: float,
+):
+    """Two-panel figure: GT (left), predicted (right), shared color scale."""
+    import matplotlib.pyplot as plt
+
+    fig, axes = plt.subplots(1, 2, figsize=(11, 5))
+    axes[0].imshow(gt, vmin=0, vmax=_DISTANCE_MAX_A, cmap="viridis")
+    axes[0].set_title(f"GT {query_atom}-{query_atom} (Å)")
+    im1 = axes[1].imshow(pred, vmin=0, vmax=_DISTANCE_MAX_A, cmap="viridis")
+    axes[1].set_title(f"Predicted {query_atom}-{query_atom} (Å)")
+    for ax in axes:
+        ax.set_xlabel("residue j")
+        ax.set_ylabel("residue i")
+    # Right-edge colorbar shared between the two panels — they're on
+    # the same scale, so one bar avoids duplicating the legend.
+    fig.colorbar(im1, ax=axes, fraction=0.046, label="distance (Å)")
+    mae_str = f"{mae:.2f} Å" if np.isfinite(mae) else "NaN"
+    fig.suptitle(
+        f"{entry_id}  (n_residues={n_residues}, n_seeded={n_seeded}, "
+        f"MAE={mae_str})"
+    )
+    return fig
+
+
+# --------------------------------------------------------------------------
+# PDF assemblers
+# --------------------------------------------------------------------------
+
+
+def plot_infer_pdf(out_path: Path, records: list[dict[str, Any]]) -> None:
+    """Write one predicted-heatmap page per (structure, n_seeded).
+
+    ``records`` is the materialized output of :func:`inference.predict`
+    (the CLI lists it before calling us so the writer + plotter both
+    see the same data).
+    """
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not records:
+        raise SystemExit("plot_infer_pdf: no records to plot")
+
+    with PdfPages(out_path) as pdf:
+        for record in records:
+            fig = figure_predicted_heatmap(record)
+            pdf.savefig(fig, bbox_inches="tight")
+            plt.close(fig)
+
+
+def plot_evaluate_pdf(out_path: Path, result: EvalResult) -> None:
+    """Write one GT-vs-predicted page per (structure, n_seeded).
+
+    Reconstructs the GT and predicted matrices from
+    ``result.per_example`` (which holds every evaluated pair's GT and
+    expected distance). N per structure comes from
+    ``result.extras["per_structure_n_residues"]``, populated by
+    :func:`inference.evaluate`. MAE per (structure, n_seeded) comes
+    from ``result.extras["per_structure_mae"]``.
+    """
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    extras = result.extras
+    n_residues_by_entry: dict[str, int] = extras["per_structure_n_residues"]
+    mae_by_n_by_entry: dict[Any, dict[str, float]] = extras["per_structure_mae"]
+    query_atom = extras.get("query_atom", "CA")
+    seed_n_values = list(extras.get("seed_n_values", []))
+    if not seed_n_values:
+        # Fall back to whatever n_seeded values appear in the rows.
+        seed_n_values = sorted({int(r["n_seeded"]) for r in result.per_example})
+
+    # Bucket per_example rows by (entry_id, n_seeded). The MAE-by-n
+    # dict's keys can be ints or stringified ints depending on whether
+    # extras went through a JSON round-trip; ``_lookup_mae`` handles
+    # both.
+    by_key: dict[tuple[str, int], list[dict]] = {}
+    entry_order: list[str] = []
+    seen_entries: set[str] = set()
+    for row in result.per_example:
+        entry_id = row["entry_id"]
+        n_seeded = int(row["n_seeded"])
+        by_key.setdefault((entry_id, n_seeded), []).append(row)
+        if entry_id not in seen_entries:
+            seen_entries.add(entry_id)
+            entry_order.append(entry_id)
+
+    if not by_key:
+        raise SystemExit("plot_evaluate_pdf: EvalResult has no per_example rows to plot")
+
+    with PdfPages(out_path) as pdf:
+        for entry_id in entry_order:
+            n = int(n_residues_by_entry[entry_id])
+            for n_seeded in seed_n_values:
+                rows = by_key.get((entry_id, int(n_seeded)))
+                if not rows:
+                    continue
+                pairs = [(int(r["i"]), int(r["j"])) for r in rows]
+                gt_vals = [float(r["gt_angstrom"]) for r in rows]
+                pred_vals = [float(r["expected_angstrom"]) for r in rows]
+                gt_mat = _reconstruct_matrix(pairs, gt_vals, n)
+                pred_mat = _reconstruct_matrix(pairs, pred_vals, n)
+                mae = _lookup_mae(mae_by_n_by_entry, n_seeded, entry_id)
+                fig = figure_gt_vs_predicted(
+                    entry_id=entry_id,
+                    n_residues=n,
+                    n_seeded=int(n_seeded),
+                    query_atom=query_atom,
+                    gt=gt_mat,
+                    pred=pred_mat,
+                    mae=mae,
+                )
+                pdf.savefig(fig, bbox_inches="tight")
+                plt.close(fig)
+
+
+def _lookup_mae(
+    mae_by_n_by_entry: dict[Any, dict[str, float]],
+    n_seeded: int,
+    entry_id: str,
+) -> float:
+    """Pull MAE out of ``per_structure_mae`` regardless of int/str key shape."""
+    for key in (n_seeded, str(n_seeded)):
+        inner = mae_by_n_by_entry.get(key)
+        if inner is not None and entry_id in inner:
+            return float(inner[entry_id])
+    return float("nan")

--- a/marinfold/pyproject.toml
+++ b/marinfold/pyproject.toml
@@ -35,7 +35,9 @@ mlx = ["mlx>=0.18; sys_platform == 'darwin'", "mlx-lm>=0.20; sys_platform == 'da
 # Their heavy parser deps (gemmi, biopython, …) are opt-in via these
 # extras and lazy-imported inside the impl modules so the marinfold
 # CLI can fail with a clear message when an extra isn't installed.
-contacts-and-distances-v1 = ["gemmi>=0.6"]
+# matplotlib here is for the impl's plots.py (PDF heatmap writers
+# behind ``--out-plots``); imported lazily inside the helpers.
+contacts-and-distances-v1 = ["gemmi>=0.6", "matplotlib"]
 
 [project.scripts]
 marinfold = "marinfold.cli:main"

--- a/marinfold/tests/document_structures/contacts_and_distances_v1/test_plots.py
+++ b/marinfold/tests/document_structures/contacts_and_distances_v1/test_plots.py
@@ -1,0 +1,137 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke tests for the impl's ``plots.py`` PDF writers.
+
+These tests don't run a model. They build tiny synthetic predict /
+evaluate outputs by hand and assert that the corresponding PDF writer
+produces a non-empty file with the expected page count.
+"""
+
+from pathlib import Path
+
+import pytest
+
+# Skip the whole module cleanly when matplotlib isn't installed (i.e.
+# the ``[contacts-and-distances-v1]`` extra wasn't synced). CI that
+# installs the extra will exercise the assertions.
+matplotlib = pytest.importorskip("matplotlib")
+matplotlib.use("Agg")  # headless backend
+
+from marinfold import EvalResult  # noqa: E402
+from marinfold.document_structures.contacts_and_distances_v1 import (  # noqa: E402
+    plot_evaluate_pdf,
+    plot_infer_pdf,
+)
+
+
+def _read_pdf_page_count(pdf_path: Path) -> int:
+    """Page count via pypdf if installed, else count ``/Type /Page`` markers.
+
+    The marker count is good enough for a smoke test — matplotlib's
+    PdfPages writes one page object per page, and there's no other
+    source of ``/Type /Page`` in these PDFs.
+    """
+    try:
+        from pypdf import PdfReader
+        return len(PdfReader(str(pdf_path)).pages)
+    except ImportError:
+        blob = pdf_path.read_bytes()
+        return blob.count(b"/Type /Page") - blob.count(b"/Type /Pages")
+
+
+def test_plot_infer_pdf_writes_one_page_per_record(tmp_path: Path) -> None:
+    records = [
+        {
+            "entry_id": "AF-ABC123-F1",
+            "n_residues": 5,
+            "n_seeded": 0,
+            "query_atom": "CA",
+            "pairs": [(1, 2), (1, 3), (2, 4), (3, 5)],
+            "expected_distances": [4.0, 7.5, 10.2, 15.1],
+        },
+        {
+            "entry_id": "AF-ABC123-F1",
+            "n_residues": 5,
+            "n_seeded": 5,
+            "query_atom": "CA",
+            "pairs": [(1, 2), (1, 3), (2, 4), (3, 5)],
+            "expected_distances": [4.1, 7.6, 10.0, 14.8],
+        },
+    ]
+    out_pdf = tmp_path / "infer.pdf"
+    plot_infer_pdf(out_pdf, records)
+    assert out_pdf.exists()
+    assert out_pdf.stat().st_size > 0
+    assert _read_pdf_page_count(out_pdf) == 2
+
+
+def test_plot_evaluate_pdf_writes_one_page_per_structure_n_seeded(
+    tmp_path: Path,
+) -> None:
+    # Two structures, two seed-N values: expect 4 pages.
+    per_example = []
+    for entry_id, n in [("AF-A-F1", 5), ("AF-B-F1", 6)]:
+        for n_seeded in (0, 5):
+            for i in range(1, n):
+                for j in range(i + 1, n + 1):
+                    gt = float(j - i)
+                    pred = float(j - i) + 0.5
+                    per_example.append({
+                        "entry_id": entry_id,
+                        "n_seeded": n_seeded,
+                        "i": i,
+                        "j": j,
+                        "gt_angstrom": gt,
+                        "expected_angstrom": pred,
+                        "abs_err_angstrom": abs(pred - gt),
+                    })
+    result = EvalResult(
+        metrics={"mae_at_n0_angstrom": 0.5, "mae_at_n5_angstrom": 0.5},
+        per_example=per_example,
+        extras={
+            "structure": "contacts-and-distances-v1",
+            "model": "dummy",
+            "backend": "transformers",
+            "query_atom": "CA",
+            "seed_n_values": [0, 5],
+            "n_structures": 2,
+            "per_structure_mae": {
+                0: {"AF-A-F1": 0.5, "AF-B-F1": 0.5},
+                5: {"AF-A-F1": 0.5, "AF-B-F1": 0.5},
+            },
+            "per_structure_n_pairs": {
+                0: {"AF-A-F1": 10, "AF-B-F1": 15},
+                5: {"AF-A-F1": 10, "AF-B-F1": 15},
+            },
+            "per_structure_n_residues": {"AF-A-F1": 5, "AF-B-F1": 6},
+        },
+    )
+    out_pdf = tmp_path / "eval.pdf"
+    plot_evaluate_pdf(out_pdf, result)
+    assert out_pdf.exists()
+    assert out_pdf.stat().st_size > 0
+    assert _read_pdf_page_count(out_pdf) == 4
+
+
+def test_plot_evaluate_pdf_tolerates_string_mae_keys(tmp_path: Path) -> None:
+    """``extras`` round-tripped through JSON gets int keys stringified —
+    the writer should still find the MAE entry and produce a page."""
+    per_example = [
+        {"entry_id": "X", "n_seeded": 0, "i": 1, "j": 3,
+         "gt_angstrom": 8.0, "expected_angstrom": 8.1, "abs_err_angstrom": 0.1},
+    ]
+    result = EvalResult(
+        metrics={"mae_at_n0_angstrom": 0.1},
+        per_example=per_example,
+        extras={
+            "query_atom": "CA",
+            "seed_n_values": [0],
+            "per_structure_mae": {"0": {"X": 0.1}},  # stringified key
+            "per_structure_n_pairs": {"0": {"X": 1}},
+            "per_structure_n_residues": {"X": 3},
+        },
+    )
+    out_pdf = tmp_path / "eval_stringkeys.pdf"
+    plot_evaluate_pdf(out_pdf, result)
+    assert _read_pdf_page_count(out_pdf) == 1


### PR DESCRIPTION
## Summary

- Adds `--out-plots PATH.pdf` to `marinfold infer` and `marinfold evaluate` (and the per-impl `contacts-and-distances-v1` driver). Each (structure, n_seeded) becomes one heatmap page: predicted-only for infer, GT-vs-predicted side-by-side for evaluate. Adding more plots later is a matter of appending pages.
- New module: `marinfold/marinfold/document_structures/contacts_and_distances_v1/plots.py`. Matrices are reconstructed from `predict` records / `EvalResult.per_example`; masked pairs (GT > cap or non-finite) render as NaN so the eval panel shows exactly which pairs were scored.
- `evaluate()` extras gain `per_structure_n_residues` so the PDF writer doesn't have to re-parse structure files. `matplotlib` is added to the `contacts-and-distances-v1` extra and imported lazily inside the helpers — base `marinfold` installs stay light.
- Three smoke tests in `marinfold/tests/document_structures/contacts_and_distances_v1/test_plots.py` build synthetic predict / evaluate outputs and assert page counts.

## Test plan

- [x] `uv run pytest tests/ -m "not network"` — 64 passed (61 existing + 3 new), 2 deselected.
- [x] `uv run marinfold infer --help` / `marinfold evaluate --help` show the new flag with helpful text.
- [x] `--out-plots foo.png` rejected by argparse (validator requires `.pdf`).
- [ ] End-to-end: run `marinfold evaluate --backend transformers --input-dir <small-cif-dir> --metrics-out m.json --out-plots p.pdf` against the 1B model and eyeball the PDF.
