### PR TITLE
docs(AGENTS): require timing capture for any predictor run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,54 @@ editing a history file so `history/RUNS.md` stays current.
 
 See `history/README.md` for the schema and the full policy.
 
+### Capture timings for every predictor run
+
+**Always record per-protein (or per-input) wall-time and worker
+metadata when you run *any* predictor**, whether it's a MarinFold
+model, Protenix, ESMFold, AlphaFold, or anyone else's. **Save
+timings to a CSV at evaluation time, not "we can reconstruct it
+later from logs"** — Modal's ephemeral-app logs get pruned, iris
+job records get garbage-collected, and "we'll grab it from the
+output dirs' mtimes" is fragile across re-syncs. Bake it into the
+predictor wrapper.
+
+Minimum schema (one row per (input, mode) pair, or per (input,
+seed) if the predictor splits work that way):
+
+```
+stem, n_residues, n_pairs, mode,
+elapsed_seconds,             # pure inference time (matches AF3-paper convention)
+model_load_seconds,          # weight-load + runner setup time, reported separately
+total_seconds,               # everything: setup + inference + dump (sanity check)
+model_nickname,              # e.g. "protenix-v2", "marinfold-1b"
+runner_tag,                  # "modal", "iris", "local"
+gpu_name, gpu_total_memory_gb, gpu_compute_capability,
+hostname, platform, torch_version,
+timestamp_utc
+```
+
+Plus any per-predictor-specific columns (e.g. `n_seeds`,
+`n_samples_per_seed`, `batch_size`).
+
+This schema is concretely realized in
+[`experiments/exp12_data_protenix_foldbench_monomers/data/timings.csv`](experiments/exp12_data_protenix_foldbench_monomers/data/timings.csv)
+and
+[`experiments/exp20_evals_marinfold_1b_foldbench/data/timings.csv`](experiments/exp20_evals_marinfold_1b_foldbench/data/timings.csv) — they share enough columns
+that the two CSVs join cleanly on `(stem, n_residues)`. Match it
+when adding a new evaluator so cross-experiment timing comparisons
+(e.g. MarinFold vs Protenix vs ESMFold scaling curves) just work.
+Commit the CSV to git; upload alongside other artifacts when going
+to the HF bucket. Plot conventions for the timing-vs-length curve
+are in
+[`experiments/exp12_data_protenix_foldbench_monomers/_scripts/plot_timings.py`](experiments/exp12_data_protenix_foldbench_monomers/_scripts/plot_timings.py).
+
+For Modal-hosted predictors: capture worker metadata once in
+`@modal.enter` (stash in `self.worker_meta`), time the inference in
+`predict_one`, and write a `timings.json` per (input, mode) on the
+output Volume — then a small post-hoc script aggregates those into
+the CSV. Don't try to recover this from Modal logs after the fact;
+ephemeral-app logs disappear.
+
 ## See also
 
 - `RESOURCES.md` — datasets, tokenizers, prior repos and prior runs.

--- a/experiments/AGENTS.md
+++ b/experiments/AGENTS.md
@@ -91,6 +91,16 @@ whichever fits the work.
    the same W&B run share one history file. See the root
    `AGENTS.md` and `history/README.md` for the schema.
 
+9. **Capture per-input timings whenever you run a predictor.** Bake
+   timing capture into the wrapper at evaluation time and commit a
+   `data/timings.csv` to the experiment dir — don't plan to
+   reconstruct from logs after the fact (Modal's ephemeral-app logs
+   get pruned). Use the schema documented in the root `AGENTS.md`
+   "Capture timings for every predictor run" section so cross-
+   experiment timing comparisons (e.g. exp12 Protenix vs exp20
+   MarinFold-1B) join on `(stem, n_residues)` without bespoke
+   munging.
+
 ## Importing from kind libraries
 
 An experiment that needs marin or a kind library has its own


### PR DESCRIPTION
## Summary

Add a new Hard Rule to the root `AGENTS.md` ("Capture timings for every predictor run") and a short pointer from `experiments/AGENTS.md` so it's discoverable from both surfaces.

## Why

The original exp12 (Protenix on FoldBench monomers) run didn't capture per-protein wall-times because the wrapper didn't record them, and by the time we wanted them (to compare against exp20's MarinFold-1B), Modal's ephemeral-app logs had been pruned. The fix required an instrumented re-run of a 20-protein subset (exp12 follow-up PR #22) — avoidable if we'd baked timing capture in from the start.

## What

A new Hard Rule next to the existing W&B / HF / Run history policies in root `AGENTS.md`, documenting:
- The minimum CSV schema (the columns that already join cleanly between exp12 and exp20)
- The Modal-specific pattern (`@modal.enter` for worker meta; `predict_one` writes `timings.json` on the output Volume; aggregator script builds the CSV)
- A direct don't-do: don't plan to reconstruct timings from logs

`experiments/AGENTS.md` gets a one-rule addition that points at the root section, so anyone working under `experiments/` discovers it.

## Test plan

- [x] Schema matches what's in [`exp12/data/timings.csv`](experiments/exp12_data_protenix_foldbench_monomers/data/timings.csv) and [`exp20/data/timings.csv`](experiments/exp20_evals_marinfold_1b_foldbench/data/timings.csv) — they already join on `(stem, n_residues)`.
- [ ] No-op for `/ultrareview`; this is policy-doc only.
