### PR TITLE
docs: clarify region-aware bucket examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,17 +265,20 @@ actually run in**, not a fixed region:
 gs://marin-<region>/protein-structure/MarinFold/<experiment-name>/...
 ```
 
-- **TPU training / eval** pins to `us-east5-a` (co-located with the
-  `marin-us-east5` checkpoint bucket; the v5p pool is
-  `{us-central1-a, us-east5-a}`) → write to
-  `gs://marin-us-east5/protein-structure/MarinFold/<exp>/`.
-- **CPU data-gen on the Iris cluster** lands in us-central1 /
-  us-central2 (or even Europe if you over-request) → pin the worker
-  zone and write to the matching same-region bucket, e.g.
-  `gs://marin-us-central1/protein-structure/MarinFold/<exp>/`.
-  Writing this output to `marin-us-east5` instead means every worker
-  does a cross-region PUT (exp5 already moved to `marin-us-central1`
-  for exactly this reason).
+- **TPU training / eval** follows the same rule: pin the TPU zone,
+  then write to the matching `marin-<region>` bucket. For our
+  current v5p-based MarinFold jobs that usually means `us-east5-a`
+  and `gs://marin-us-east5/protein-structure/MarinFold/<exp>/`, but
+  that is an example, not a global rule.
+- **CPU data-gen on the Iris cluster** likewise depends on where the
+  workers actually land: us-central1 / us-central2 are common, but
+  fallback pools can spill farther. Pin the worker zone and write to
+  the matching same-region bucket, e.g.
+  `gs://marin-us-central1/protein-structure/MarinFold/<exp>/` for a
+  job pinned to `us-central1-a`. Writing that output to a different
+  region (for example `marin-us-east5`) means every worker does a
+  cross-region PUT; exp5 already moved to `marin-us-central1` for
+  exactly this reason.
 - If a single canonical location is genuinely needed, do **one bulk
   copy after the job completes**, not thousands of streamed
   cross-region worker PUTs — and respect the > 10 GB sign-off rule

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -57,6 +57,14 @@ Large MarinFold experiment artifacts that don't fit in git (raw distograms, pred
 gs://marin-<region>/protein-structure/MarinFold/<experiment-name>/...
 ```
 
-in the `marin-<region>` bucket co-located with the job's compute zone (`marin-us-east5` for us-east5-a TPU train/eval, `marin-us-central1` for CPU data-gen on the Iris cluster), where `<experiment-name>` is descriptive enough to be recognizable to the marin team (e.g. `exp26/protein-contacts-1_5b-distance-masked-70f8f5-step-49999-foldbench-monomers/`). See AGENTS.md "GCS bucket" and "Cross-region data transfers" for the full convention. Small CSVs and plots that feed READMEs still live in the experiment dir's `data/` and `plots/` — GCS is for the big stuff.
-
+in the `marin-<region>` bucket matching the job's compute zone. For
+example, our current v5p TPU train/eval jobs often use
+`marin-us-east5`, while a CPU data-gen job pinned to `us-central1-a`
+should use `marin-us-central1`; the region follows the pinned compute,
+not the other way around. `<experiment-name>` should be descriptive
+enough to be recognizable to the marin team (e.g.
+`exp26/protein-contacts-1_5b-distance-masked-70f8f5-step-49999-foldbench-monomers/`).
+See AGENTS.md "GCS bucket" and "Cross-region data transfers" for the
+full convention. Small CSVs and plots that feed READMEs still live in
+the experiment dir's `data/` and `plots/` — GCS is for the big stuff.
 

--- a/models/AGENTS.md
+++ b/models/AGENTS.md
@@ -29,13 +29,15 @@ only.
    ignored by the hasher.
 
 3. **Co-locate compute with its bucket region.** Pin TPU
-   training/eval jobs to `us-east5-a` (matching the `marin-us-east5`
-   checkpoint bucket; the v5p pool is `{us-central1-a, us-east5-a}`)
-   via `ResourceConfig.with_tpu(..., zone="us-east5-a")`. Cross-region
-   checkpoint I/O is slow and expensive. The same co-location rule
-   applies to *every* iris job, not just TPU training — see the root
-   `AGENTS.md` "Cross-region data transfers & the shared Iris cluster"
-   rule.
+   training/eval jobs to the zone whose regional bucket you intend to
+   use, then write checkpoints and large artifacts to the matching
+   `marin-<region>` bucket. For our current v5p-based MarinFold jobs
+   that usually means `ResourceConfig.with_tpu(..., zone="us-east5-a")`
+   together with `marin-us-east5`, but if a job is pinned elsewhere
+   the bucket should move with it. Cross-region checkpoint I/O is slow
+   and expensive. The same co-location rule applies to *every* iris
+   job, not just TPU training — see the root `AGENTS.md`
+   "Cross-region data transfers & the shared Iris cluster" rule.
 
 4. **Tokenizer revisions are pinned.** Always use the `repo@revision`
    suffix in tokenizer names so levanter's cache is keyed by


### PR DESCRIPTION
## Why

Follow-up to #60.

That PR introduced the right top-level policy, but two summaries still read like hardcoded region rules:
- the root/models guidance still implied TPU train/eval always uses `us-east5`
- `RESOURCES.md` still implied CPU data-gen on Iris always uses `marin-us-central1`

That undercut the new "bucket matches pinned compute region" rule and could steer future jobs back into cross-region I/O.

## What changed

- clarify in `AGENTS.md` that `us-east5-a` + `marin-us-east5` is the current v5p example, not the universal TPU rule
- clarify in `models/AGENTS.md` that the bucket should move with the pinned TPU zone
- rewrite the `RESOURCES.md` summary so `marin-us-east5` and `marin-us-central1` are examples, and explicitly state that region follows pinned compute

## Impact

- preserves the current v5p/us-east5 workflow where it is actually intended
- avoids documenting cross-region bucket choices as defaults for future TPU or CPU jobs in other zones

## Validation

- docs-only change; no automated tests relevant
- reviewed the final diff and rescanned the affected docs for consistent region-aware wording
