### PR TITLE
contacts-v1: contact-map heatmaps in explore_documents.ipynb

### DIFF
--- a/marinfold/marinfold/document_structures/contacts_v1/explore_documents.ipynb
+++ b/marinfold/marinfold/document_structures/contacts_v1/explore_documents.ipynb
@@ -76,7 +76,7 @@
    "cell_type": "markdown",
    "id": "cellheatmapmd",
    "metadata": {},
-   "source": "## Contact-map heatmaps\n\nEach document encodes a binary contact map \u2014 which residue pairs are\nlisted as contacts (after the min-degree filter and truncation). Below is\nthe contact map for the first `N` documents: a symmetric `L x L` grid\nwhere a dark cell at `(i, j)` means residues `i` and `j` are in contact."
+   "source": "## Contact-map heatmaps\n\nEach document encodes a binary map of its **emitted** contacts \u2014 the\nresidue pairs actually written into the document, after the min-degree\nfilter and truncation (so `contacts_emitted`, not `contacts_pre_filter`).\nBelow is that map for the first `N` documents: a symmetric `L x L` grid\nwhere a dark cell at `(i, j)` means residues `i` and `j` are a contact."
   },
   {
    "cell_type": "code",
@@ -84,7 +84,7 @@
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": "def contact_matrix(document):\n    \"\"\"L x L binary symmetric contact map, indexed by sequence position.\"\"\"\n    n_term, c_term, residues, contacts = parse_document(document)\n    p2s = pos_to_seq(n_term, c_term)\n    L = len(residues)\n    m = np.zeros((L, L), dtype=np.uint8)\n    for x, y in contacts:\n        i, j = p2s[x], p2s[y]\n        m[i, j] = m[j, i] = 1\n    return m\n\n\nN = 10  # number of documents to show\nncols = 5\nnrows = (N + ncols - 1) // ncols\nfig, axes = plt.subplots(nrows, ncols, figsize=(3.2 * ncols, 3.4 * nrows))\nfor k, ax in enumerate(np.atleast_1d(axes).flatten()):\n    if k >= N:\n        ax.axis(\"off\")\n        continue\n    row = df.iloc[k]\n    ax.imshow(contact_matrix(row.document), cmap=\"Greys\",\n              origin=\"upper\", interpolation=\"nearest\")\n    ax.set_title(f\"{row.entry_id}\\nL={row.seq_len} \u00b7 {row.contacts_emitted} contacts\",\n                 fontsize=8)\n    ax.set_xticks([])\n    ax.set_yticks([])\nfig.suptitle(f\"contacts-v1 contact maps \u2014 first {N} documents\", fontsize=12)\nfig.tight_layout()"
+   "source": "def contact_matrix(document):\n    \"\"\"L x L binary symmetric contact map, indexed by sequence position.\"\"\"\n    n_term, c_term, residues, contacts = parse_document(document)\n    p2s = pos_to_seq(n_term, c_term)\n    L = len(residues)\n    m = np.zeros((L, L), dtype=np.uint8)\n    for x, y in contacts:\n        i, j = p2s[x], p2s[y]\n        m[i, j] = m[j, i] = 1\n    return m\n\n\nN = 10  # number of documents to show\nncols = 5\nnrows = (N + ncols - 1) // ncols\nfig, axes = plt.subplots(nrows, ncols, figsize=(3.2 * ncols, 3.4 * nrows))\nfor k, ax in enumerate(np.atleast_1d(axes).flatten()):\n    if k >= N:\n        ax.axis(\"off\")\n        continue\n    row = df.iloc[k]\n    ax.imshow(contact_matrix(row.document), cmap=\"Greys\",\n              origin=\"upper\", interpolation=\"nearest\")\n    ax.set_title(f\"{row.entry_id}\\nL={row.seq_len} \u00b7 {row.contacts_emitted} emitted\",\n                 fontsize=8)\n    ax.set_xticks([])\n    ax.set_yticks([])\nfig.suptitle(f\"contacts-v1 emitted-contact maps \u2014 first {N} documents\", fontsize=12)\nfig.tight_layout()"
   },
   {
    "cell_type": "markdown",

--- a/marinfold/marinfold/document_structures/contacts_v1/explore_documents.ipynb
+++ b/marinfold/marinfold/document_structures/contacts_v1/explore_documents.ipynb
@@ -10,7 +10,7 @@
    "cell_type": "code",
    "id": "cell01",
    "metadata": {},
-   "source": "from pathlib import Path\n\nimport matplotlib.pyplot as plt\nimport pyarrow.parquet as pq\n\n# Path to your generated documents parquet \u2014 change as needed.\nDOCS_PARQUET = Path(\"/home/bizon/contacts_v1_shard0/docs.parquet\")\n\ndf = pq.read_table(DOCS_PARQUET).to_pandas()\nprint(f\"{len(df)} documents  |  columns:\")\nprint(list(df.columns))\ndf.head(3)",
+   "source": "from pathlib import Path\n\nimport matplotlib.pyplot as plt\nimport numpy as np\nimport pyarrow.parquet as pq\n\n# Path to your generated documents parquet \u2014 change as needed.\nDOCS_PARQUET = Path(\"/home/bizon/contacts_v1_shard0/docs.parquet\")\n\ndf = pq.read_table(DOCS_PARQUET).to_pandas()\nprint(f\"{len(df)} documents  |  columns:\")\nprint(list(df.columns))\ndf.head(3)",
    "execution_count": null,
    "outputs": []
   },
@@ -71,6 +71,20 @@
    "source": "row = df.iloc[0]\nn_term, c_term, residues, contacts = parse_document(row.document)\np2s = pos_to_seq(n_term, c_term)\n\nprint(row.entry_id, \"| seq_len\", row.seq_len, \"| plddt\", round(row.global_plddt, 1),\n      \"| contacts\", row.contacts_emitted, \"| truncated\", row.truncated)\nprint(f\"n_term <p{n_term}>   c_term <p{c_term}>\")\nprint(\"sequence:\", sequence_1letter(n_term, c_term, residues))\nprint(\"\\nfirst 10 contacts (mapped to sequence positions):\")\nfor x, y in contacts[:10]:\n    i, j = p2s[x], p2s[y]\n    print(f\"  <p{x}>/<p{y}>  ->  seq {i}-{j}  ({residues[x]}{i}-{residues[y]}{j})\")",
    "execution_count": null,
    "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cellheatmapmd",
+   "metadata": {},
+   "source": "## Contact-map heatmaps\n\nEach document encodes a binary contact map \u2014 which residue pairs are\nlisted as contacts (after the min-degree filter and truncation). Below is\nthe contact map for the first `N` documents: a symmetric `L x L` grid\nwhere a dark cell at `(i, j)` means residues `i` and `j` are in contact."
+  },
+  {
+   "cell_type": "code",
+   "id": "cellheatmapcode",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "def contact_matrix(document):\n    \"\"\"L x L binary symmetric contact map, indexed by sequence position.\"\"\"\n    n_term, c_term, residues, contacts = parse_document(document)\n    p2s = pos_to_seq(n_term, c_term)\n    L = len(residues)\n    m = np.zeros((L, L), dtype=np.uint8)\n    for x, y in contacts:\n        i, j = p2s[x], p2s[y]\n        m[i, j] = m[j, i] = 1\n    return m\n\n\nN = 10  # number of documents to show\nncols = 5\nnrows = (N + ncols - 1) // ncols\nfig, axes = plt.subplots(nrows, ncols, figsize=(3.2 * ncols, 3.4 * nrows))\nfor k, ax in enumerate(np.atleast_1d(axes).flatten()):\n    if k >= N:\n        ax.axis(\"off\")\n        continue\n    row = df.iloc[k]\n    ax.imshow(contact_matrix(row.document), cmap=\"Greys\",\n              origin=\"upper\", interpolation=\"nearest\")\n    ax.set_title(f\"{row.entry_id}\\nL={row.seq_len} \u00b7 {row.contacts_emitted} contacts\",\n                 fontsize=8)\n    ax.set_xticks([])\n    ax.set_yticks([])\nfig.suptitle(f\"contacts-v1 contact maps \u2014 first {N} documents\", fontsize=12)\nfig.tight_layout()"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Adds a **Contact-map heatmaps** section to `explore_documents.ipynb`.

`contact_matrix(document)` decodes a document into a binary, symmetric `L x L` contact map (sequence-position indexed, via the existing `parse_document` / `pos_to_seq` helpers), and a grid cell plots the contact maps for the **first N documents** — `N = 10` for now, as a single knob at the top of the cell.

Validated: all code cells execute end-to-end against the real 2,000-document parquet; the first document decodes to a 156x156 symmetric matrix with 159 contact cells, matching its `contacts_emitted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)