### PR TITLE
exp67: record published HF-bucket location of the final model

### DIFF
--- a/experiments/exp67_models_contacts_v1_1_5b/README.md
+++ b/experiments/exp67_models_contacts_v1_1_5b/README.md
@@ -227,6 +227,18 @@ run ran to completion** (all 12,000 steps, `SUCCEEDED`).
     co-located). **The final loadable model is `hf/step-11999/`** — no manual
     export needed (the `export_*.py` script remains as a re-export path).
 
+**Published to the open-athena HF bucket** (final checkpoint, 2026-06-15):
+```
+hf://buckets/open-athena/MarinFold/checkpoints/protein-contacts-1_5b-3.5e-4-contacts-v1-unmasked-3b5cf2/hf/step-11999/
+```
+(7 files, 5.89 GB; weights + tokenizer co-located; follows the
+`checkpoints/<wandb-run-name>-<id>/hf/step-<N>/` convention.) HF buckets aren't
+`HfFileSystem`-addressable, so consume in two steps:
+```bash
+hf buckets cp -r hf://buckets/open-athena/MarinFold/checkpoints/protein-contacts-1_5b-3.5e-4-contacts-v1-unmasked-3b5cf2/hf/step-11999 ./model
+python -c "from transformers import AutoModelForCausalLM, AutoTokenizer; AutoModelForCausalLM.from_pretrained('./model'); AutoTokenizer.from_pretrained('./model')"
+```
+
 ## Conclusion
 
 The quick/simple 1.5B contacts-v1 run trained cleanly end-to-end: train loss

--- a/history/runs/20260610_exp67_models_contacts_v1_1_5b_protein_contacts_1_5b_3_5e_4_contacts_v1_unmasked.md
+++ b/history/runs/20260610_exp67_models_contacts_v1_1_5b_protein_contacts_1_5b_3_5e_4_contacts_v1_unmasked.md
@@ -38,8 +38,10 @@ pending stalls on v5p capacity). Artifacts under
 `gs://marin-us-east5/protein-structure/MarinFold/exp67_contacts_v1_1_5b/checkpoints/protein-contacts-1_5b-3.5e-4-contacts-v1-unmasked-3b5cf2/`:
 levanter `checkpoints/step-{2000,4000,6000,8000,10000,11999}` + auto HF exports
 `hf/step-{…,11999}` (safetensors + tokenizer co-located). Final loadable model:
-`hf/step-11999/`. Follow-up: downstream contact-recapitulation eval vs the prior
-contacts-and-distances-v1 1.5B.
+`hf/step-11999/`. **Published to the open-athena HF bucket (2026-06-15):**
+`hf://buckets/open-athena/MarinFold/checkpoints/protein-contacts-1_5b-3.5e-4-contacts-v1-unmasked-3b5cf2/hf/step-11999/`
+(7 files, 5.89 GB, weights + tokenizer co-located). Follow-up: downstream
+contact-recapitulation eval vs the prior contacts-and-distances-v1 1.5B.
 
 ## Detailed plan
 


### PR DESCRIPTION
Small follow-up to the (merged) #70: the final HF model was pushed to the open-athena HF bucket, so this records where it lives.

**Published:**
```
hf://buckets/open-athena/MarinFold/checkpoints/protein-contacts-1_5b-3.5e-4-contacts-v1-unmasked-3b5cf2/hf/step-11999/
```
7 files, 5.89 GB — `config.json` + 2 safetensors shards + index + the contacts-v1 tokenizer co-located (tokenizer-with-model hard rule). Follows the `checkpoints/<wandb-run-name>-<id>/hf/step-<N>/` convention (matches the existing `…-distance-masked-70f8f5/` run).

Updates the experiment README **Results** and the run-history outcome with the path + the 2-step bucket-consume snippet (HF buckets aren't `HfFileSystem`-addressable).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)