### PR TITLE
contacts-v1: reuse contacts-and-distances-v1 tokens (positions + section markers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ fractions, pLDDT filter, context-length budget).
 
 A second format, `contacts-v1`
 ([SPEC.md](marinfold/marinfold/document_structures/contacts_v1/SPEC.md)),
-is contacts-only: a residue sequence — `<pos-N> <AA>` statements in
+is contacts-only: a residue sequence — `<pN> <AA>` statements in
 random order, with `<n-term>`/`<c-term>` markers and residues numbered
 from a random start that wraps around 2000 indices — followed by
 `<contact>` statements for the strongest

--- a/marinfold/marinfold/document_structures/contacts_v1/SPEC.md
+++ b/marinfold/marinfold/document_structures/contacts_v1/SPEC.md
@@ -4,44 +4,50 @@ This document defines a spec for the *contacts-v1* document type. It is the inpu
 
 ## Example document
 
+(Shown with the **actual emitted tokens**; the original design sketch used
+`<pos-22>` / `<begin-sequence>` / `<begin-structure>` and lowercase amino
+acids, but per the decisions below those are realized as the
+contacts-and-distances-v1 tokens `<p22>` / `<begin_sequence>` /
+`<begin_statements>` and uppercase `<ALA>` …)
+
 ```
 <contacts-v1>
-<begin-sequence>
-<pos-22> <phe>
-<n-term> <pos-20>
-<pos-21> <ala>
-<c-term> <pos 22>
-<pos-20> <ala>
-<begin-structure>
-<contact> <pos-20> <pos-21> 
-<contact> <pos-22> <pos-21> 
+<begin_sequence>
+<p22> <PHE>
+<n-term> <p20>
+<p21> <ALA>
+<c-term> <p22>
+<p20> <ALA>
+<begin_statements>
+<contact> <p20> <p21>
+<contact> <p22> <p21>
 <end>
 ```
 
 ## Details
 
-We have two sections: a sequence section (starting with `<begin-sequence>`) and a structure section (starting with `<begin-structure>`).
+We have two sections: a sequence section (starting with `<begin_sequence>`) and a structure section (starting with `<begin_statements>`).
 
 ### Sequence section
 This consists of three kinds of statements.
 
-`<POS-XXX> <RESIDUE>` indicates that position XXX is the given amino acid. We have indexing tokens `<pos-0000>` through `<pos-1999>` (2000 indices total).
+`<pXXX> <RESIDUE>` indicates that position XXX is the given amino acid. The position tokens are contacts-and-distances-v1's `<p0>` through `<p1999>` (2000 indices total), reused rather than minted anew.
 
-`<n-term>` `<pos-XXX>` indicates that position XXX is the N-terminus of a protein chain
+`<n-term>` `<pXXX>` indicates that position XXX is the N-terminus of a protein chain
 
-`<c-term>` `<pos-XXX>` indicates that position XXX is the C-terminus of a protein chain.
+`<c-term>` `<pXXX>` indicates that position XXX is the C-terminus of a protein chain.
 
 The statements of the sequence section are given in random order. We define the amino acid for all residues exactly once. We define the N- and C-termini for each protein chain.
 
 ### Residue indexing
 We support structures with up to 2000 residues
 
-Rather than numbering residues in a protein as e.g. 0 to 1999, each time we generate a document we pick a random number n in [0, 2000) to be the n-terminal residue. We start indexing from this residue. Residue indices "wrap around", so the residue after `<pos-1999>` is `<pos-0>`. The motivation here is that we want the model to be experienced in using all residue indices. Since most proteins are way less than 2000 residues, if we always started the protein chain off at `<pos-0>` the model would only rarely see the higher value indices.
+Rather than numbering residues in a protein as e.g. 0 to 1999, each time we generate a document we pick a random number n in [0, 2000) to be the n-terminal residue. We start indexing from this residue. Residue indices "wrap around", so the residue after `<p1999>` is `<p0>`. The motivation here is that we want the model to be experienced in using all residue indices. Since most proteins are way less than 2000 residues, if we always started the protein chain off at `<p0>` the model would only rarely see the higher value indices.
 
 In the future we will support multiple protein chains, and we will just have multiple <n-term> and <c-term> statements for these. They will need to be spaced out enough to not overlap. For example we might have one protein that starts at index 1800 and continues until residue 100, and another that starts at residue 300 and continues until 800.
 
 ### Structure section
-The structure section consists of statements of the form `<contact>` `<pos-XXX>` `<pos-YYY>`, which indicates that residues at index XXX and YYY are in contact.
+The structure section consists of statements of the form `<contact>` `<pXXX>` `<pYYY>`, which indicates that residues at index XXX and YYY are in contact.
 
 Contacts are defined as contact degree > 0 where contact degree is implemented in [pyconfind](https://github.com/timodonnell/pyconfind). We run pyconfind in `native_only=True` mode, i.e. only consider the actual given amino acid at each position rather than all other possibilities.
 
@@ -49,7 +55,7 @@ Before selecting which contacts to include, we discard any contact whose contact
 
 From the contacts that pass this threshold, we include the N with the highest contact degree (the N strongest), where N is chosen so the document fills the 8192-token budget (see Document length). These N selected contacts are then listed in **random order** in the structure section — they are *not* sorted by degree. (We select by strength so that, when a protein has more above-threshold contacts than fit, the weakest are the ones dropped; but the order they appear in the document is randomized so the model does not learn a degree-sorted ordering.)
 
-Note that the contact matrix is symmetric. We randomize the order that each contact pair is given in: if there is a contact between XXX and YYY, with 50% probability we output `<contact> <pos-XXX> <pos-YYY>` and the other half of the time we output `<contact> <pos-YYY> <pos-XXX>`. Each contact is only specified once, i.e. once we emit the contact between XXX and YYY we will never emit it again in either order.
+Note that the contact matrix is symmetric. We randomize the order that each contact pair is given in: if there is a contact between XXX and YYY, with 50% probability we output `<contact> <pXXX> <pYYY>` and the other half of the time we output `<contact> <pYYY> <pXXX>`. Each contact is only specified once, i.e. once we emit the contact between XXX and YYY we will never emit it again in either order.
 
 ### Document length
 Our max document length is 8192 tokens. N (the number of contacts included) is the number of the strongest *above-threshold* contacts whose `<contact>` statements fit in the budget remaining after the sequence section. If the protein has more above-threshold contacts than fit, the weakest of them are dropped (truncation); if it has fewer, all above-threshold contacts are included and the document is shorter than the budget.
@@ -69,24 +75,33 @@ the spec changes.
 
 ### Decisions that override the spec text
 
-- **Position tokens are unpadded: `<pos-0>` … `<pos-1999>`.** The
-  *Details* section above writes `<pos-0000>` through `<pos-1999>`
-  (zero-padded), but the example writes `<pos-22>`. Per a maintainer
-  decision the unpadded form (matching the example) is canonical. 2000
-  tokens total.
-- **Amino-acid tokens are the uppercase three-letter tokens reused from
-  contacts-and-distances-v1: `<ALA>`, `<ARG>`, … `<VAL>`.** The example
-  above shows lowercase (`<phe>`, `<ala>`), but per a maintainer
-  decision contacts-v1 reuses the existing uppercase AA tokens so the
-  two document structures share amino-acid embeddings (useful for the
-  planned later fine-tuning). No lowercase `<ala>`-style tokens exist in
-  the vocab.
-- **The worked example is illustrative and has informal typos** that the
-  implementation does not reproduce: `<c-term> <pos 22>` is always
-  emitted as `<c-term> <pos-22>` (hyphenated), and the prose "we will
-  never see `<contact> <pos-XXX> <pos-YYY>` or `<contact> <pos-YYY>
-  <pos-XXX>`" means a contact pair is emitted exactly once in one of the
-  two orders.
+contacts-v1 **reuses contacts-and-distances-v1 tokens wherever an
+equivalent already exists**, so the two structures share token IDs /
+embeddings and a contacts-v1 model can be fine-tuned on
+contacts-and-distances-v1 documents without a tokenizer change. This
+overrides the spec's own token spellings:
+
+- **Position tokens reuse `<p0>` … `<p1999>`.** The *Details* section's
+  `<pXXX>` indices (sketched as `<pos-0000>` / `<pos-22>` in the original
+  draft) are contacts-and-distances-v1's existing `<p0>`–`<p2700>`
+  position tokens; contacts-v1 uses the first 2000 of them and mints no
+  `<pos-N>` tokens. Note a contacts-v1 position is a *randomized
+  wrap-around* index, whereas the same `<pX>` in contacts-and-distances-v1
+  is a true chain position — the leading doc-type token distinguishes the
+  two interpretations.
+- **Section markers reuse `<begin_sequence>` / `<begin_statements>`.**
+  The spec's `<begin-sequence>` / `<begin-structure>` are realized as
+  contacts-and-distances-v1's underscore-spelled markers (so
+  `<begin_statements>` opens the structure section).
+- **Amino-acid tokens reuse the uppercase `<ALA>` … `<VAL>`.** The
+  example's lowercase (`<phe>`, `<ala>`) is not used; reusing the
+  uppercase AAs shares amino-acid embeddings with contacts-and-distances-v1.
+- **`<end>` is the shared contacts-and-distances-v1 token** too.
+
+The only tokens contacts-v1 mints itself are `<contacts-v1>`, `<n-term>`,
+`<c-term>`, `<contact>`, and the (unused) `<think>` — five tokens with no
+contacts-and-distances-v1 analog. (The original example's `<c-term> <pos
+22>` space typo is emitted as `<c-term> <p22>`.)
 
 ### Points the spec left open (implementation choices)
 
@@ -139,11 +154,12 @@ the spec changes.
   (2) the shuffle of the sequence-section statements, then (3) the
   shuffle of the N selected contacts (their in-document order), then
   (4) the per-contact pair-order coin flips.
-- **Vocab order.** Load-bearing and append-only: contacts-v1 native
-  control tokens, then `<pos-0>`…`<pos-1999>`, then `<think>`, then the
-  contacts-and-distances-v1 `all_domain_tokens()` list deduplicated. The
-  only token shared between the two groups is `<end>`, kept once (shared
-  id). Total domain vocab = 4845 tokens (4847 with `<pad>`/`<eos>`).
+- **Vocab order.** Load-bearing and append-only: the 5 native tokens
+  (`<contacts-v1>`, `<n-term>`, `<c-term>`, `<contact>`, `<think>`), then
+  the entire contacts-and-distances-v1 `all_domain_tokens()` list. The two
+  groups are disjoint — contacts-v1 reuses c-and-d-v1 tokens by *emitting*
+  them, not by re-minting — so no dedup is needed. Total domain vocab =
+  2843 tokens (2845 with `<pad>`/`<eos>`).
 
 ### Metadata tracked (beyond the spec)
 

--- a/marinfold/marinfold/document_structures/contacts_v1/__init__.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/__init__.py
@@ -3,9 +3,9 @@
 
 """contacts-v1 document structure.
 
-Serialize each protein as a *sequence section* (one ``<pos-X> <AA>``
+Serialize each protein as a *sequence section* (one ``<pX> <AA>``
 statement per residue, plus ``<n-term>`` / ``<c-term>`` markers, in random
-order) followed by a *structure section* of ``<contact> <pos-X> <pos-Y>``
+order) followed by a *structure section* of ``<contact> <pX> <pY>``
 statements for the strongest pyconfind side-chain contacts (as many as
 fill the context-length budget), listed in random order. Residues are
 numbered from a random n-terminal index that wraps around 2000 position

--- a/marinfold/marinfold/document_structures/contacts_v1/cli.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/cli.py
@@ -31,7 +31,7 @@ from typing import Any
 from marinfold import build_tokenizer, write_docs
 
 from . import generate
-from .vocab import CONTEXT_LENGTH, NAME, all_domain_tokens
+from .vocab import CONTEXT_LENGTH, NAME, all_domain_tokens, position_token
 
 
 # --------------------------------------------------------------------------
@@ -131,7 +131,8 @@ def cmd_view(args: argparse.Namespace) -> None:
             f"  residues={result.seq_len}  "
             f"global_plddt={result.global_plddt:.1f}  "
             f"start_index={result.start_index}  "
-            f"n_term=<pos-{result.n_term_index}>  c_term=<pos-{result.c_term_index}>"
+            f"n_term={position_token(result.n_term_index)}  "
+            f"c_term={position_token(result.c_term_index)}"
         )
         print(
             f"  contacts: {result.contacts_emitted} included / "
@@ -152,7 +153,7 @@ def cmd_view(args: argparse.Namespace) -> None:
         print(f"  strongest contacts (up to {ncap}, sorted for display):")
         for c in by_degree[:ncap]:
             print(
-                f"    <pos-{c.pos_i}>/<pos-{c.pos_j}>  "
+                f"    {position_token(c.pos_i)}/{position_token(c.pos_j)}  "
                 f"{c.resname_i}{c.resnum_i}–{c.resname_j}{c.resnum_j}  "
                 f"degree={c.degree:.4f}"
             )

--- a/marinfold/marinfold/document_structures/contacts_v1/generate.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/generate.py
@@ -44,7 +44,18 @@ from .parse import (
     analyze_structure,
     iter_analyzed_structures,
 )
-from .vocab import CONTEXT_LENGTH, NUM_POSITION_INDICES
+from .vocab import (
+    BEGIN_SEQUENCE_TOKEN,
+    BEGIN_STRUCTURE_TOKEN,
+    CONTACT_TOKEN,
+    CONTEXT_LENGTH,
+    C_TERM_TOKEN,
+    DOC_TYPE_TOKEN,
+    END_TOKEN,
+    NUM_POSITION_INDICES,
+    N_TERM_TOKEN,
+    position_token,
+)
 
 
 # Token counts the budget arithmetic depends on.
@@ -236,10 +247,11 @@ def build_document(
 
     # Sequence section: per-residue assignments + the two termini, shuffled.
     seq_statements: list[tuple[str, ...]] = [
-        (f"<pos-{pos_of_seq[k]}>", f"<{r.resname}>") for k, r in enumerate(residues)
+        (position_token(pos_of_seq[k]), f"<{r.resname}>")
+        for k, r in enumerate(residues)
     ]
-    seq_statements.append(("<n-term>", f"<pos-{n_term_index}>"))
-    seq_statements.append(("<c-term>", f"<pos-{c_term_index}>"))
+    seq_statements.append((N_TERM_TOKEN, position_token(n_term_index)))
+    seq_statements.append((C_TERM_TOKEN, position_token(c_term_index)))
     rng.shuffle(seq_statements)
 
     # Structure section. Rank by descending degree (stable sort keeps
@@ -288,14 +300,14 @@ def build_document(
             flipped=rng.random() < 0.5,
         ))
 
-    tokens: list[str] = ["<contacts-v1>", "<begin-sequence>"]
+    tokens: list[str] = [DOC_TYPE_TOKEN, BEGIN_SEQUENCE_TOKEN]
     for statement in seq_statements:
         tokens.extend(statement)
-    tokens.append("<begin-structure>")
+    tokens.append(BEGIN_STRUCTURE_TOKEN)
     for c in emitted:
         first, second = (c.pos_j, c.pos_i) if c.flipped else (c.pos_i, c.pos_j)
-        tokens += ["<contact>", f"<pos-{first}>", f"<pos-{second}>"]
-    tokens.append("<end>")
+        tokens += [CONTACT_TOKEN, position_token(first), position_token(second)]
+    tokens.append(END_TOKEN)
 
     return GenerationResult(
         entry_id=entry_id,

--- a/marinfold/marinfold/document_structures/contacts_v1/generate.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/generate.py
@@ -14,12 +14,12 @@ input structure, fully deterministic given the structure's ``entry_id``:
 2. Pick a random n-terminal index ``start`` in ``[0, 2000)``; number
    residues ``start, start+1, …`` with wrap-around (so the model sees
    the whole index range, not just the low values most proteins reach).
-3. Emit the sequence section — one ``<pos-X> <AA>`` statement per
+3. Emit the sequence section — one ``<pX> <AA>`` statement per
    residue plus one ``<n-term>`` and one ``<c-term>`` statement — in
    random order.
 4. Emit the structure section — select the N strongest contacts (N
    chosen to fill the context-length budget, dropping the weakest if
-   they don't all fit), then emit ``<contact> <pos-X> <pos-Y>``
+   they don't all fit), then emit ``<contact> <pX> <pY>``
    statements for them in *random* order, each pair's order coin-flipped.
 
 The pure builder :func:`build_document` takes already-computed residues
@@ -59,10 +59,10 @@ from .vocab import (
 
 
 # Token counts the budget arithmetic depends on.
-_SEQ_TOKENS_PER_RESIDUE = 2     # <pos-X> <AA>
-_TERMINUS_STATEMENTS = 2        # <n-term> <pos-S>  and  <c-term> <pos-E>
-_CONTACT_TOKENS_PER_STATEMENT = 3   # <contact> <pos-X> <pos-Y>
-# <contacts-v1> <begin-sequence> … <begin-structure> … <end>
+_SEQ_TOKENS_PER_RESIDUE = 2     # <pX> <AA>
+_TERMINUS_STATEMENTS = 2        # <n-term> <pS>  and  <c-term> <pE>
+_CONTACT_TOKENS_PER_STATEMENT = 3   # <contact> <pX> <pY>
+# <contacts-v1> <begin_sequence> … <begin_statements> … <end>
 _FRAME_TOKENS = 4
 
 
@@ -97,7 +97,7 @@ class EmittedContact:
     ``resnum`` / ``resname`` fields are in canonical sequence order for
     interpretability. ``pos_i`` / ``pos_j`` are the document position
     indices for ``seq_i`` / ``seq_j``. ``flipped`` records the coin flip:
-    when True the document writes ``<contact> <pos_j> <pos_i>`` (j first).
+    when True the document writes ``<contact> <pJ> <pI>`` (j first).
     """
 
     seq_i: int

--- a/marinfold/marinfold/document_structures/contacts_v1/vocab.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/vocab.py
@@ -11,23 +11,30 @@ stable for every checkpoint trained against the contacts-v1 vocab.
 Append-only — never reorder. (Reordering is a v2 event: new structure,
 new tokenizer, new experiment.)
 
-The vocab is the union of three groups, in this fixed order:
+contacts-v1 **reuses contacts-and-distances-v1 tokens wherever a token
+with the same meaning already exists**, so the two structures share token
+IDs / embeddings and a contacts-v1 model can later be fine-tuned on
+contacts-and-distances-v1 documents without a tokenizer change. Concretely
+a contacts-v1 document emits:
 
-1. contacts-v1's own control tokens, then the 2000 unpadded position
-   tokens ``<pos-0>`` .. ``<pos-1999>``, then ``<think>``.
-2. every token in the contacts-and-distances-v1
-   :func:`~marinfold.document_structures.contacts_and_distances_v1.vocab.all_domain_tokens`
-   list, deduplicated against group 1. Per SPEC.md these are carried as
-   *additional* tokens so a contacts-v1 model can later be fine-tuned on
-   contacts-and-distances-v1 documents without changing the tokenizer.
-   This group is also where contacts-v1 gets its amino-acid tokens
-   (uppercase ``<ALA>`` .. ``<VAL>``) and ``<UNK>`` from — contacts-v1
-   intentionally reuses them rather than minting a parallel set.
+- ``<contacts-v1>``, ``<n-term>``, ``<c-term>``, ``<contact>`` — minted
+  here (no contacts-and-distances-v1 analog), plus the unused ``<think>``.
+- ``<begin_sequence>`` / ``<begin_statements>`` — the section markers,
+  reused from contacts-and-distances-v1 (its underscore spelling).
+- ``<p0>`` .. ``<p1999>`` — residue position indices, reused from
+  contacts-and-distances-v1's ``<p0>`` .. ``<p2700>``.
+- ``<ALA>`` .. ``<VAL>`` (uppercase amino acids), ``<UNK>``, and ``<end>``
+  — reused from contacts-and-distances-v1.
 
-The only token shared between groups 1 and 2 is ``<end>``; dedup keeps
-the group-1 (lower-id) copy so the two structures share one ``<end>``.
+The vocab is therefore: the 5 native tokens, then the entire
+contacts-and-distances-v1 ``all_domain_tokens()`` list (which supplies
+every reused token plus the rest of its vocab, carried so the fine-tuning
+path keeps a single tokenizer). The two groups are disjoint.
 """
 
+from marinfold.document_structures.contacts_and_distances_v1.vocab import (
+    MAX_POSITION as _CD_V1_MAX_POSITION,
+)
 from marinfold.document_structures.contacts_and_distances_v1.vocab import (
     all_domain_tokens as _cd_v1_all_domain_tokens,
 )
@@ -36,48 +43,80 @@ from marinfold.document_structures.contacts_and_distances_v1.vocab import (
 NAME = "contacts-v1"
 CONTEXT_LENGTH = 8192
 
-# Residues are indexed into 2000 position tokens with wrap-around (see
-# generate.py). This caps the longest single chain we can serialize:
-# structures with more residues than indices can't be uniquely numbered
-# and are dropped at generation time.
+# Residues are indexed into NUM_POSITION_INDICES position tokens with
+# wrap-around (see generate.py). This caps the longest single chain we can
+# serialize: structures with more residues than indices can't be uniquely
+# numbered and are dropped at generation time.
 NUM_POSITION_INDICES = 2000
 
-# contacts-v1's own control tokens. ``<end>`` is shared with
-# contacts-and-distances-v1 (see module docstring).
-CONTROL_TOKENS = [
-    "<contacts-v1>",
-    "<begin-sequence>",
-    "<begin-structure>",
-    "<n-term>",
-    "<c-term>",
-    "<contact>",
-    "<end>",
+# --- Tokens contacts-v1 mints itself (no contacts-and-distances-v1 analog) ---
+DOC_TYPE_TOKEN = "<contacts-v1>"
+N_TERM_TOKEN = "<n-term>"
+C_TERM_TOKEN = "<c-term>"
+CONTACT_TOKEN = "<contact>"
+# Reasoning scratch token reserved by SPEC.md. Unused by the generator.
+THINK_TOKEN = "<think>"
+
+NATIVE_TOKENS = [
+    DOC_TYPE_TOKEN,
+    N_TERM_TOKEN,
+    C_TERM_TOKEN,
+    CONTACT_TOKEN,
+    THINK_TOKEN,
 ]
 
-# Unpadded position tokens <pos-0> .. <pos-1999>.
-POSITION_TOKENS = [f"<pos-{i}>" for i in range(NUM_POSITION_INDICES)]
+# --- Tokens reused from contacts-and-distances-v1 (emitted, not minted) ---
+BEGIN_SEQUENCE_TOKEN = "<begin_sequence>"      # start of the sequence section
+BEGIN_STRUCTURE_TOKEN = "<begin_statements>"   # start of the structure section
+END_TOKEN = "<end>"
 
-# Reasoning scratch token reserved by SPEC.md. Unused by the generator.
-THINK_TOKEN = ["<think>"]
+
+def position_token(index: int) -> str:
+    """Token for a residue position index — reused ``<pX>`` from c-and-d-v1."""
+    return f"<p{index}>"
+
+
+def _validate_reuse() -> None:
+    """Fail loudly if a reused token isn't actually in the c-and-d-v1 vocab.
+
+    Guards against the two vocabs drifting apart (e.g. a c-and-d-v1 rename
+    silently turning a "reused" token into a contacts-v1-only token).
+    """
+    if NUM_POSITION_INDICES > _CD_V1_MAX_POSITION + 1:
+        raise ValueError(
+            f"contacts-v1 needs <p0>..<p{NUM_POSITION_INDICES - 1}> but "
+            f"contacts-and-distances-v1 only defines up to "
+            f"<p{_CD_V1_MAX_POSITION}>"
+        )
+    cd_v1 = set(_cd_v1_all_domain_tokens())
+    reused = {BEGIN_SEQUENCE_TOKEN, BEGIN_STRUCTURE_TOKEN, END_TOKEN,
+              position_token(0), position_token(NUM_POSITION_INDICES - 1)}
+    missing = reused - cd_v1
+    if missing:
+        raise ValueError(
+            f"contacts-v1 reuses tokens absent from contacts-and-distances-v1: "
+            f"{sorted(missing)}"
+        )
+
+
+_validate_reuse()
 
 
 def contacts_v1_native_tokens() -> list[str]:
-    """The tokens contacts-v1 mints itself (control + positions + think).
-
-    Group 1 of the vocab. Amino-acid / ``<UNK>`` tokens are *not* here —
-    they come from the contacts-and-distances-v1 block (group 2).
-    """
-    return [*CONTROL_TOKENS, *POSITION_TOKENS, *THINK_TOKEN]
+    """The tokens contacts-v1 mints itself (no contacts-and-distances-v1 analog)."""
+    return list(NATIVE_TOKENS)
 
 
 def additional_tokens() -> list[str]:
-    """contacts-and-distances-v1 tokens carried as additional vocab (group 2).
+    """The full contacts-and-distances-v1 vocab, carried in this tokenizer.
 
-    Deduplicated against :func:`contacts_v1_native_tokens` (only ``<end>``
-    overlaps). Returned in contacts-and-distances-v1's canonical order with
-    the overlapping token removed.
+    Supplies every token contacts-v1 reuses (section markers, ``<p*>``,
+    amino acids, ``<UNK>``, ``<end>``) plus the rest of the
+    contacts-and-distances-v1 vocab (distance bins, atoms, …) so the
+    fine-tuning path keeps a single tokenizer. Disjoint from
+    :func:`contacts_v1_native_tokens`.
     """
-    native = set(contacts_v1_native_tokens())
+    native = set(NATIVE_TOKENS)
     return [t for t in _cd_v1_all_domain_tokens() if t not in native]
 
 
@@ -87,8 +126,7 @@ def all_domain_tokens() -> list[str]:
     ``build_tokenizer`` prepends the ``<pad>`` / ``<eos>`` specials (ids 0
     and 1); this function returns the domain tokens only, starting at id 2.
 
-    The group order (native control → positions → ``<think>`` → the
-    deduplicated contacts-and-distances-v1 block) and the within-group
-    order are both load-bearing.
+    The group order (the native tokens, then the contacts-and-distances-v1
+    block) and the within-group order are both load-bearing.
     """
     return [*contacts_v1_native_tokens(), *additional_tokens()]

--- a/marinfold/tests/document_structures/contacts_v1/test_cli.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_cli.py
@@ -8,6 +8,9 @@ from pathlib import Path
 import pytest
 
 from marinfold.document_structures.contacts_v1 import cli
+from marinfold.document_structures.contacts_v1.generate import build_document
+from marinfold.document_structures.contacts_v1.parse import RawContact, ResidueInfo
+from marinfold.document_structures.contacts_v1.vocab import position_token
 
 
 def test_generate_parses():
@@ -76,6 +79,33 @@ def test_view_parses_with_max_contacts():
 def test_view_default_max_contacts():
     args = cli.build_parser().parse_args(["view", "--input", "x"])
     assert args.max_contacts == 20
+
+
+def test_view_prints_reused_position_tokens(monkeypatch, capsys):
+    residues = [
+        ResidueInfo(seq_index=0, resname="ALA", resnum=1, chain="A"),
+        ResidueInfo(seq_index=1, resname="GLY", resnum=2, chain="A"),
+        ResidueInfo(seq_index=2, resname="SER", resnum=3, chain="A"),
+    ]
+    result = build_document("view-demo", residues, [RawContact(0, 2, 0.9)])
+    assert result is not None
+    monkeypatch.setattr(
+        cli.generate,
+        "generate_documents",
+        lambda **_: iter([result]),
+    )
+
+    args = cli.build_parser().parse_args(["view", "--input", "demo.cif", "--max-contacts", "5"])
+    args.func(args)
+
+    out = capsys.readouterr().out
+    assert f"n_term={position_token(result.n_term_index)}" in out
+    assert f"c_term={position_token(result.c_term_index)}" in out
+    assert (
+        f"{position_token(result.contacts[0].pos_i)}/"
+        f"{position_token(result.contacts[0].pos_j)}"
+    ) in out
+    assert "<pos-" not in out
 
 
 def test_tokenizer_parses():

--- a/marinfold/tests/document_structures/contacts_v1/test_generate.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_generate.py
@@ -39,14 +39,15 @@ def _residues(n: int, *, start_resnum: int = 1) -> list[ResidueInfo]:
 
 
 def _pos_indices(document: str) -> list[int]:
-    return [int(m) for m in re.findall(r"<pos-(\d+)>", document)]
+    # Positions are reused <pX> tokens from contacts-and-distances-v1.
+    return [int(m) for m in re.findall(r"<p(\d+)>", document)]
 
 
 def _sections(document: str) -> tuple[list[str], list[str]]:
     """Split into (sequence-section tokens, structure-section tokens)."""
     toks = document.split()
-    bs = toks.index("<begin-structure>")
-    seq = toks[toks.index("<begin-sequence>") + 1: bs]
+    bs = toks.index("<begin_statements>")
+    seq = toks[toks.index("<begin_sequence>") + 1: bs]
     struct = toks[bs + 1: toks.index("<end>")]
     return seq, struct
 
@@ -60,8 +61,8 @@ def test_document_framing():
     res = build_document("e", _residues(5), [RawContact(0, 2, 0.9)])
     toks = res.document.split()
     assert toks[0] == "<contacts-v1>"
-    assert toks[1] == "<begin-sequence>"
-    assert "<begin-structure>" in toks
+    assert toks[1] == "<begin_sequence>"     # reused from c-and-d-v1
+    assert "<begin_statements>" in toks      # reused from c-and-d-v1
     assert toks[-1] == "<end>"
 
 
@@ -71,7 +72,7 @@ def test_sequence_section_defines_each_residue_once_plus_two_termini():
     seq, _ = _sections(res.document)
     assert seq.count("<n-term>") == 1
     assert seq.count("<c-term>") == 1
-    # One <pos-X> <AA> statement per residue → exactly len residues AA tokens,
+    # One <pX> <AA> statement per residue → exactly len residues AA tokens,
     # and the residue position indices are the L distinct wrapped indices.
     n = vocab.NUM_POSITION_INDICES
     expected = {(res.start_index + k) % n for k in range(len(residues))}
@@ -189,14 +190,14 @@ def test_emitted_pair_order_matches_flip_flag():
     contacts = [RawContact(0, 5, 0.9), RawContact(1, 8, 0.6), RawContact(3, 11, 0.3)]
     res = build_document("flip", residues, contacts)
     _, struct = _sections(res.document)
-    # struct is groups of <contact> <pos-a> <pos-b>.
+    # struct is groups of <contact> <pA> <pB>.
     triples = [struct[i:i + 3] for i in range(0, len(struct), 3)]
     assert len(triples) == len(res.contacts)
     for (marker, a, b), c in zip(triples, res.contacts):
         assert marker == "<contact>"
         first, second = (c.pos_j, c.pos_i) if c.flipped else (c.pos_i, c.pos_j)
-        assert a == f"<pos-{first}>"
-        assert b == f"<pos-{second}>"
+        assert a == f"<p{first}>"
+        assert b == f"<p{second}>"
 
 
 # ---------------------------------------------------------------------------

--- a/marinfold/tests/document_structures/contacts_v1/test_vocab.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_vocab.py
@@ -4,7 +4,9 @@
 """Vocabulary + tokenizer tests for the contacts-v1 document structure.
 
 These are pure (no pyconfind, no network) — they exercise the token list
-and the shared ``build_tokenizer``.
+and the shared ``build_tokenizer``. contacts-v1 mints only 5 tokens and
+reuses everything else (positions, section markers, amino acids, ``<UNK>``,
+``<end>``) from the contacts-and-distances-v1 vocab.
 """
 
 from marinfold import build_tokenizer
@@ -12,84 +14,83 @@ from marinfold.document_structures.contacts_and_distances_v1.vocab import (
     all_domain_tokens as cd_v1_all_domain_tokens,
 )
 from marinfold.document_structures.contacts_v1.vocab import (
-    CONTROL_TOKENS,
+    BEGIN_SEQUENCE_TOKEN,
+    BEGIN_STRUCTURE_TOKEN,
+    END_TOKEN,
     NAME,
+    NATIVE_TOKENS,
     NUM_POSITION_INDICES,
-    POSITION_TOKENS,
     additional_tokens,
     all_domain_tokens,
     contacts_v1_native_tokens,
+    position_token,
 )
 
 
 def test_name_and_index_space():
     assert NAME == "contacts-v1"
     assert NUM_POSITION_INDICES == 2000
-    assert len(POSITION_TOKENS) == 2000
-    assert POSITION_TOKENS[0] == "<pos-0>"
-    assert POSITION_TOKENS[-1] == "<pos-1999>"
 
 
-def test_position_tokens_unpadded():
-    # SPEC example writes <pos-22>, not <pos-0022>.
-    assert "<pos-22>" in POSITION_TOKENS
-    assert "<pos-0022>" not in POSITION_TOKENS
+def test_native_tokens_are_the_five_unique_ones():
+    assert NATIVE_TOKENS == [
+        "<contacts-v1>", "<n-term>", "<c-term>", "<contact>", "<think>",
+    ]
+    assert contacts_v1_native_tokens() == NATIVE_TOKENS
+
+
+def test_reused_tokens_are_the_cd_v1_spellings():
+    # Section markers + positions are reused from contacts-and-distances-v1,
+    # NOT minted with contacts-v1's hyphen / <pos-N> spellings.
+    assert BEGIN_SEQUENCE_TOKEN == "<begin_sequence>"
+    assert BEGIN_STRUCTURE_TOKEN == "<begin_statements>"
+    assert END_TOKEN == "<end>"
+    assert position_token(0) == "<p0>"
+    assert position_token(1999) == "<p1999>"
+
+
+def test_no_minted_duplicates_of_reused_tokens():
+    tokens = set(all_domain_tokens())
+    # The old contacts-v1-only spellings must NOT exist anymore.
+    for dead in ("<pos-0>", "<pos-1999>", "<begin-sequence>", "<begin-structure>"):
+        assert dead not in tokens
+    # The reused spellings (from c-and-d-v1) are present exactly once.
+    doc = all_domain_tokens()
+    for reused in ("<begin_sequence>", "<begin_statements>", "<p0>", "<p1999>",
+                   "<ALA>", "<UNK>", "<end>"):
+        assert reused in tokens
+        assert doc.count(reused) == 1
+
+
+def test_native_and_additional_are_disjoint():
+    native = set(contacts_v1_native_tokens())
+    extra = set(additional_tokens())
+    assert native.isdisjoint(extra)
+    # additional is the full c-and-d-v1 vocab (nothing removed — no overlap).
+    assert additional_tokens() == cd_v1_all_domain_tokens()
 
 
 def test_token_order_invariants():
     tokens = all_domain_tokens()
-    # Group 1 leads: native control, then positions, then <think>.
+    # Native tokens lead, then the whole contacts-and-distances-v1 block.
+    assert tokens[:5] == NATIVE_TOKENS
     assert tokens[0] == "<contacts-v1>"
-    assert tokens[: len(CONTROL_TOKENS)] == CONTROL_TOKENS
-    assert tokens[len(CONTROL_TOKENS)] == "<pos-0>"
-    think_idx = len(CONTROL_TOKENS) + NUM_POSITION_INDICES
-    assert tokens[think_idx] == "<think>"
-    # Group 2 (the contacts-and-distances-v1 block) follows.
-    assert tokens[think_idx + 1] == "<contacts-and-distances-v1>"
+    assert tokens[5] == "<contacts-and-distances-v1>"
 
 
-def test_tokens_unique_and_end_is_shared():
+def test_tokens_unique():
     tokens = all_domain_tokens()
-    assert len(tokens) == len(set(tokens)), "domain tokens must be unique"
-    # <end> appears in both groups but is deduped to one shared id.
-    assert tokens.count("<end>") == 1
-
-
-def test_reused_amino_acid_and_unk_tokens_present():
-    tokens = set(all_domain_tokens())
-    # Uppercase AA tokens are reused from contacts-and-distances-v1.
-    for aa in ("<ALA>", "<MET>", "<PHE>", "<VAL>", "<GLY>"):
-        assert aa in tokens
-    assert "<UNK>" in tokens
-    assert "<think>" in tokens
-    # The lowercase form from the SPEC example is NOT used.
-    assert "<ala>" not in tokens
-
-
-def test_additional_tokens_are_cd_v1_minus_overlap():
-    extra = additional_tokens()
-    native = set(contacts_v1_native_tokens())
-    # additional_tokens excludes anything already native (only <end> overlaps).
-    assert not (set(extra) & native)
-    cd_v1 = cd_v1_all_domain_tokens()
-    assert set(extra) == set(cd_v1) - {"<end>"}
-    assert len(extra) == len(cd_v1) - 1
+    assert len(tokens) == len(set(tokens))
 
 
 def test_domain_token_count():
-    # 7 control + 2000 positions + 1 <think> + (2838 - 1 deduped <end>).
-    expected = (
-        len(CONTROL_TOKENS)
-        + NUM_POSITION_INDICES
-        + 1
-        + (len(cd_v1_all_domain_tokens()) - 1)
-    )
-    assert len(all_domain_tokens()) == expected == 4845
+    # 5 native + the full 2838-token contacts-and-distances-v1 vocab.
+    assert len(all_domain_tokens()) == 5 + len(cd_v1_all_domain_tokens()) == 2843
 
 
 def test_build_tokenizer_size_and_specials():
     tok = build_tokenizer(all_domain_tokens())
-    assert len(tok) == 4847  # 4845 domain + <pad> + <eos>
+    assert len(tok) == 2845  # 2843 domain + <pad> + <eos>
     assert tok.convert_tokens_to_ids("<pad>") == 0
     assert tok.convert_tokens_to_ids("<eos>") == 1
     assert tok.convert_tokens_to_ids("<contacts-v1>") == 2
@@ -98,17 +99,27 @@ def test_build_tokenizer_size_and_specials():
 def test_build_tokenizer_roundtrip_sample():
     tok = build_tokenizer(all_domain_tokens())
     sample = (
-        "<contacts-v1> <begin-sequence> "
-        "<pos-22> <PHE> <n-term> <pos-20> <pos-21> <ALA> "
-        "<c-term> <pos-22> <pos-20> <ALA> "
-        "<begin-structure> "
-        "<contact> <pos-20> <pos-21> <contact> <pos-22> <pos-21> "
+        "<contacts-v1> <begin_sequence> "
+        "<p22> <PHE> <n-term> <p20> <p21> <ALA> "
+        "<c-term> <p22> <p20> <ALA> "
+        "<begin_statements> "
+        "<contact> <p20> <p21> <contact> <p22> <p21> "
         "<end>"
     )
     ids = tok.encode(sample, add_special_tokens=False)
     assert len(ids) == len(sample.split())
     unk_id = tok.convert_tokens_to_ids("<UNK>")
     assert unk_id not in ids
+
+
+def test_position_tokens_shared_with_cd_v1():
+    # A contacts-v1 position token and the same c-and-d-v1 token map to one id.
+    tok = build_tokenizer(all_domain_tokens())
+    assert tok.convert_tokens_to_ids("<p22>") == tok.convert_tokens_to_ids(
+        position_token(22)
+    )
+    # <p2000>..<p2700> exist (from c-and-d-v1) but are unused by contacts-v1.
+    assert tok.convert_tokens_to_ids("<p2700>") != tok.unk_token_id
 
 
 def test_unk_token_decodes():


### PR DESCRIPTION
Follow-up to #47 (Refs #46): maximize token reuse between `contacts-v1`
and `contacts-and-distances-v1`.

Per discussion, `contacts-v1` now **reuses contacts-and-distances-v1
tokens wherever an equivalent already exists**, instead of minting
parallel ones:

| was (minted) | now (reused from c-and-d-v1) |
|---|---|
| `<pos-0>` … `<pos-1999>` | `<p0>` … `<p1999>` |
| `<begin-sequence>` | `<begin_sequence>` |
| `<begin-structure>` | `<begin_statements>` |
| (amino acids, `<UNK>`, `<end>` already reused) | unchanged |

The only tokens `contacts-v1` mints itself are now the **5** with no
contacts-and-distances-v1 analog: `<contacts-v1>`, `<n-term>`, `<c-term>`,
`<contact>`, `<think>`.

### Why

A `contacts-v1` model now shares position / section-marker / amino-acid
embeddings with `contacts-and-distances-v1`, so fine-tuning a contacts-v1
model on contacts-and-distances-v1 documents transfers those
representations directly (the stated reason for carrying the c-and-d-v1
vocab in the first place). The domain vocab also shrinks **4845 → 2843**.

One semantic caveat, documented in SPEC.md: a contacts-v1 `<pX>` is a
*randomized wrap-around* index while in contacts-and-distances-v1 the same
`<pX>` is a *true chain position* — the leading doc-type token
disambiguates.

### Changes

- `vocab.py`: native tokens are just the 5 unique ones; `<begin_sequence>`,
  `<begin_statements>`, `<p0>`–`<p1999>` reused via constants /
  `position_token()`. Imports validate at load that every reused token
  exists in the c-and-d-v1 vocab (guards against drift).
- `generate.py`: emit the reused tokens.
- `SPEC.md`: example, Details, and the "Implementation notes &
  discrepancies" section updated; README example updated.
- Tests: `test_vocab.py` rewritten for the new structure (incl. shared-id
  and no-minted-duplicate checks); `test_generate.py` helpers/assertions.

### Verification

Full marinfold suite green (143 passed, 2 skipped, 5 network-deselected);
contacts-v1 pyconfind integration tests pass. Example 1QYS document now
starts `<contacts-v1> <begin_sequence> <p1153> <LEU> …`.

Nothing was published from the previous vocab (no tokenizer pushed, no
dataset, no trained model), so this is a safe pre-training change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
