### PR TITLE
contacts-v1: minimum sequence-separation requirement for contacts

### DIFF
--- a/marinfold/marinfold/document_structures/contacts_v1/README.md
+++ b/marinfold/marinfold/document_structures/contacts_v1/README.md
@@ -22,10 +22,11 @@ A document is a single space-separated token string:
   `<n-term>` and one `<c-term>` marker, all in random order. Residues are
   numbered from a random n-terminal index that wraps around 2000 position
   indices (so the model sees the whole index range, not just low values).
-- **Structure section** — pyconfind side-chain contacts with contact
-  degree ≥ `min_contact_degree` (default 0.001). We take the strongest N
-  that fill the 8192-token budget and list them in random order; each
-  `<contact>` pair's order is coin-flipped.
+- **Structure section** — pyconfind side-chain contacts, restricted to
+  pairs at least `min_seq_separation` residues apart in the chain (default
+  6) with contact degree ≥ `min_contact_degree` (default 0.001). We take
+  the strongest N that fill the 8192-token budget and list them in random
+  order; each `<contact>` pair's order is coin-flipped.
 - **Token reuse** — positions (`<pN>`), section markers (`<begin_sequence>`
   / `<begin_statements>`), amino acids (`<ALA>`…), `<UNK>` and `<end>` are
   reused from `contacts-and-distances-v1`; only `<contacts-v1>`, `<n-term>`,
@@ -33,31 +34,36 @@ A document is a single space-separated token string:
 - **Deterministic** per `entry_id` (the RNG seed), so the same structure +
   id always yields the same document.
 
-A tiny worked example — a 4-residue chain `MET-ALA-GLY-PHE` numbered from
-a random start index of 20. It's a single space-separated line in a file;
-shown one statement per line here:
+A tiny worked example — an 8-residue chain `MET-ALA-GLY-PHE-SER-THR-LYS-VAL`
+numbered from a random start index of 20. It's a single space-separated line
+in a file; shown one statement per line here:
 
 ```
 <contacts-v1>
 <begin_sequence>
 <p23> <PHE>
 <n-term> <p20>
+<p26> <LYS>
+<p25> <THR>
+<p27> <VAL>
 <p21> <ALA>
-<c-term> <p23>
-<p20> <MET>
 <p22> <GLY>
+<c-term> <p27>
+<p20> <MET>
+<p24> <SER>
 <begin_statements>
-<contact> <p20> <p23>
-<contact> <p20> <p22>
+<contact> <p21> <p27>
+<contact> <p20> <p26>
 <end>
 ```
 
-All six sequence statements — the four `<pN> <AA>` residues and the two
+The ten sequence statements — the eight `<pN> <AA>` residues and the two
 terminus markers — appear in **one random order**, so `<n-term>` /
 `<c-term>` are interleaved with the residues rather than grouped up front.
-The contacts are **also in random order** (selected strongest-first to fill
-the budget, but not *listed* by degree — here the degree-0.92 `<p20> <p22>`
-contact comes second), each pair's two positions coin-flipped.
+The two contacts are **also in random order** (selected strongest-first to
+fill the budget, but not *listed* by degree), each pair's two positions
+coin-flipped. Both pairs span ≥ 6 residues in the chain (`p20`–`p26` and
+`p21`–`p27`); closer pairs are excluded by `min_seq_separation` (default 6).
 
 Eyeball a real one (prints the document + a contact table):
 
@@ -158,10 +164,10 @@ The tokenizer subcommand needs no extra (pyconfind is only used by
 
 ## Algorithm knobs
 
-`--min-contact-degree` (0.001), `--context-length` (8192), `--assembly`
-(`none` = asymmetric unit as-is), and the pyconfind geometry knobs
-`--contact-distance` / `--dcut` / `--clash-distance`. See
-`contacts-v1 generate --help` for the full set.
+`--min-seq-separation` (6), `--min-contact-degree` (0.001),
+`--context-length` (8192), `--assembly` (`none` = asymmetric unit as-is),
+and the pyconfind geometry knobs `--contact-distance` / `--dcut` /
+`--clash-distance`. See `contacts-v1 generate --help` for the full set.
 
 ## Library interface
 

--- a/marinfold/marinfold/document_structures/contacts_v1/SPEC.md
+++ b/marinfold/marinfold/document_structures/contacts_v1/SPEC.md
@@ -51,6 +51,8 @@ The structure section consists of statements of the form `<contact>` `<pXXX>` `<
 
 Contacts are defined as contact degree > 0 where contact degree is implemented in [pyconfind](https://github.com/timodonnell/pyconfind). We run pyconfind in `native_only=True` mode, i.e. only consider the actual given amino acid at each position rather than all other possibilities.
 
+We also require a minimum primary-sequence separation: a pair of residues at sequence positions i and j is only a contact if `|i - j| >= min_seq_separation` (default 6). Residues 5 or fewer positions apart in the chain are never contacts, regardless of geometry — this keeps trivial local / secondary-structure contacts out of the documents.
+
 Before selecting which contacts to include, we discard any contact whose contact degree is below a minimum threshold (`min_contact_degree`, default 0.001). Contacts below this threshold are **never** written to a document, even if there is room for them. (pyconfind reports many very weak contacts — degrees down to ~1e-8 — and this threshold keeps those noise-level contacts out.)
 
 From the contacts that pass this threshold, we include the N with the highest contact degree (the N strongest), where N is chosen so the document fills the 8192-token budget (see Document length). These N selected contacts are then listed in **random order** in the structure section — they are *not* sorted by degree. (We select by strength so that, when a protein has more above-threshold contacts than fit, the weakest are the ones dropped; but the order they appear in the document is randomized so the model does not learn a degree-sorted ordering.)
@@ -129,6 +131,13 @@ contacts-and-distances-v1 analog. (The original example's `<c-term> <pos
 - **Residue-count bounds.** "Up to 2000 residues" is enforced: chains
   with fewer than 2 residues or more than 2000 (can't be uniquely
   indexed under wrap-around) are skipped with a warning.
+- **Minimum sequence separation.** A pair counts as a contact only if its
+  residues are at least `config.min_seq_separation` (default 6) positions
+  apart in the primary sequence (`seq_j - seq_i >= min_seq_separation`).
+  This is *definitional* — closer pairs are filtered before anything is
+  counted, so `contacts_pre_filter` (and the degree statistics) already
+  exclude them. (`contacts-and-distances-v1` used the same minimum of 6 via
+  its `short_range_sep`.)
 - **Minimum degree filter.** Contacts with degree below
   `config.min_contact_degree` (default 0.001) are dropped before anything
   else and are never emitted, regardless of budget. pyconfind returns a

--- a/marinfold/marinfold/document_structures/contacts_v1/cli.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/cli.py
@@ -63,6 +63,7 @@ def _config_from_args(args: argparse.Namespace) -> generate.GenerationConfig:
         dcut=args.dcut,
         clash_distance=args.clash_distance,
         assembly=args.assembly,
+        min_seq_separation=args.min_seq_separation,
         min_contact_degree=args.min_contact_degree,
     )
 
@@ -235,6 +236,10 @@ def _add_generation_common(p: argparse.ArgumentParser) -> None:
                    help="CA-CA pair cutoff in Å for the contact-degree search.")
     p.add_argument("--clash-distance", type=float, default=cfg.clash_distance,
                    help="Backbone-clash cutoff in Å used while pruning rotamers.")
+    p.add_argument("--min-seq-separation", type=int, default=cfg.min_seq_separation,
+                   help="Minimum primary-sequence separation |i-j| for a pair "
+                        "to count as a contact; closer pairs are never "
+                        f"contacts (default {cfg.min_seq_separation}).")
     p.add_argument("--min-contact-degree", type=float, default=cfg.min_contact_degree,
                    help="Drop contacts with degree below this before "
                         "selection; they are never included even if there is "

--- a/marinfold/marinfold/document_structures/contacts_v1/generate.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/generate.py
@@ -73,9 +73,13 @@ class GenerationConfig:
     """Hyperparameters for contacts-v1 generation.
 
     The first four are pyconfind geometry knobs (SPEC defaults — confind's
-    C++ defaults, native-only). ``min_contact_degree`` filters out weak
-    contacts before selection: any contact with degree below it is never
-    emitted, even if there is budget room (pyconfind returns a long tail of
+    C++ defaults, native-only). ``min_seq_separation`` is the minimum
+    primary-sequence separation for a pair to count as a contact: residues
+    fewer than this many positions apart in the chain (``|i - j| <
+    min_seq_separation``) are never contacts (default 6, i.e. 5-or-closer
+    pairs are excluded). ``min_contact_degree`` filters out weak contacts
+    before selection: any contact with degree below it is never emitted,
+    even if there is budget room (pyconfind returns a long tail of
     near-zero-degree contacts). ``num_position_indices`` is the size of the
     position-token space and must match ``vocab.NUM_POSITION_INDICES``; it
     also caps the longest chain we can serialize (one index per residue,
@@ -86,6 +90,7 @@ class GenerationConfig:
     contact_distance: float = 3.0
     dcut: float = 25.0
     clash_distance: float = 2.0
+    min_seq_separation: int = 6
     min_contact_degree: float = 0.001
     num_position_indices: int = NUM_POSITION_INDICES
     assembly: int | str | None = None
@@ -255,6 +260,14 @@ def build_document(
     seq_statements.append((N_TERM_TOKEN, position_token(n_term_index)))
     seq_statements.append((C_TERM_TOKEN, position_token(c_term_index)))
     rng.shuffle(seq_statements)
+
+    # Sequence-separation filter (definitional): residues fewer than
+    # min_seq_separation positions apart in the primary sequence are never
+    # contacts, so they're dropped before anything is counted.
+    contacts = [
+        c for c in contacts
+        if (c.seq_j - c.seq_i) >= config.min_seq_separation
+    ]
 
     # Structure section. Rank by descending degree (stable sort keeps
     # pyconfind's (seq_i, seq_j) ordering as the deterministic tie-break),

--- a/marinfold/tests/document_structures/contacts_v1/test_cli.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_cli.py
@@ -42,6 +42,18 @@ def test_min_contact_degree_override():
     assert cfg.min_contact_degree == 0.05
 
 
+def test_min_seq_separation_default_and_override():
+    args = cli.build_parser().parse_args(["generate", "--input", "x", "--out", "o.jsonl"])
+    assert args.min_seq_separation == 6
+    assert cli._config_from_args(args).min_seq_separation == 6
+
+    args2 = cli.build_parser().parse_args([
+        "generate", "--input", "x", "--out", "o.jsonl", "--min-seq-separation", "12",
+    ])
+    assert args2.min_seq_separation == 12
+    assert cli._config_from_args(args2).min_seq_separation == 12
+
+
 def test_parquet_column_defaults():
     args = cli.build_parser().parse_args([
         "generate", "--input", "shard.parquet", "--out", "docs.parquet",
@@ -100,12 +112,15 @@ def test_view_default_max_contacts():
 
 def test_view_prints_reused_position_tokens(monkeypatch, capsys):
     residues = [
-        ResidueInfo(seq_index=0, resname="ALA", resnum=1, chain="A"),
-        ResidueInfo(seq_index=1, resname="GLY", resnum=2, chain="A"),
-        ResidueInfo(seq_index=2, resname="SER", resnum=3, chain="A"),
+        ResidueInfo(seq_index=i, resname=aa, resnum=1 + i, chain="A")
+        for i, aa in enumerate(
+            ["ALA", "GLY", "SER", "THR", "LYS", "VAL", "LEU", "PHE"]
+        )
     ]
-    result = build_document("view-demo", residues, [RawContact(0, 2, 0.9)])
+    # sep 6 → survives the default min_seq_separation=6 filter.
+    result = build_document("view-demo", residues, [RawContact(0, 6, 0.9)])
     assert result is not None
+    assert result.contacts_emitted == 1
     monkeypatch.setattr(
         cli.generate,
         "generate_documents",

--- a/marinfold/tests/document_structures/contacts_v1/test_generate.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_generate.py
@@ -38,6 +38,13 @@ def _residues(n: int, *, start_resnum: int = 1) -> list[ResidueInfo]:
     ]
 
 
+# Most builder tests exercise mechanics orthogonal to the sequence-separation
+# filter. This permissive config (min_seq_separation=1 keeps every pair, since
+# seq_i < seq_j) lets their small synthetic contacts through; the seq-sep
+# filter has dedicated tests below.
+_CFG = GenerationConfig(min_seq_separation=1)
+
+
 def _pos_indices(document: str) -> list[int]:
     # Positions are reused <pX> tokens from contacts-and-distances-v1.
     return [int(m) for m in re.findall(r"<p(\d+)>", document)]
@@ -58,7 +65,7 @@ def _sections(document: str) -> tuple[list[str], list[str]]:
 
 
 def test_document_framing():
-    res = build_document("e", _residues(5), [RawContact(0, 2, 0.9)])
+    res = build_document("e", _residues(5), [RawContact(0, 2, 0.9)], config=_CFG)
     toks = res.document.split()
     assert toks[0] == "<contacts-v1>"
     assert toks[1] == "<begin_sequence>"     # reused from c-and-d-v1
@@ -83,13 +90,14 @@ def test_sequence_section_defines_each_residue_once_plus_two_termini():
 
 
 def test_token_count_matches_split_and_num_tokens():
-    res = build_document("e", _residues(6), [RawContact(0, 3, 0.5), RawContact(1, 4, 0.2)])
+    res = build_document("e", _residues(6), [RawContact(0, 3, 0.5), RawContact(1, 4, 0.2)],
+                         config=_CFG)
     assert res.num_tokens == len(res.document.split())
 
 
 def test_tokenizes_with_no_unk():
     res = build_document("vocabcheck", _residues(9),
-                         [RawContact(0, 4, 0.7), RawContact(2, 8, 0.3)])
+                         [RawContact(0, 4, 0.7), RawContact(2, 8, 0.3)], config=_CFG)
     tok = build_tokenizer(vocab.all_domain_tokens())
     ids = tok.encode(res.document, add_special_tokens=False)
     assert len(ids) == len(res.document.split())
@@ -114,8 +122,8 @@ def test_unk_resname_emits_unk_token():
 def test_deterministic_same_entry_id():
     residues = _residues(8)
     contacts = [RawContact(0, 4, 0.9), RawContact(1, 6, 0.5), RawContact(2, 7, 0.1)]
-    a = build_document("AF-X", residues, contacts)
-    b = build_document("AF-X", residues, contacts)
+    a = build_document("AF-X", residues, contacts, config=_CFG)
+    b = build_document("AF-X", residues, contacts, config=_CFG)
     assert a.document == b.document
     assert a.start_index == b.start_index
 
@@ -136,13 +144,18 @@ def test_readme_worked_example_is_current():
     """
     residues = [
         ResidueInfo(i, name, 1 + i, "A")
-        for i, name in enumerate(["MET", "ALA", "GLY", "PHE"])
+        for i, name in enumerate(
+            ["MET", "ALA", "GLY", "PHE", "SER", "THR", "LYS", "VAL"]
+        )
     ]
-    contacts = [RawContact(0, 2, 0.92), RawContact(0, 3, 0.31)]
+    # Both contacts span >= 6 residues, so they survive the default
+    # min_seq_separation=6 (the example uses the default config).
+    contacts = [RawContact(0, 6, 0.91), RawContact(1, 7, 0.42)]
     expected = (
         "<contacts-v1> <begin_sequence> <p23> <PHE> <n-term> <p20> "
-        "<p21> <ALA> <c-term> <p23> <p20> <MET> <p22> <GLY> <begin_statements> "
-        "<contact> <p20> <p23> <contact> <p20> <p22> <end>"
+        "<p26> <LYS> <p25> <THR> <p27> <VAL> <p21> <ALA> <p22> <GLY> "
+        "<c-term> <p27> <p20> <MET> <p24> <SER> <begin_statements> "
+        "<contact> <p21> <p27> <contact> <p20> <p26> <end>"
     )
     assert build_document("ex-21", residues, contacts).document == expected
 
@@ -193,7 +206,7 @@ def test_wraparound_actually_wraps():
 def test_contacts_selected_by_strength_multiset_preserved():
     residues = _residues(10)
     contacts = [RawContact(0, 5, 0.2), RawContact(1, 7, 0.9), RawContact(2, 9, 0.5)]
-    res = build_document("order", residues, contacts)
+    res = build_document("order", residues, contacts, config=_CFG)
     # All fit → all included; the multiset of degrees is preserved.
     assert res.contacts_emitted == 3
     assert sorted(c.degree for c in res.contacts) == [0.2, 0.5, 0.9]
@@ -204,7 +217,7 @@ def test_contacts_listed_in_random_order_not_degree_sorted():
     # ~1/39! — so a non-sorted order is a reliable signal of randomization.
     residues = _residues(40)
     contacts = [RawContact(i, i + 1, float(39 - i)) for i in range(39)]
-    res = build_document("randorder", residues, contacts)
+    res = build_document("randorder", residues, contacts, config=_CFG)
     degrees = [c.degree for c in res.contacts]
     assert res.contacts_emitted == 39
     assert sorted(degrees) == [float(d) for d in range(1, 40)]  # multiset intact
@@ -214,7 +227,7 @@ def test_contacts_listed_in_random_order_not_degree_sorted():
 def test_emitted_pair_order_matches_flip_flag():
     residues = _residues(12)
     contacts = [RawContact(0, 5, 0.9), RawContact(1, 8, 0.6), RawContact(3, 11, 0.3)]
-    res = build_document("flip", residues, contacts)
+    res = build_document("flip", residues, contacts, config=_CFG)
     _, struct = _sections(res.document)
     # struct is groups of <contact> <pA> <pB>.
     triples = [struct[i:i + 3] for i in range(0, len(struct), 3)]
@@ -236,7 +249,8 @@ def test_truncation_keeps_strongest_and_respects_budget():
     # 40 contacts with strictly decreasing degrees.
     contacts = [RawContact(i, i + 1, float(40 - i)) for i in range(40)]
     context_length = 200  # frame(4)+seq(2*50)+termini(4)=108 → 30 contacts fit
-    res = build_document("trunc", residues, contacts, context_length=context_length)
+    res = build_document("trunc", residues, contacts, context_length=context_length,
+                         config=_CFG)
     assert res.contacts_pre_filter == 40
     assert res.contacts_passing_min_degree == 40  # all degrees >= 0.001
     assert res.contacts_emitted == 30
@@ -257,7 +271,7 @@ def test_truncation_keeps_strongest_and_respects_budget():
 def test_not_truncated_when_everything_fits():
     residues = _residues(6)
     contacts = [RawContact(0, 3, 0.9), RawContact(1, 5, 0.4)]
-    res = build_document("fits", residues, contacts)
+    res = build_document("fits", residues, contacts, config=_CFG)
     assert res.truncated is False
     assert res.contacts_excluded == 0
     assert res.contacts_passing_min_degree == 2
@@ -293,7 +307,7 @@ def test_min_degree_filter_excludes_weak_contacts_even_with_space():
         RawContact(2, 7, 0.0005),   # below threshold
         RawContact(3, 8, 1e-8),     # below threshold
     ]
-    res = build_document("weak", residues, contacts)
+    res = build_document("weak", residues, contacts, config=_CFG)
     assert res.contacts_pre_filter == 4
     assert res.contacts_passing_min_degree == 2
     assert res.contacts_emitted == 2          # weak ones never included
@@ -311,7 +325,7 @@ def test_min_degree_filter_excludes_weak_contacts_even_with_space():
 def test_custom_min_contact_degree_threshold():
     residues = _residues(10)
     contacts = [RawContact(0, 5, 0.9), RawContact(1, 6, 0.05), RawContact(2, 7, 0.005)]
-    cfg = GenerationConfig(min_contact_degree=0.1)
+    cfg = GenerationConfig(min_contact_degree=0.1, min_seq_separation=1)
     res = build_document("thresh", residues, contacts, config=cfg)
     assert res.contacts_passing_min_degree == 1   # only 0.9 >= 0.1
     assert res.contacts_emitted == 1
@@ -322,7 +336,7 @@ def test_custom_min_contact_degree_threshold():
 def test_all_contacts_below_threshold():
     residues = _residues(6)
     contacts = [RawContact(0, 3, 0.0002), RawContact(1, 5, 1e-7)]
-    res = build_document("allweak", residues, contacts)
+    res = build_document("allweak", residues, contacts, config=_CFG)
     assert res.contacts_pre_filter == 2
     assert res.contacts_passing_min_degree == 0
     assert res.contacts_emitted == 0
@@ -335,6 +349,47 @@ def test_all_contacts_below_threshold():
     # Document still valid: sequence section + empty structure section.
     assert res.document.split()[-1] == "<end>"
     assert "<contact>" not in res.document.split()
+
+
+# ---------------------------------------------------------------------------
+# Minimum sequence-separation filter
+# ---------------------------------------------------------------------------
+
+
+def test_seq_separation_filter_excludes_close_pairs_by_default():
+    residues = _residues(12)
+    contacts = [
+        RawContact(0, 5, 0.9),   # sep 5 → excluded (default min_seq_separation=6)
+        RawContact(0, 6, 0.8),   # sep 6 → kept
+        RawContact(1, 9, 0.7),   # sep 8 → kept
+        RawContact(4, 5, 0.6),   # sep 1 → excluded
+    ]
+    res = build_document("sep", residues, contacts)  # default config
+    assert res.contacts_pre_filter == 2          # only the sep>=6 pairs are contacts
+    assert res.contacts_emitted == 2
+    assert sorted(c.degree for c in res.contacts) == [0.7, 0.8]
+    assert all((c.seq_j - c.seq_i) >= 6 for c in res.contacts)
+    # The strongest pair (degree 0.9) was excluded by the seq-sep filter, so
+    # the degree stats reflect only the surviving (>=6) pairs.
+    assert res.highest_contact_degree == 0.8
+
+
+def test_custom_min_seq_separation():
+    residues = _residues(20)
+    contacts = [RawContact(0, 6, 0.9), RawContact(0, 9, 0.5), RawContact(0, 15, 0.3)]
+    res = build_document("sep10", residues, contacts,
+                         config=GenerationConfig(min_seq_separation=10))
+    # Only seps >= 10 survive → just (0, 15).
+    assert res.contacts_pre_filter == 1
+    assert {c.seq_j - c.seq_i for c in res.contacts} == {15}
+
+
+def test_min_seq_separation_one_keeps_adjacent_pairs():
+    residues = _residues(10)
+    contacts = [RawContact(0, 1, 0.9), RawContact(2, 3, 0.5)]  # seps 1, 1
+    res = build_document("sep1", residues, contacts,
+                         config=GenerationConfig(min_seq_separation=1))
+    assert res.contacts_emitted == 2
 
 
 # ---------------------------------------------------------------------------
@@ -388,7 +443,7 @@ def test_generate_documents_warns_and_skips_when_fixed_section_exceeds_context_l
 def test_metadata_row_and_summary_dict():
     residues = _residues(5)
     contacts = [RawContact(0, 2, 0.9), RawContact(1, 4, 0.5)]
-    res = build_document("AF-META", residues, contacts, global_plddt=87.5)
+    res = build_document("AF-META", residues, contacts, global_plddt=87.5, config=_CFG)
     row = res.metadata_row()
     assert row["document"] == res.document
     assert row["entry_id"] == "AF-META"


### PR DESCRIPTION
Adds a configurable **minimum primary-sequence separation** for contacts (Refs #46).

A pair of residues counts as a contact only if they are at least `min_seq_separation` positions apart in the chain (`seq_j - seq_i >= min_seq_separation`, **default 6**). Residues 5-or-fewer apart are never contacts, regardless of geometry — this keeps trivial local / secondary-structure contacts out. (Same minimum of 6 `contacts-and-distances-v1` used via `short_range_sep`.)

It's **definitional**: the filter runs before anything is counted, so `contacts_pre_filter` and the degree statistics already exclude the close pairs.

### Changes
- `GenerationConfig.min_seq_separation` (default 6); `build_document` drops `seq_j - seq_i < min_seq_separation` first. CLI flag `--min-seq-separation`.
- `SPEC.md` (structure section + Implementation notes & discrepancies) and `README.md` updated; the README worked example is regenerated as an **8-residue** chain (a 4-mer can't have a ≥6-separation contact), with both contacts spanning exactly 6.
- Tests: dedicated seq-sep tests (default / custom threshold / disabled); the other builder tests pass a permissive config (`min_seq_separation=1`) so their small synthetic contacts aren't dropped; README-example guard test updated.

### Impact
On 1QYS the default drops the local contacts: **198 → 101** (emitted 141 → 76); every surviving contact spans ≥ 6 residues. Full marinfold suite green (159 passed, 2 skipped, 8 network-deselected).

I'm regenerating the 2,000-document afdb-24M shard with this default so the new emitted-contact heatmaps (empty `|i-j|<6` diagonal band) show up in the notebook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)