### PR TITLE
contacts-v1: persist seq-sep metadata and fix view output

### DIFF
--- a/marinfold/marinfold/document_structures/contacts_v1/README.md
+++ b/marinfold/marinfold/document_structures/contacts_v1/README.md
@@ -76,7 +76,8 @@ uv run contacts-v1 view --input tests/data/1QYS.cif
 ## Output + metadata
 
 `generate` writes one row per protein — the `document` token string plus
-metadata columns mirroring the published `protein-docs` datasets:
+metadata columns mirroring the published `protein-docs` datasets, plus
+the sequence-separation knob that defines what counts as a contact:
 
 | column | meaning |
 |---|---|
@@ -84,7 +85,8 @@ metadata columns mirroring the published `protein-docs` datasets:
 | `seq_len` | residue count |
 | `global_plddt` | mean CA B-factor (pLDDT for AFDB inputs) |
 | `start_index`, `n_term_index`, `c_term_index` | residue-numbering offsets |
-| `contacts_pre_filter` | all contacts with degree > 0 |
+| `min_seq_separation` | minimum `|i-j|` required for a pair to count as a contact |
+| `contacts_pre_filter` | contacts with degree > 0 that survive the `min_seq_separation` definition |
 | `contacts_passing_min_degree` | how many passed the min-degree filter |
 | `contacts_emitted` / `contacts_excluded` | included / not included |
 | `truncated` | whether a budget overflow dropped an eligible contact |

--- a/marinfold/marinfold/document_structures/contacts_v1/SPEC.md
+++ b/marinfold/marinfold/document_structures/contacts_v1/SPEC.md
@@ -175,10 +175,13 @@ contacts-and-distances-v1 analog. (The original example's `<c-term> <pos
 The spec does not define output metadata; the issue asks to track
 protein-docs-style metadata. Per document we record: `entry_id`,
 `seq_len`, `global_plddt` (mean CA B-factor), `start_index`,
-`n_term_index`, `c_term_index`, `num_tokens`, `sha1` of the document,
-and the following contact statistics:
+`n_term_index`, `c_term_index`, `min_seq_separation`, `num_tokens`,
+`sha1` of the document, and the following contact statistics:
 
-- `contacts_pre_filter` — total contacts (degree > 0) the protein had.
+- `min_seq_separation` — the minimum sequence separation used for this
+  row's contact definition.
+- `contacts_pre_filter` — total contacts (degree > 0) that survived the
+  `min_seq_separation` definition.
 - `contacts_passing_min_degree` — how many passed the `min_contact_degree`
   filter (the pool the strongest N are chosen from).
 - `contacts_emitted` — how many were included in the document.
@@ -186,10 +189,11 @@ and the following contact statistics:
   emitted`); counts both below-threshold and budget-truncated contacts.
 - `truncated` — whether a budget overflow dropped any above-threshold
   contact (`contacts_passing_min_degree > contacts_emitted`).
-- `highest_contact_degree` — max degree over all the protein's contacts.
-- `lowest_nonzero_contact_degree` — min degree over all the protein's
-  contacts (pyconfind only returns degree > 0, so this is the smallest
-  positive degree, which may be below the filter threshold).
+- `highest_contact_degree` — max degree over the protein's surviving
+  (`min_seq_separation`-respecting) contacts.
+- `lowest_nonzero_contact_degree` — min degree over the protein's
+  surviving contacts (pyconfind only returns degree > 0, so this is the
+  smallest positive degree, which may be below the filter threshold).
 - `lowest_included_contact_degree` — min degree among the contacts that
   made it into the document (always ≥ `min_contact_degree`).
 

--- a/marinfold/marinfold/document_structures/contacts_v1/cli.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/cli.py
@@ -89,6 +89,11 @@ def _write_summary(
         json.dump(summary, f, indent=2, default=str)
 
 
+def _format_optional_degree(value: float | None) -> str:
+    """Render an optional degree for terminal display."""
+    return "n/a" if value is None else f"{value:.4f}"
+
+
 # --------------------------------------------------------------------------
 # Subcommand handlers
 # --------------------------------------------------------------------------
@@ -144,14 +149,15 @@ def cmd_view(args: argparse.Namespace) -> None:
             f"  contacts: {result.contacts_emitted} included / "
             f"{result.contacts_excluded} excluded / "
             f"{result.contacts_passing_min_degree} pass min-degree / "
-            f"{result.contacts_pre_filter} found  "
+            f"{result.contacts_pre_filter} survive seq-sep>="
+            f"{result.min_seq_separation}  "
             f"truncated={result.truncated}  tokens={result.num_tokens}"
         )
         if result.contacts_pre_filter:
             print(
-                f"  degree: highest={result.highest_contact_degree:.4f}  "
-                f"lowest_nonzero={result.lowest_nonzero_contact_degree:.4f}  "
-                f"lowest_included={result.lowest_included_contact_degree:.4f}"
+                f"  degree: highest={_format_optional_degree(result.highest_contact_degree)}  "
+                f"lowest_nonzero={_format_optional_degree(result.lowest_nonzero_contact_degree)}  "
+                f"lowest_included={_format_optional_degree(result.lowest_included_contact_degree)}"
             )
         ncap = args.max_contacts
         # Contacts appear in random order in the document; sort for display.

--- a/marinfold/marinfold/document_structures/contacts_v1/generate.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/generate.py
@@ -139,10 +139,11 @@ class GenerationResult:
 
     The flat scalars mirror the metadata columns of the published
     ``timodonnell/protein-docs`` datasets (``seq_len``,
-    ``contacts_pre_filter``, ``contacts_emitted``, …). :meth:`metadata_row`
-    is the flat parquet/jsonl row; :meth:`summary_dict` is the richer view
-    (full sequence + per-contact degrees) for the local ``--summary-out``
-    JSON.
+    ``contacts_pre_filter``, ``contacts_emitted``, …), plus the
+    contact-definition knob that affects those counts
+    (``min_seq_separation``). :meth:`metadata_row` is the flat
+    parquet/jsonl row; :meth:`summary_dict` is the richer view (full
+    sequence + per-contact degrees) for the local ``--summary-out`` JSON.
     """
 
     entry_id: str
@@ -153,6 +154,7 @@ class GenerationResult:
     start_index: int
     n_term_index: int
     c_term_index: int
+    min_seq_separation: int
     contacts_pre_filter: int
     contacts_passing_min_degree: int
     contacts_emitted: int
@@ -180,6 +182,7 @@ class GenerationResult:
             "start_index": self.start_index,
             "n_term_index": self.n_term_index,
             "c_term_index": self.c_term_index,
+            "min_seq_separation": self.min_seq_separation,
             "contacts_pre_filter": self.contacts_pre_filter,
             "contacts_passing_min_degree": self.contacts_passing_min_degree,
             "contacts_emitted": self.contacts_emitted,
@@ -269,10 +272,11 @@ def build_document(
         if (c.seq_j - c.seq_i) >= config.min_seq_separation
     ]
 
-    # Structure section. Rank by descending degree (stable sort keeps
-    # pyconfind's (seq_i, seq_j) ordering as the deterministic tie-break),
-    # then drop contacts below the minimum-degree threshold before picking
-    # which survive truncation.
+    # Structure section. These counts/stats are over the post-seq-sep pool.
+    # Rank by descending degree (stable sort keeps pyconfind's
+    # (seq_i, seq_j) ordering as the deterministic tie-break), then drop
+    # contacts below the minimum-degree threshold before picking which
+    # survive truncation.
     ordered = sorted(contacts, key=lambda c: -c.degree)
     contacts_pre_filter = len(ordered)
     highest_degree = ordered[0].degree if ordered else None
@@ -333,6 +337,7 @@ def build_document(
         start_index=start,
         n_term_index=n_term_index,
         c_term_index=c_term_index,
+        min_seq_separation=config.min_seq_separation,
         contacts_pre_filter=contacts_pre_filter,
         contacts_passing_min_degree=contacts_passing,
         contacts_emitted=len(emitted),

--- a/marinfold/tests/document_structures/contacts_v1/test_cli.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from marinfold.document_structures.contacts_v1 import cli
-from marinfold.document_structures.contacts_v1.generate import build_document
+from marinfold.document_structures.contacts_v1.generate import GenerationConfig, build_document
 from marinfold.document_structures.contacts_v1.parse import RawContact, ResidueInfo
 from marinfold.document_structures.contacts_v1.vocab import position_token
 
@@ -138,6 +138,34 @@ def test_view_prints_reused_position_tokens(monkeypatch, capsys):
         f"{position_token(result.contacts[0].pos_j)}"
     ) in out
     assert "<pos-" not in out
+
+
+def test_view_handles_no_included_contacts(monkeypatch, capsys):
+    residues = [
+        ResidueInfo(seq_index=i, resname=aa, resnum=1 + i, chain="A")
+        for i, aa in enumerate(["ALA", "GLY", "SER", "THR"])
+    ]
+    result = build_document(
+        "view-empty-contacts",
+        residues,
+        [RawContact(0, 2, 0.9)],
+        config=GenerationConfig(min_seq_separation=1, min_contact_degree=1.0),
+    )
+    assert result is not None
+    assert result.contacts_pre_filter == 1
+    assert result.contacts_emitted == 0
+    monkeypatch.setattr(
+        cli.generate,
+        "generate_documents",
+        lambda **_: iter([result]),
+    )
+
+    args = cli.build_parser().parse_args(["view", "--input", "demo.cif"])
+    args.func(args)
+
+    out = capsys.readouterr().out
+    assert "survive seq-sep>=1" in out
+    assert "lowest_included=n/a" in out
 
 
 def test_tokenizer_parses():

--- a/marinfold/tests/document_structures/contacts_v1/test_generate.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_generate.py
@@ -449,6 +449,7 @@ def test_metadata_row_and_summary_dict():
     assert row["entry_id"] == "AF-META"
     assert row["seq_len"] == 5
     assert row["global_plddt"] == 87.5
+    assert row["min_seq_separation"] == 1
     assert row["contacts_pre_filter"] == 2
     assert row["contacts_passing_min_degree"] == 2
     assert row["contacts_emitted"] == 2
@@ -460,6 +461,7 @@ def test_metadata_row_and_summary_dict():
     assert len(row["sha1"]) == 40
     summary = res.summary_dict()
     assert "document" not in summary
+    assert summary["min_seq_separation"] == 1
     assert summary["sequence"] == ["MET", "ALA", "GLY", "LYS", "PHE"]
     assert len(summary["contacts"]) == 2
     # Contacts are in (random) document order; check as a set.


### PR DESCRIPTION
## Summary
- persist `min_seq_separation` in per-row contacts-v1 metadata so generated docs stay self-describing after the definitional seq-sep filter change
- align the README/SPEC/`contacts-v1 view` wording with the actual post-seq-separation meaning of `contacts_pre_filter` and the degree stats
- make `contacts-v1 view` handle the `lowest_included_contact_degree=None` case without crashing

## Testing
- `uv run --project marinfold pytest marinfold/tests/document_structures/contacts_v1/test_generate.py marinfold/tests/document_structures/contacts_v1/test_cli.py -q`