### PR TITLE
contacts-v1: explore_documents.ipynb for the generated parquet

### DIFF
--- a/marinfold/marinfold/document_structures/contacts_v1/README.md
+++ b/marinfold/marinfold/document_structures/contacts_v1/README.md
@@ -88,6 +88,10 @@ metadata columns mirroring the published `protein-docs` datasets:
 `--summary-out FILE.json` additionally writes a rich per-protein summary
 (full residue sequence + every emitted contact with its degree).
 
+To explore a generated `docs.parquet` interactively — metadata
+distributions, a document decoder, and per-protein inspection — see
+[`explore_documents.ipynb`](explore_documents.ipynb).
+
 ## Generate documents
 
 ### From local structure files

--- a/marinfold/marinfold/document_structures/contacts_v1/explore_documents.ipynb
+++ b/marinfold/marinfold/document_structures/contacts_v1/explore_documents.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell00",
+   "metadata": {},
+   "source": "# contacts-v1 \u2014 explore generated documents\n\nLoads the `docs.parquet` produced by `contacts-v1 generate` (one row per\nprotein: the `document` token string plus metadata columns) and gives a few\nstarting points for a closer look \u2014 metadata distributions, a document\ndecoder, and per-protein inspection.\n\nSee [`README.md`](README.md) / [`SPEC.md`](SPEC.md) for the document format."
+  },
+  {
+   "cell_type": "code",
+   "id": "cell01",
+   "metadata": {},
+   "source": "from pathlib import Path\n\nimport matplotlib.pyplot as plt\nimport pyarrow.parquet as pq\n\n# Path to your generated documents parquet \u2014 change as needed.\nDOCS_PARQUET = Path(\"/home/bizon/contacts_v1_shard0/docs.parquet\")\n\ndf = pq.read_table(DOCS_PARQUET).to_pandas()\nprint(f\"{len(df)} documents  |  columns:\")\nprint(list(df.columns))\ndf.head(3)",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell02",
+   "metadata": {},
+   "source": "## Metadata overview"
+  },
+  {
+   "cell_type": "code",
+   "id": "cell03",
+   "metadata": {},
+   "source": "metric_cols = [\n    \"seq_len\", \"global_plddt\",\n    \"contacts_pre_filter\", \"contacts_passing_min_degree\",\n    \"contacts_emitted\", \"contacts_excluded\",\n    \"highest_contact_degree\", \"lowest_included_contact_degree\",\n    \"num_tokens\",\n]\ndf[metric_cols].describe().T",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "cell04",
+   "metadata": {},
+   "source": "n = len(df)\nprint(f\"documents:                     {n}\")\nprint(f\"truncated (hit 8192 budget):   {int(df.truncated.sum())} ({100 * df.truncated.mean():.1f}%)\")\nprint(f\"within 192 tokens of budget:   {int((df.num_tokens >= 8000).sum())}\")\nfiltered = 1 - df.contacts_passing_min_degree.sum() / df.contacts_pre_filter.sum()\nprint(f\"dropped by min-degree filter:  {100 * filtered:.1f}% of all found contacts\")\nprint(f\"total contacts emitted:        {int(df.contacts_emitted.sum()):,}\")",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell05",
+   "metadata": {},
+   "source": "## Distributions"
+  },
+  {
+   "cell_type": "code",
+   "id": "cell06",
+   "metadata": {},
+   "source": "fig, ax = plt.subplots(2, 2, figsize=(11, 7))\ndf.seq_len.hist(bins=40, ax=ax[0, 0]); ax[0, 0].set_title(\"seq_len (residues)\")\ndf.num_tokens.hist(bins=40, ax=ax[0, 1]); ax[0, 1].set_title(\"num_tokens\")\nax[0, 1].axvline(8192, color=\"r\", ls=\"--\", lw=1)\ndf.contacts_emitted.hist(bins=40, ax=ax[1, 0]); ax[1, 0].set_title(\"contacts_emitted\")\nax[1, 1].scatter(df.seq_len, df.num_tokens, s=6, alpha=0.25)\nax[1, 1].axhline(8192, color=\"r\", ls=\"--\", lw=1)\nax[1, 1].set_xlabel(\"seq_len\"); ax[1, 1].set_ylabel(\"num_tokens\")\nax[1, 1].set_title(\"length vs tokens\")\nfig.tight_layout()",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell07",
+   "metadata": {},
+   "source": "## Decode a document\n\nEach `document` is one token string:\n`<contacts-v1> <begin_sequence> \u2026 <begin_statements> \u2026 <end>`. The helpers\nbelow recover the residues (`<pN> <AA>`), the N/C termini, the contacts\n(`<contact> <pX> <pY>`), and the chain sequence in n-term\u2192c-term order.\n\nPositions are randomized wrap-around indices, so a contact's `<pX>`/`<pY>`\nare *document* indices, not sequence positions \u2014 use `pos_to_seq` to map\nthem back to 0-based sequence positions."
+  },
+  {
+   "cell_type": "code",
+   "id": "cell08",
+   "metadata": {},
+   "source": "_AA3_TO_1 = {\n    \"ALA\": \"A\", \"ARG\": \"R\", \"ASN\": \"N\", \"ASP\": \"D\", \"CYS\": \"C\", \"GLN\": \"Q\",\n    \"GLU\": \"E\", \"GLY\": \"G\", \"HIS\": \"H\", \"ILE\": \"I\", \"LEU\": \"L\", \"LYS\": \"K\",\n    \"MET\": \"M\", \"PHE\": \"F\", \"PRO\": \"P\", \"SER\": \"S\", \"THR\": \"T\", \"TRP\": \"W\",\n    \"TYR\": \"Y\", \"VAL\": \"V\", \"UNK\": \"X\",\n}\nNUM_INDICES = 2000\n\n\ndef parse_document(doc):\n    \"\"\"Decode a document into (n_term, c_term, residues, contacts).\n\n    residues: {pos_index: \"AAA\"};  contacts: [(pos_x, pos_y), ...].\n    \"\"\"\n    toks = doc.split()\n    bs = toks.index(\"<begin_sequence>\")\n    bt = toks.index(\"<begin_statements>\")\n    end = toks.index(\"<end>\")\n    residues, n_term, c_term = {}, None, None\n    seq = toks[bs + 1:bt]\n    for i in range(0, len(seq), 2):\n        a, b = seq[i], seq[i + 1]\n        if a == \"<n-term>\":\n            n_term = int(b[2:-1])\n        elif a == \"<c-term>\":\n            c_term = int(b[2:-1])\n        else:\n            residues[int(a[2:-1])] = b.strip(\"<>\")\n    contacts = []\n    st = toks[bt + 1:end]\n    for i in range(0, len(st), 3):\n        contacts.append((int(st[i + 1][2:-1]), int(st[i + 2][2:-1])))\n    return n_term, c_term, residues, contacts\n\n\ndef ordered_positions(n_term, c_term, num_indices=NUM_INDICES):\n    \"\"\"Position indices from n-term to c-term (wrapping around).\"\"\"\n    out, pos = [], n_term\n    while True:\n        out.append(pos)\n        if pos == c_term:\n            break\n        pos = (pos + 1) % num_indices\n    return out\n\n\ndef sequence_1letter(n_term, c_term, residues):\n    return \"\".join(\n        _AA3_TO_1.get(residues[p], \"X\")\n        for p in ordered_positions(n_term, c_term)\n    )\n\n\ndef pos_to_seq(n_term, c_term, num_indices=NUM_INDICES):\n    \"\"\"Map a document position index -> 0-based sequence position.\"\"\"\n    return {p: k for k, p in enumerate(ordered_positions(n_term, c_term, num_indices))}",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "cell09",
+   "metadata": {},
+   "source": "row = df.iloc[0]\nn_term, c_term, residues, contacts = parse_document(row.document)\np2s = pos_to_seq(n_term, c_term)\n\nprint(row.entry_id, \"| seq_len\", row.seq_len, \"| plddt\", round(row.global_plddt, 1),\n      \"| contacts\", row.contacts_emitted, \"| truncated\", row.truncated)\nprint(f\"n_term <p{n_term}>   c_term <p{c_term}>\")\nprint(\"sequence:\", sequence_1letter(n_term, c_term, residues))\nprint(\"\\nfirst 10 contacts (mapped to sequence positions):\")\nfor x, y in contacts[:10]:\n    i, j = p2s[x], p2s[y]\n    print(f\"  <p{x}>/<p{y}>  ->  seq {i}-{j}  ({residues[x]}{i}-{residues[y]}{j})\")",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell10",
+   "metadata": {},
+   "source": "## Pick a specific protein"
+  },
+  {
+   "cell_type": "code",
+   "id": "cell11",
+   "metadata": {},
+   "source": "# the largest protein, and the ones that hit the token budget\nlargest = df.loc[df.seq_len.idxmax()]\nprint(\"largest:\", largest.entry_id, \"| len\", largest.seq_len, \"| tokens\", largest.num_tokens)\n\ntruncated = df[df.truncated]\nprint(\"truncated docs:\", len(truncated))\ntruncated[[\"entry_id\", \"seq_len\", \"contacts_pre_filter\",\n           \"contacts_emitted\", \"contacts_excluded\", \"num_tokens\"]]",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "cell12",
+   "metadata": {},
+   "source": "# look up one by entry_id and decode it\nentry = \"AF-A0A6A5T025-F1\"   # <- change to any entry_id in df\nr = df[df.entry_id == entry].iloc[0]\nn_term, c_term, residues, contacts = parse_document(r.document)\nprint(entry, \"| len\", r.seq_len, \"| contacts\", r.contacts_emitted)\nprint(\"sequence:\", sequence_1letter(n_term, c_term, residues))",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell13",
+   "metadata": {},
+   "source": "## Per-contact degrees (optional)\n\nThe `document` records *which* residues are in contact but not the contact\n*degree*. Those live in the sibling `summary.json` (from `--summary-out`),\nkeyed per protein. It is large (~282 MB for 2,000 proteins), so load it only\nwhen you need the degrees:\n\n```python\nimport json\nsummary = json.load(open(DOCS_PARQUET.with_name(\"summary.json\")))\nby_id = {d[\"entry_id\"]: d for d in summary[\"documents\"]}\nby_id[\"AF-E9I562-F1\"][\"contacts\"][:5]   # each: pos_i / pos_j / resnum / resname / degree / flipped\n```"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds `explore_documents.ipynb` to the contacts-v1 package — a starter
notebook for taking a closer look at a generated `docs.parquet` (one row
per protein: the `document` token string + metadata columns).

It:
- loads the parquet and shows a metadata overview (`describe`) + headline
  stats (truncation, budget headroom, % contacts dropped by the min-degree
  filter, total contacts);
- plots distributions (seq_len, num_tokens, contacts_emitted, length-vs-tokens);
- provides a small **document decoder** (`parse_document`,
  `ordered_positions`, `sequence_1letter`, `pos_to_seq`) that recovers the
  residue sequence, the N/C termini, and the contacts — mapping each
  contact's randomized `<pX>`/`<pY>` indices back to 0-based sequence
  positions (e.g. `MET65-ASN24`);
- has cells to pull the largest / truncated proteins or look up by
  `entry_id`, plus a note on getting per-contact degrees from `summary.json`.

The `DOCS_PARQUET` path at the top defaults to the locally generated shard;
change it as needed. The README points to the notebook.

Validated: all code cells execute end-to-end against a real 2,000-document
`docs.parquet`, and the decoder's residue/contact counts and termini match
the metadata columns across small, large, and truncated documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)