### PR TITLE
docs(agents): region-aware GCS policy + cross-region transfer rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,27 +219,77 @@ tokenizer is "well-known" and pinned by URL elsewhere (e.g.
 `timodonnell/protein-docs-tokenizer@<sha>`) — co-locate it so
 nothing breaks if the source tokenizer URL changes.
 
-### GCS bucket: `marin-us-east5/protein-structure/MarinFold`
+### Cross-region data transfers & the shared Iris cluster
 
-When an experiment needs to dump large eval outputs (raw
+Storage and bandwidth are dominant cost drivers for this project,
+and the marin Iris pools straddle regions and continents — the v5p
+TPU pool spans `{us-central1-a, us-east5-a}`, the CPU pool reaches
+`europe-west4`, and the controller lives in `us-central1-a`. There
+is no single region that "the cluster" is in, so cross-region I/O is
+a default failure mode, not a rare edge case. Treat it as something
+to avoid:
+
+- **Don't stream large data across regions or to the open internet.**
+  Co-locate a job's GCS I/O with its compute zone (see "GCS bucket"
+  below). Stream through `fsspec` rather than copying artifacts to
+  local disk, and never pull more than a few MB across regions in a
+  hot path.
+- **Pin the worker zone** (`--zone`, `ResourceConfig`) so workers
+  land in-region with their data, and prefer in-region preemptible
+  pools over over-requesting on-demand capacity. Over-requesting
+  on-demand workers spills them cross-continent: exp53 asked for a
+  large on-demand CPU pool, spilled to `europe-west4`, and those
+  workers did slow trans-Atlantic reads/writes and became the
+  straggler tail.
+- **A cross-region copy larger than 10 GB needs explicit human
+  sign-off**, regardless of previous instructions. Under that, mirror
+  once into the local region and reference the local copy thereafter
+  (mirrors marin's `TransferBudget` default of 10 GB).
+- **Never use the GCS storage-transfer-service** to move data between
+  regions without explicit user approval — bulk cross-region moves
+  are a real cost event.
+- **Never stop, restart, or bounce the shared Iris cluster** unless
+  the user gives express permission. Other people's jobs run on it.
+
+### GCS bucket: `marin-<region>/protein-structure/MarinFold/` (co-locate with compute)
+
+When an experiment needs to dump large eval/data outputs (raw
 distograms, prediction batches, intermediate parquets) to GCS —
 typically because it ran on TRC via iris and the worker is
-ephemeral — write them under
+ephemeral — write them under the
+`protein-structure/MarinFold/<experiment-name>/` prefix, but in the
+`marin-<region>` bucket **co-located with the zone the job's workers
+actually run in**, not a fixed region:
 
 ```
-gs://marin-us-east5/protein-structure/MarinFold/<experiment-name>/...
+gs://marin-<region>/protein-structure/MarinFold/<experiment-name>/...
 ```
 
-where `<experiment-name>` is informative enough that someone
-scanning the bucket can tell what it is without reading the source
-(e.g.
+- **TPU training / eval** pins to `us-east5-a` (co-located with the
+  `marin-us-east5` checkpoint bucket; the v5p pool is
+  `{us-central1-a, us-east5-a}`) → write to
+  `gs://marin-us-east5/protein-structure/MarinFold/<exp>/`.
+- **CPU data-gen on the Iris cluster** lands in us-central1 /
+  us-central2 (or even Europe if you over-request) → pin the worker
+  zone and write to the matching same-region bucket, e.g.
+  `gs://marin-us-central1/protein-structure/MarinFold/<exp>/`.
+  Writing this output to `marin-us-east5` instead means every worker
+  does a cross-region PUT (exp5 already moved to `marin-us-central1`
+  for exactly this reason).
+- If a single canonical location is genuinely needed, do **one bulk
+  copy after the job completes**, not thousands of streamed
+  cross-region worker PUTs — and respect the > 10 GB sign-off rule
+  above.
+
+Keep the `protein-structure/MarinFold/<experiment-name>/` prefix
+identical across regions, so MarinFold outputs stay co-located by
+convention and the marin team can find them at a glance. Make
+`<experiment-name>` informative enough to recognize without reading
+the source (e.g.
 `exp26/protein-contacts-1_5b-distance-masked-70f8f5-step-49999-foldbench-monomers/`).
-The point is to keep all MarinFold outputs co-located under one
-prefix so the marin team can find them and tell at a glance what
-each subdir is — don't sprinkle MarinFold artifacts across
-`gs://marin-us-east5/eval/...`, `gs://marin-us-east5/checkpoints/...`,
-etc. (those prefixes belong to the marin protein-experiments
-convention, not ours).
+Don't sprinkle MarinFold artifacts across `marin-<region>/eval/...`,
+`marin-<region>/checkpoints/...`, etc. (those prefixes belong to the
+marin protein-experiments convention, not ours).
 
 The same "small artifacts (CSVs, plots) stay in git, large
 artifacts go to durable storage" rule from the HF bucket section

--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ run name. (See `AGENTS.md` "HF bucket" for the splitting policy.)
 — first-class published text / tokenized corpora that levanter
 loads via `hf://datasets/` URIs. Long-tail / in-flight data
 artifacts go to the bucket instead.
-- **GCS** (`gs://marin-us-east5/<...>`) — large intermediate
+- **GCS** (`gs://marin-<region>/<...>`, co-located with the job's
+compute zone — see `AGENTS.md` "GCS bucket") — large intermediate
 artifacts produced by marin's executor (tokenized parquets,
 cached features, predictions).
 - **W&B** (`https://wandb.ai/open-athena/MarinFold`) — training and

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -54,9 +54,9 @@ After the rename to MarinFold, let's put runs at https://wandb.ai/open-athena/Ma
 Large MarinFold experiment artifacts that don't fit in git (raw distograms, prediction batches, intermediate parquets — typically produced by iris jobs on TRC) live under
 
 ```
-gs://marin-us-east5/protein-structure/MarinFold/<experiment-name>/...
+gs://marin-<region>/protein-structure/MarinFold/<experiment-name>/...
 ```
 
-where `<experiment-name>` is descriptive enough to be recognizable to the marin team (e.g. `exp26/protein-contacts-1_5b-distance-masked-70f8f5-step-49999-foldbench-monomers/`). See AGENTS.md "GCS bucket" for the full convention. Small CSVs and plots that feed READMEs still live in the experiment dir's `data/` and `plots/` — GCS is for the big stuff.
+in the `marin-<region>` bucket co-located with the job's compute zone (`marin-us-east5` for us-east5-a TPU train/eval, `marin-us-central1` for CPU data-gen on the Iris cluster), where `<experiment-name>` is descriptive enough to be recognizable to the marin team (e.g. `exp26/protein-contacts-1_5b-distance-masked-70f8f5-step-49999-foldbench-monomers/`). See AGENTS.md "GCS bucket" and "Cross-region data transfers" for the full convention. Small CSVs and plots that feed READMEs still live in the experiment dir's `data/` and `plots/` — GCS is for the big stuff.
 
 

--- a/experiments/AGENTS.md
+++ b/experiments/AGENTS.md
@@ -50,8 +50,11 @@ whichever fits the work.
 
 2. **Don't commit ad-hoc binaries.** Commit small CSVs to `data/` and
    plots to `plots/`. Large model weights, intermediate parquets,
-   prediction dumps, etc. go to GCS (`gs://marin-us-east5/...`) or
-   HuggingFace (`buckets/open-athena/MarinFold` for checkpoints,
+   prediction dumps, etc. go to GCS (the region-co-located
+   `gs://marin-<region>/protein-structure/MarinFold/...` — write to
+   the bucket matching your job's compute zone; see the root
+   `AGENTS.md` "GCS bucket" rule) or HuggingFace
+   (`buckets/open-athena/MarinFold` for checkpoints,
    `datasets/timodonnell/<name>` for datasets). See the root
    `README.md` for the policy.
 

--- a/models/AGENTS.md
+++ b/models/AGENTS.md
@@ -28,10 +28,14 @@ only.
    should bust the cache when changed — plain dataclass fields are
    ignored by the hasher.
 
-3. **Co-locate TPU with checkpoint bucket.** Pin TPU jobs to
-   `us-east5-a` (or whichever zone matches the bucket region) via
-   `ResourceConfig.with_tpu(..., zone="us-east5-a")`. Cross-region
-   checkpoint I/O is slow and expensive.
+3. **Co-locate compute with its bucket region.** Pin TPU
+   training/eval jobs to `us-east5-a` (matching the `marin-us-east5`
+   checkpoint bucket; the v5p pool is `{us-central1-a, us-east5-a}`)
+   via `ResourceConfig.with_tpu(..., zone="us-east5-a")`. Cross-region
+   checkpoint I/O is slow and expensive. The same co-location rule
+   applies to *every* iris job, not just TPU training — see the root
+   `AGENTS.md` "Cross-region data transfers & the shared Iris cluster"
+   rule.
 
 4. **Tokenizer revisions are pinned.** Always use the `repo@revision`
    suffix in tokenizer names so levanter's cache is keyed by


### PR DESCRIPTION
## Why

We mirror marin's agent conventions, but MarinFold's agent docs were missing marin's **cross-region data-transfer** rules — and the one region rule we *did* have was pointing the wrong way.

marin states these bluntly across its agent docs (links pinned to [marin-community/marin](https://github.com/marin-community/marin) @ `4c326d2`):
- [`AGENTS.md` L47-49](https://github.com/marin-community/marin/blob/4c326d2a71acdeb104c24f3a8ba08c9f5ea98c77/AGENTS.md#L47-L49) — never bounce the Iris cluster without permission; never read/write large data across regions or the open internet; no storage-transfer-service moves.
- [`lib/marin/AGENTS.md` L25](https://github.com/marin-community/marin/blob/4c326d2a71acdeb104c24f3a8ba08c9f5ea98c77/lib/marin/AGENTS.md#L25) — "NEVER load GCS files from across region if they are more than a few MB."
- [`experiments/AGENTS.md` L12-26](https://github.com/marin-community/marin/blob/4c326d2a71acdeb104c24f3a8ba08c9f5ea98c77/experiments/AGENTS.md#L12-L26) — region-aware paths; cross-region copies up to 10 GB allowed, **>10 GB needs explicit human sign-off** (`TransferBudget`).
- [`docs/tutorials/storage-bucket.md` L16-23](https://github.com/marin-community/marin/blob/4c326d2a71acdeb104c24f3a8ba08c9f5ea98c77/docs/tutorials/storage-bucket.md#L16-L23) — pick a bucket region matching your compute.

MarinFold had a good TPU-only co-location rule (`models/AGENTS.md` #3) but **no general principle**, and its root `AGENTS.md` "GCS bucket" rule mandated `gs://marin-us-east5/...` for *all* output. The marin Iris pools straddle regions/continents (v5p TPUs in `{us-central1-a, us-east5-a}`; CPU pool reaches `europe-west4`; controller in `us-central1-a` — per [`lib/iris/config/marin.yaml`](https://github.com/marin-community/marin/blob/4c326d2a71acdeb104c24f3a8ba08c9f5ea98c77/lib/iris/config/marin.yaml)), so that blanket mandate is **cross-region for CPU data-gen jobs** — exp53 spilled on-demand workers to `europe-west4` doing trans-Atlantic I/O, and exp5 already deviated to `marin-us-central1`.

## What changed

Chosen direction: **region-aware co-location** (write GCS output to the `marin-<region>` bucket matching each job's compute zone, under the shared `protein-structure/MarinFold/<exp>/` prefix).

- **`AGENTS.md`** — new "Cross-region data transfers & the shared Iris cluster" hard rule; rewrite "GCS bucket" to be region-co-located (us-east5 for TPU train/eval; us-central1 for CPU data-gen) with a one-bulk-copy-after escape hatch and the >10 GB sign-off threshold.
- **`experiments/AGENTS.md`, `RESOURCES.md`, `README.md`** — point at `gs://marin-<region>/protein-structure/MarinFold/` instead of hardcoded us-east5.
- **`models/AGENTS.md`** — generalize rule #3 from TPU-only to every iris job; cross-reference the new root rule.

Docs-only; no code paths touched. Existing TPU training/eval behavior (pin us-east5-a → write marin-us-east5) is unchanged — it's now stated as the TPU case of a general rule rather than a universal mandate. The marin rules cited above were verified present on `marin-community/marin@main` (`4c326d2`), not just the local `protein-training-1b` checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
