### PR TITLE
contacts-v1: afdb-24M parquet input + package README

### DIFF
--- a/marinfold/marinfold/document_structures/contacts_v1/README.md
+++ b/marinfold/marinfold/document_structures/contacts_v1/README.md
@@ -1,0 +1,154 @@
+# contacts-v1
+
+A protein-document format: each single-chain protein is serialized as a
+**sequence section** (the residues) followed by a **structure section**
+(side-chain *contacts* scored by [pyconfind](https://github.com/timodonnell/pyconfind)).
+The full format spec plus the as-built "Implementation notes &
+discrepancies" live in [`SPEC.md`](SPEC.md).
+
+## Document structure
+
+A document is a single space-separated token string:
+
+```
+<contacts-v1> <begin_sequence>
+    [ <pN> <AA> | <n-term> <pN> | <c-term> <pN> ]   # one per residue + the two termini, shuffled
+<begin_statements>
+    [ <contact> <pX> <pY> ]                          # strongest contacts, random order
+<end>
+```
+
+- **Sequence section** — one `<pN> <AA>` statement per residue, plus one
+  `<n-term>` and one `<c-term>` marker, all in random order. Residues are
+  numbered from a random n-terminal index that wraps around 2000 position
+  indices (so the model sees the whole index range, not just low values).
+- **Structure section** — pyconfind side-chain contacts with contact
+  degree ≥ `min_contact_degree` (default 0.001). We take the strongest N
+  that fill the 8192-token budget and list them in random order; each
+  `<contact>` pair's order is coin-flipped.
+- **Token reuse** — positions (`<pN>`), section markers (`<begin_sequence>`
+  / `<begin_statements>`), amino acids (`<ALA>`…), `<UNK>` and `<end>` are
+  reused from `contacts-and-distances-v1`; only `<contacts-v1>`, `<n-term>`,
+  `<c-term>`, `<contact>` and `<think>` are minted here. See [`SPEC.md`](SPEC.md).
+- **Deterministic** per `entry_id` (the RNG seed), so the same structure +
+  id always yields the same document.
+
+Eyeball a real one (prints the document + a contact table):
+
+```bash
+cd marinfold
+uv sync --extra contacts-v1
+uv run contacts-v1 view --input tests/data/1QYS.cif
+```
+
+## Output + metadata
+
+`generate` writes one row per protein — the `document` token string plus
+metadata columns mirroring the published `protein-docs` datasets:
+
+| column | meaning |
+|---|---|
+| `entry_id` | structure id (and generation seed) |
+| `seq_len` | residue count |
+| `global_plddt` | mean CA B-factor (pLDDT for AFDB inputs) |
+| `start_index`, `n_term_index`, `c_term_index` | residue-numbering offsets |
+| `contacts_pre_filter` | all contacts with degree > 0 |
+| `contacts_passing_min_degree` | how many passed the min-degree filter |
+| `contacts_emitted` / `contacts_excluded` | included / not included |
+| `truncated` | whether a budget overflow dropped an eligible contact |
+| `highest_contact_degree`, `lowest_nonzero_contact_degree`, `lowest_included_contact_degree` | degree stats |
+| `num_tokens`, `sha1` | document length + checksum |
+
+`--summary-out FILE.json` additionally writes a rich per-protein summary
+(full residue sequence + every emitted contact with its degree).
+
+## Generate documents
+
+### From local structure files
+
+```bash
+uv run contacts-v1 generate \
+    --input /path/to/structures/ \           # a .pdb/.cif(.gz) file or a directory of them
+    --out docs.parquet \                     # one row per structure (.jsonl works too)
+    --summary-out summary.json
+```
+
+### From afdb-24M (~1000 documents)
+
+[`afdb-24M`](https://huggingface.co/datasets/timodonnell/afdb-24M) is
+sharded Parquet (2,000 structures/shard) with the raw mmCIF in a
+`cif_content` column — point `--input` straight at a shard:
+
+```bash
+# one shard ≈ 2,000 AFDB structures, ~100 MB
+hf download timodonnell/afdb-24M \
+    shard_000000-009999/shard_000000.parquet \
+    --repo-type dataset --local-dir afdb
+
+uv run contacts-v1 generate \
+    --input afdb/shard_000000-009999/shard_000000.parquet \
+    --num-docs 1000 \
+    --out contacts_v1_docs.parquet \
+    --summary-out contacts_v1_summary.json
+```
+
+Roughly <1 s per structure (a few minutes for 1,000); installing
+`pyconfind[fast]` (numba) speeds up the contact backend. The `entry_id`
+column is used as each document's seed, so a document is reproducible from
+its AFDB id. Inspect the result:
+
+```bash
+python -c "import pyarrow.parquet as pq; t=pq.read_table('contacts_v1_docs.parquet'); \
+print(t.num_rows, 'docs'); print(t.column_names)"
+```
+
+Sample stats (illustrative — first few of shard 0):
+
+```
+entry_id           len  plddt  contacts(emit/found)  truncated  tokens
+AF-E9I562-F1       156   87.5         159/238          False      797
+AF-A0A2N8S3N2-F1   616   89.4         939/1299         False     4057
+AF-A0A7G8TSG9-F1    49   77.3          67/83           False      307
+```
+
+Use `--num-docs` to cap output; a whole shard's 2,000 structures works
+too (just drop `--num-docs`). For a custom schema use `--cif-column` /
+`--id-column`.
+
+## Build the tokenizer
+
+```bash
+uv run contacts-v1 tokenizer --save-local ./contacts-v1-tokenizer
+# or: uv run contacts-v1 tokenizer --push open-athena/contacts-v1-tokenizer
+```
+
+The tokenizer subcommand needs no extra (pyconfind is only used by
+`generate` / `view`).
+
+## Algorithm knobs
+
+`--min-contact-degree` (0.001), `--context-length` (8192), `--assembly`
+(`none` = asymmetric unit as-is), and the pyconfind geometry knobs
+`--contact-distance` / `--dcut` / `--clash-distance`. See
+`contacts-v1 generate --help` for the full set.
+
+## Library interface
+
+For the future zephyr data job (or any script), import the package:
+
+```python
+from marinfold.document_structures.contacts_v1 import (
+    generate_documents,   # over a file / dir / parquet shard(s) -> Iterator[GenerationResult]
+    generate_document,    # one structure (path or gemmi.Structure) -> GenerationResult | None
+    build_document,       # pure builder from (entry_id, residues, contacts)
+    GenerationConfig,
+)
+
+for result in generate_documents("afdb/shard_000000.parquet", num_docs=1000):
+    row = result.metadata_row()        # flat dict: document + metadata columns
+    # ... write row to your sink
+```
+
+`generate_document` accepts a `gemmi.Structure` directly (no temp files),
+and you can pass a pre-loaded `rotamer_library` (from
+`pyconfind.load_library`) to skip re-parsing it across calls.

--- a/marinfold/marinfold/document_structures/contacts_v1/README.md
+++ b/marinfold/marinfold/document_structures/contacts_v1/README.md
@@ -67,9 +67,10 @@ metadata columns mirroring the published `protein-docs` datasets:
 ### From local structure files
 
 ```bash
+# a .pdb/.cif(.gz) file or a directory of them; .jsonl works too
 uv run contacts-v1 generate \
-    --input /path/to/structures/ \           # a .pdb/.cif(.gz) file or a directory of them
-    --out docs.parquet \                     # one row per structure (.jsonl works too)
+    --input /path/to/structures/ \
+    --out docs.parquet \
     --summary-out summary.json
 ```
 

--- a/marinfold/marinfold/document_structures/contacts_v1/__init__.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/__init__.py
@@ -34,16 +34,21 @@ from .generate import (
     generate_documents,
 )
 from .parse import (
+    DEFAULT_CIF_COLUMN,
+    DEFAULT_ID_COLUMN,
     AnalyzedStructure,
     RawContact,
     ResidueInfo,
     analyze_structure,
     iter_analyzed_structures,
+    iter_parquet_analyzed_structures,
 )
 from .vocab import CONTEXT_LENGTH, NAME, NUM_POSITION_INDICES, all_domain_tokens
 
 __all__ = [
     "CONTEXT_LENGTH",
+    "DEFAULT_CIF_COLUMN",
+    "DEFAULT_ID_COLUMN",
     "NAME",
     "NUM_POSITION_INDICES",
     "AnalyzedStructure",
@@ -58,4 +63,5 @@ __all__ = [
     "generate_document",
     "generate_documents",
     "iter_analyzed_structures",
+    "iter_parquet_analyzed_structures",
 ]

--- a/marinfold/marinfold/document_structures/contacts_v1/cli.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/cli.py
@@ -31,6 +31,7 @@ from typing import Any
 from marinfold import build_tokenizer, write_docs
 
 from . import generate
+from .parse import DEFAULT_CIF_COLUMN, DEFAULT_ID_COLUMN
 from .vocab import CONTEXT_LENGTH, NAME, all_domain_tokens, position_token
 
 
@@ -100,6 +101,8 @@ def cmd_generate(args: argparse.Namespace) -> None:
         context_length=args.context_length,
         config=config,
         rotamer_library=args.rotamer_library,
+        cif_column=args.cif_column,
+        id_column=args.id_column,
     ))
     write_docs(
         args.out,
@@ -124,6 +127,8 @@ def cmd_view(args: argparse.Namespace) -> None:
         context_length=args.context_length,
         config=config,
         rotamer_library=args.rotamer_library,
+        cif_column=args.cif_column,
+        id_column=args.id_column,
     ):
         shown += 1
         print(f"\n=== {result.entry_id} ===")
@@ -199,7 +204,15 @@ def _add_generation_common(p: argparse.ArgumentParser) -> None:
     """Args shared by ``generate`` and ``view``."""
     cfg = generate.GenerationConfig()
     p.add_argument("--input", type=Path, required=True,
-                   help="PDB / mmCIF (.gz) file or directory of them.")
+                   help="PDB / mmCIF (.gz) file or directory of them, OR a "
+                        ".parquet shard / directory of shards in the afdb-24M "
+                        "layout (structures read from --cif-column).")
+    p.add_argument("--cif-column", default=DEFAULT_CIF_COLUMN,
+                   help="For parquet input: column holding the mmCIF text "
+                        f"(default {DEFAULT_CIF_COLUMN!r}).")
+    p.add_argument("--id-column", default=DEFAULT_ID_COLUMN,
+                   help="For parquet input: column holding the entry id / "
+                        f"generation seed (default {DEFAULT_ID_COLUMN!r}).")
     p.add_argument("--num-docs", type=int, default=None,
                    help="Cap on documents produced (default: one per input).")
     p.add_argument("--context-length", type=int, default=CONTEXT_LENGTH,

--- a/marinfold/marinfold/document_structures/contacts_v1/generate.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/generate.py
@@ -38,6 +38,8 @@ from pathlib import Path
 from typing import Any
 
 from .parse import (
+    DEFAULT_CIF_COLUMN,
+    DEFAULT_ID_COLUMN,
     AnalyzedStructure,
     RawContact,
     ResidueInfo,
@@ -399,17 +401,23 @@ def generate_documents(
     context_length: int = CONTEXT_LENGTH,
     config: GenerationConfig = GenerationConfig(),
     rotamer_library=None,
+    cif_column: str = DEFAULT_CIF_COLUMN,
+    id_column: str | None = DEFAULT_ID_COLUMN,
 ) -> Iterator[GenerationResult]:
     """Yield one :class:`GenerationResult` per input structure (up to ``num_docs``).
 
     The driving entry point — ``cli.py`` parses args and calls this with
-    the assembled :class:`GenerationConfig`. Structures that fail to parse,
-    are multi-chain, or fall outside the serializable residue range are
-    skipped with a warning.
+    the assembled :class:`GenerationConfig`. ``input_path`` may be a
+    structure file / directory, or a ``.parquet`` shard / directory of
+    shards in the afdb-24M layout (structures read from ``cif_column``, ids
+    from ``id_column``). Structures that fail to parse, are multi-chain, or
+    fall outside the serializable residue range are skipped with a warning.
     """
     produced = 0
     for analyzed in iter_analyzed_structures(
         Path(input_path),
+        cif_column=cif_column,
+        id_column=id_column,
         native_only=config.native_only,
         contact_distance=config.contact_distance,
         dcut=config.dcut,

--- a/marinfold/marinfold/document_structures/contacts_v1/parse.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/parse.py
@@ -37,6 +37,11 @@ _STRUCTURE_EXTS = (
     ".pdb", ".pdb.gz", ".ent", ".ent.gz",
 )
 
+# Default parquet columns for the afdb-24M layout: each row carries the raw
+# mmCIF text in ``cif_content`` and the AFDB id in ``entry_id``.
+DEFAULT_CIF_COLUMN = "cif_content"
+DEFAULT_ID_COLUMN = "entry_id"
+
 # Map every residue name pyconfind treats as protein (its
 # LEGAL_RESIDUE_NAMES: the standard 20 plus HIS variants, MSE, and a few
 # modified residues) to a canonical-20 three-letter token. Modified
@@ -235,9 +240,100 @@ def iter_structure_paths(path: Path) -> Iterator[Path]:
             yield p
 
 
+def _gemmi_structure_from_cif_text(cif_text: str, *, name: str | None = None):
+    """Parse mmCIF text (e.g. an afdb-24M ``cif_content`` cell) to a structure."""
+    import gemmi
+
+    structure = gemmi.read_structure_string(cif_text)
+    if name and not structure.name:
+        structure.name = name
+    return structure
+
+
+def _parquet_paths(path: Path) -> list[Path]:
+    """Return the ``.parquet`` shard(s) at/under ``path`` (empty if none)."""
+    if path.is_file():
+        return [path] if path.suffix.lower() == ".parquet" else []
+    if path.is_dir():
+        return sorted(path.rglob("*.parquet"))
+    return []
+
+
+def iter_parquet_analyzed_structures(
+    parquet_path: Path,
+    *,
+    cif_column: str = DEFAULT_CIF_COLUMN,
+    id_column: str | None = DEFAULT_ID_COLUMN,
+    native_only: bool = True,
+    contact_distance: float = 3.0,
+    dcut: float = 25.0,
+    clash_distance: float = 2.0,
+    assembly: int | str | None = None,
+    rotamer_library=None,
+    batch_size: int = 64,
+) -> Iterator[AnalyzedStructure]:
+    """Analyze structures from a parquet shard's ``cif_column`` (afdb-24M layout).
+
+    Row batches are streamed (so a ``num_docs`` cap downstream stops early
+    and cheaply), and ``id_column`` supplies each structure's ``entry_id``
+    (the deterministic generation seed). When ``id_column`` is missing /
+    empty a synthetic ``<stem>:row<N>`` id is used. Rows that fail to parse
+    or analyze are skipped with a warning.
+
+    Raises:
+        ValueError: ``cif_column`` is not present in the parquet schema.
+    """
+    import pyarrow.parquet as pq
+
+    parquet_path = Path(parquet_path)
+    parquet_file = pq.ParquetFile(parquet_path)
+    schema_names = set(parquet_file.schema_arrow.names)
+    if cif_column not in schema_names:
+        raise ValueError(
+            f"{parquet_path}: no column {cif_column!r} "
+            f"(available: {sorted(schema_names)})"
+        )
+    use_id = bool(id_column) and id_column in schema_names
+    columns = [cif_column] + ([id_column] if use_id else [])
+
+    row_offset = 0
+    for batch in parquet_file.iter_batches(batch_size=batch_size, columns=columns):
+        cif_arr = batch.column(cif_column)
+        id_arr = batch.column(id_column) if use_id else None
+        for i in range(batch.num_rows):
+            entry_id = (
+                id_arr[i].as_py() if id_arr is not None
+                else f"{parquet_path.stem}:row{row_offset + i}"
+            )
+            cif_text = cif_arr[i].as_py()
+            if not cif_text:
+                warnings.warn(
+                    f"skipping {entry_id}: empty {cif_column!r}", stacklevel=2
+                )
+                continue
+            try:
+                structure = _gemmi_structure_from_cif_text(cif_text, name=str(entry_id))
+                yield analyze_structure(
+                    structure,
+                    entry_id=str(entry_id),
+                    native_only=native_only,
+                    contact_distance=contact_distance,
+                    dcut=dcut,
+                    clash_distance=clash_distance,
+                    assembly=assembly,
+                    rotamer_library=rotamer_library,
+                )
+            except (ValueError, RuntimeError) as exc:
+                warnings.warn(f"skipping {entry_id}: {exc}", stacklevel=2)
+                continue
+        row_offset += batch.num_rows
+
+
 def iter_analyzed_structures(
     path: Path,
     *,
+    cif_column: str = DEFAULT_CIF_COLUMN,
+    id_column: str | None = DEFAULT_ID_COLUMN,
     native_only: bool = True,
     contact_distance: float = 3.0,
     dcut: float = 25.0,
@@ -245,12 +341,32 @@ def iter_analyzed_structures(
     assembly: int | str | None = None,
     rotamer_library=None,
 ) -> Iterator[AnalyzedStructure]:
-    """Analyze every structure file under ``path``.
+    """Analyze every structure under ``path``.
 
-    Files that fail to parse / analyze (including multi-chain inputs) are
-    skipped with a warning rather than aborting the whole run.
+    ``path`` may be a structure file / a directory of them, **or** a
+    ``.parquet`` shard / directory of shards in the afdb-24M layout — in
+    which case structures are read from the ``cif_column`` mmCIF text and
+    ids from ``id_column``. (If a directory holds parquet shards they take
+    precedence over loose structure files.) Inputs that fail to parse or
+    analyze — including multi-chain ones — are skipped with a warning.
     """
-    for p in iter_structure_paths(Path(path)):
+    path = Path(path)
+    parquet_paths = _parquet_paths(path)
+    if parquet_paths:
+        for parquet_path in parquet_paths:
+            yield from iter_parquet_analyzed_structures(
+                parquet_path,
+                cif_column=cif_column,
+                id_column=id_column,
+                native_only=native_only,
+                contact_distance=contact_distance,
+                dcut=dcut,
+                clash_distance=clash_distance,
+                assembly=assembly,
+                rotamer_library=rotamer_library,
+            )
+        return
+    for p in iter_structure_paths(path):
         try:
             yield analyze_structure(
                 p,

--- a/marinfold/marinfold/document_structures/contacts_v1/parse.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/parse.py
@@ -301,9 +301,13 @@ def iter_parquet_analyzed_structures(
         cif_arr = batch.column(cif_column)
         id_arr = batch.column(id_column) if use_id else None
         for i in range(batch.num_rows):
+            synthetic_entry_id = f"{parquet_path.stem}:row{row_offset + i}"
+            raw_entry_id = id_arr[i].as_py() if id_arr is not None else None
             entry_id = (
-                id_arr[i].as_py() if id_arr is not None
-                else f"{parquet_path.stem}:row{row_offset + i}"
+                synthetic_entry_id
+                if raw_entry_id is None
+                or (isinstance(raw_entry_id, str) and not raw_entry_id.strip())
+                else raw_entry_id
             )
             cif_text = cif_arr[i].as_py()
             if not cif_text:

--- a/marinfold/tests/document_structures/contacts_v1/test_cli.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_cli.py
@@ -42,6 +42,23 @@ def test_min_contact_degree_override():
     assert cfg.min_contact_degree == 0.05
 
 
+def test_parquet_column_defaults():
+    args = cli.build_parser().parse_args([
+        "generate", "--input", "shard.parquet", "--out", "docs.parquet",
+    ])
+    assert args.cif_column == "cif_content"
+    assert args.id_column == "entry_id"
+
+
+def test_parquet_column_overrides():
+    args = cli.build_parser().parse_args([
+        "generate", "--input", "shard.parquet", "--out", "docs.parquet",
+        "--cif-column", "mmcif", "--id-column", "id",
+    ])
+    assert args.cif_column == "mmcif"
+    assert args.id_column == "id"
+
+
 @pytest.mark.parametrize(("raw", "expected"), [
     ("none", None),
     ("2", 2),

--- a/marinfold/tests/document_structures/contacts_v1/test_parquet.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_parquet.py
@@ -1,0 +1,136 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for parquet (afdb-24M ``cif_content``) input to contacts-v1.
+
+``_parquet_paths`` is pure; ``_gemmi_structure_from_cif_text`` needs gemmi
+(a base dep); the end-to-end parquet generation needs pyconfind + the
+rotamer library (``network`` marker).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from marinfold.document_structures.contacts_v1.parse import _parquet_paths
+
+_1QYS = Path(__file__).parents[2] / "data" / "1QYS.cif"
+
+
+# ---------------------------------------------------------------------------
+# _parquet_paths (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_paths_single_file(tmp_path: Path):
+    p = tmp_path / "shard.parquet"
+    p.write_bytes(b"")
+    assert _parquet_paths(p) == [p]
+
+
+def test_parquet_paths_non_parquet_file(tmp_path: Path):
+    p = tmp_path / "x.cif"
+    p.write_text("")
+    assert _parquet_paths(p) == []
+
+
+def test_parquet_paths_directory_globs_sorted_recursive(tmp_path: Path):
+    (tmp_path / "b.parquet").write_bytes(b"")
+    (tmp_path / "a.parquet").write_bytes(b"")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "c.parquet").write_bytes(b"")
+    (tmp_path / "notes.cif").write_text("")  # ignored
+    assert [p.name for p in _parquet_paths(tmp_path)] == ["a.parquet", "b.parquet", "c.parquet"]
+
+
+def test_parquet_paths_dir_without_parquet_is_empty(tmp_path: Path):
+    (tmp_path / "a.cif").write_text("")
+    assert _parquet_paths(tmp_path) == []
+
+
+def test_parquet_paths_missing_is_empty(tmp_path: Path):
+    assert _parquet_paths(tmp_path / "nope") == []
+
+
+# ---------------------------------------------------------------------------
+# gemmi string parsing (gemmi is a base dep)
+# ---------------------------------------------------------------------------
+
+
+def test_gemmi_structure_from_cif_text():
+    pytest.importorskip("gemmi")
+    from marinfold.document_structures.contacts_v1.parse import (
+        _gemmi_structure_from_cif_text,
+    )
+
+    structure = _gemmi_structure_from_cif_text(_1QYS.read_text(), name="fallback")
+    assert len(structure) >= 1
+    assert sum(1 for chain in structure[0] for _ in chain) > 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end parquet generation (pyconfind + rotamer library)
+# ---------------------------------------------------------------------------
+
+
+def _write_parquet(path: Path, table_dict: dict) -> Path:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    pq.write_table(pa.table(table_dict), str(path))
+    return path
+
+
+@pytest.mark.network
+def test_generate_documents_from_parquet_uses_id_column(tmp_path: Path):
+    pytest.importorskip("pyconfind")
+    from marinfold.document_structures.contacts_v1 import generate_documents
+
+    cif = _1QYS.read_text()
+    shard = _write_parquet(
+        tmp_path / "shard.parquet",
+        {"entry_id": ["AF-A", "AF-B"], "cif_content": [cif, cif]},
+    )
+    docs = list(generate_documents(input_path=shard, num_docs=5))
+    assert [d.entry_id for d in docs] == ["AF-A", "AF-B"]
+    assert all(d.seq_len == 92 for d in docs)
+    # Same structure, different entry id → different (deterministic) document.
+    assert docs[0].document != docs[1].document
+
+
+@pytest.mark.network
+def test_generate_documents_from_parquet_num_docs_cap(tmp_path: Path):
+    pytest.importorskip("pyconfind")
+    from marinfold.document_structures.contacts_v1 import generate_documents
+
+    cif = _1QYS.read_text()
+    shard = _write_parquet(
+        tmp_path / "shard.parquet",
+        {"entry_id": [f"AF-{i}" for i in range(4)], "cif_content": [cif] * 4},
+    )
+    docs = list(generate_documents(input_path=shard, num_docs=2))
+    assert len(docs) == 2  # early-stop honored across streamed batches
+
+
+@pytest.mark.network
+def test_generate_documents_from_parquet_synthetic_id(tmp_path: Path):
+    pytest.importorskip("pyconfind")
+    from marinfold.document_structures.contacts_v1 import generate_documents
+
+    shard = _write_parquet(
+        tmp_path / "noid.parquet", {"cif_content": [_1QYS.read_text()]}
+    )
+    docs = list(generate_documents(input_path=shard))
+    assert len(docs) == 1
+    assert docs[0].entry_id.startswith("noid:row")
+
+
+def test_generate_documents_from_parquet_missing_cif_column(tmp_path: Path):
+    """Wrong --cif-column errors loudly (no pyconfind needed to hit this)."""
+    from marinfold.document_structures.contacts_v1.parse import (
+        iter_parquet_analyzed_structures,
+    )
+
+    shard = _write_parquet(tmp_path / "s.parquet", {"foo": ["x"]})
+    with pytest.raises(ValueError, match="no column 'cif_content'"):
+        list(iter_parquet_analyzed_structures(shard))

--- a/marinfold/tests/document_structures/contacts_v1/test_parquet.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_parquet.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from marinfold.document_structures.contacts_v1 import parse as parse_module
 from marinfold.document_structures.contacts_v1.parse import _parquet_paths
 
 _1QYS = Path(__file__).parents[2] / "data" / "1QYS.cif"
@@ -59,17 +60,15 @@ def test_parquet_paths_missing_is_empty(tmp_path: Path):
 
 def test_gemmi_structure_from_cif_text():
     pytest.importorskip("gemmi")
-    from marinfold.document_structures.contacts_v1.parse import (
-        _gemmi_structure_from_cif_text,
+    structure = parse_module._gemmi_structure_from_cif_text(
+        _1QYS.read_text(), name="fallback"
     )
-
-    structure = _gemmi_structure_from_cif_text(_1QYS.read_text(), name="fallback")
     assert len(structure) >= 1
     assert sum(1 for chain in structure[0] for _ in chain) > 0
 
 
 # ---------------------------------------------------------------------------
-# End-to-end parquet generation (pyconfind + rotamer library)
+# Parquet row handling
 # ---------------------------------------------------------------------------
 
 
@@ -79,6 +78,39 @@ def _write_parquet(path: Path, table_dict: dict) -> Path:
 
     pq.write_table(pa.table(table_dict), str(path))
     return path
+
+
+def test_iter_parquet_analyzed_structures_falls_back_for_empty_or_null_id(
+    monkeypatch, tmp_path: Path
+):
+    seen_entry_ids: list[str] = []
+
+    def fake_parse(_cif_text: str, *, name: str | None = None):
+        return object()
+
+    def fake_analyze(_structure, **kwargs):
+        seen_entry_ids.append(kwargs["entry_id"])
+        return kwargs["entry_id"]
+
+    monkeypatch.setattr(parse_module, "_gemmi_structure_from_cif_text", fake_parse)
+    monkeypatch.setattr(parse_module, "analyze_structure", fake_analyze)
+
+    shard = _write_parquet(
+        tmp_path / "rows.parquet",
+        {
+            "entry_id": ["", None, "AF-REAL"],
+            "cif_content": ["cif-a", "cif-b", "cif-c"],
+        },
+    )
+    rows = list(parse_module.iter_parquet_analyzed_structures(shard))
+
+    assert rows == ["rows:row0", "rows:row1", "AF-REAL"]
+    assert seen_entry_ids == rows
+
+
+# ---------------------------------------------------------------------------
+# End-to-end parquet generation (pyconfind + rotamer library)
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.network
@@ -127,10 +159,6 @@ def test_generate_documents_from_parquet_synthetic_id(tmp_path: Path):
 
 def test_generate_documents_from_parquet_missing_cif_column(tmp_path: Path):
     """Wrong --cif-column errors loudly (no pyconfind needed to hit this)."""
-    from marinfold.document_structures.contacts_v1.parse import (
-        iter_parquet_analyzed_structures,
-    )
-
     shard = _write_parquet(tmp_path / "s.parquet", {"foo": ["x"]})
     with pytest.raises(ValueError, match="no column 'cif_content'"):
-        list(iter_parquet_analyzed_structures(shard))
+        list(parse_module.iter_parquet_analyzed_structures(shard))


### PR DESCRIPTION
Adds the package README and the afdb-24M parquet input path so you can
generate ~1000 contacts-v1 documents locally in one command (Refs #46).

## README

New `marinfold/marinfold/document_structures/contacts_v1/README.md`:
document structure, the metadata columns, example commands (view, local
structure files, afdb-24M, tokenizer), algorithm knobs, and the library
interface for the future zephyr data job. (Full format spec stays in
`SPEC.md`.)

## Parquet input (afdb-24M)

afdb-24M is sharded Parquet with the raw mmCIF in a `cif_content` column,
so `generate` (which read structure *files*) couldn't point at it
directly. Now `--input` also accepts a `.parquet` shard (or a directory of
shards):

```bash
hf download timodonnell/afdb-24M \
    shard_000000-009999/shard_000000.parquet \
    --repo-type dataset --local-dir afdb

uv run contacts-v1 generate \
    --input afdb/shard_000000-009999/shard_000000.parquet \
    --num-docs 1000 \
    --out contacts_v1_docs.parquet \
    --summary-out contacts_v1_summary.json
```

- `parse.iter_parquet_analyzed_structures` streams row batches (so the
  `--num-docs` cap stops early and cheaply), parses `cif_content` via
  `gemmi.read_structure_string`, and uses the `entry_id` column as each
  document's deterministic seed (synthetic `<stem>:row<N>` if absent).
- `iter_analyzed_structures` dispatches: `.parquet` file / dir-of-shards →
  parquet mode; otherwise structure files. `--cif-column` / `--id-column`
  override the afdb-24M defaults (`cif_content` / `entry_id`).
- `generate_document` already accepted a `gemmi.Structure`, so the zephyr
  path can also feed rows in-memory without temp files.

No new dependency (pyarrow is already a base dep).

## Verified on real data

Downloaded shard 0 (2,000 structures, ~100 MB) and ran the command:
**8 documents in ~7 s** — real AFDB ids / pLDDT, sizes 49–616 residues,
sensible contact counts and token budgets (e.g. a 616-residue protein →
939 contacts, 4,057 tokens). `view` works straight on the shard too.

## Tests

90 contacts-v1 tests (13 new): `_parquet_paths` dispatch, gemmi string
parsing, and pyconfind-backed parquet generation (id-column seeding,
`num_docs` early-stop, synthetic id, missing-column error), plus CLI flag
parsing. Full marinfold suite green: 153 passed, 2 skipped, 8
network-deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
