### PR TITLE
Agent docs and skills to make performant, one-shot Zephyr pipelines.

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -17,6 +17,7 @@ The convention is borrowed from `marin-community/marin`'s
 |---|---|---|
 | [babysit-job](babysit-job/SKILL.md) | Monitor an Iris job, recover on failure | ported from marin |
 | [babysit-zephyr](babysit-zephyr/SKILL.md) | Same, for Zephyr pipeline jobs | ported from marin |
+| [zephyr-pipeline-performance](zephyr-pipeline-performance/SKILL.md) | Write a Zephyr/Iris pipeline that finishes in minutes, not hours: the five decisions that dominate wall-clock + the I/O traps that silently destroy it. Read before drafting any new `exp<N>_data_*/cli.py`. | MarinFold-native, distilled from exp5 + exp53 |
 
 ## Adapting marin skills
 

--- a/.agents/skills/zephyr-pipeline-performance/SKILL.md
+++ b/.agents/skills/zephyr-pipeline-performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zephyr-pipeline-performance
-description: Write a Zephyr/Iris data-generation pipeline that finishes in minutes, not hours. Use when authoring or reviewing an `exp<N>_data_*/cli.py` (or any `map_shard`-based job that fetches per-row inputs and emits parquet). Covers the per-row / per-shard / per-worker / per-job decisions that separate an 8-minute run from an overnight one.
+description: Write a Zephyr/Iris data-generation pipeline that finishes in minutes, not hours. Use when authoring or reviewing an `exp<N>_data_*/cli.py` (or any `map_shard`-based job that fetches per-row inputs and emits parquet). Covers the per-row / per-shard / per-worker / per-job decisions that separate a fits-in-budget run from an overnight one.
 ---
 
 # Skill: write performant Zephyr pipelines
@@ -11,19 +11,26 @@ are unobvious from the marin-zephyr docs because the costs aren't local —
 they show up as straggler tails, silently-truncated reads, or cluster bills,
 not as wrong output.
 
-This skill captures the lessons from two real MarinFold pipelines that
+This skill draws on lessons from two real MarinFold pipelines that
 chose differently:
 
-* [`experiments/exp5_data_contacts_and_distances_v2_zephyr/`](../../../experiments/exp5_data_contacts_and_distances_v2_zephyr/) —
-  1.6 M structures, ~8 min wall-clock end-to-end on Iris.
+* `experiments/exp5_data_contacts_and_distances_v2_zephyr/` —
+  1.6 M structures. The README's success criterion documents a prior
+  `gcs_uri`-mode production run (without intra-shard concurrency) at
+  **≤ 8 min wall-clock**; the current shape adds intra-shard threading
+  on top, so wall-clock should be no worse than that bound. **exp5
+  is currently on a PR branch, not yet on `main`** — if you need to
+  read its code, locate the PR via `gh pr list` and check it out
+  locally (or browse on github.com).
 * [`experiments/exp53_data_contacts_v1_zephyr/`](../../../experiments/exp53_data_contacts_v1_zephyr/) —
-  4.2 M structures (pyconfind-heavy), ~31 min projected after two hard-won fixes.
-  The pre-fix version of exp53 (commits prior to
-  [`43a0535`](https://github.com/Open-Athena/MarinFold/commit/43a0535)
-  and [`daa18e1`](https://github.com/Open-Athena/MarinFold/commit/daa18e1))
-  silently dropped 98 % of rows and re-parsed a multi-second per-worker
-  setup every shard — translating into hours of cluster wall-clock for the
-  same output.
+  4.2 M structures (pyconfind-heavy). Two hard-won fixes mid-development
+  prevented this one from running for many cluster-hours: the
+  rotamer-library memoization
+  ([`daa18e1`](https://github.com/Open-Athena/MarinFold/commit/daa18e1))
+  and the gzip-truncation fix
+  ([`43a0535`](https://github.com/Open-Athena/MarinFold/commit/43a0535))
+  — without them, a smoke test produced only 2/100 valid documents.
+  Both lessons are documented as patterns below.
 
 When you're done, your pipeline should clear every box in the
 [Pre-launch checklist](#pre-launch-checklist) at the end of this skill.
@@ -35,7 +42,10 @@ When you're done, your pipeline should clear every box in the
 1. **Inside `map_shard`, run a `ThreadPoolExecutor` around the per-row
    fetch+parse.** GCS GETs are ~30–80 ms; gemmi parse releases the GIL.
    Threading them is the single biggest per-shard speedup — exp5's prior
-   sequential version landed at ~128 s/shard; threaded landed at ~few s.
+   sequential version landed at ~128 s/shard; threaded should drop well
+   below that (estimated low-single-digit seconds at fetch-concurrency
+   32 over ~2,000 rows, but actual cluster wall-clock not yet
+   re-measured).
 2. **`--worker-cpu 1`, scale via `--max-workers`.** Per-shard CPU is
    single-threaded Python once the in-shard thread pool overlaps the I/O.
    Asking for more cores per worker wastes cluster capacity.
@@ -98,10 +108,13 @@ def generate_shard(items, shard_info, *, cfg, fetch_concurrency=32, ...):
     )
 ```
 
-**Default `--fetch-concurrency=32`** is well-calibrated for 30–80 ms GCS
-GETs and ~6 ms of CPU per row. Bump it if your CPU step is heavier (e.g.
-pyconfind-based contact computation: exp53 still uses 32, but its CPU
-dominates so the threads matter less).
+**Default `--fetch-concurrency=32`** is well-calibrated for the common
+case where the per-row GCS GET (~30–80 ms) is an order of magnitude
+larger than the per-row CPU step. If your CPU step is heavier (e.g.
+pyconfind-based contact computation in exp53, where per-doc CPU
+dominates), threading still helps but its marginal effect shrinks —
+the right concurrency knob is then closer to the worker's effective
+core count than to the I/O latency ratio.
 
 If you have *no* per-row I/O (inline cif text in the manifest), skip the
 helper — there's nothing to overlap and a thread pool is pure overhead.
@@ -162,7 +175,7 @@ shards-per-worker is a **41-hour cluster bill** if you do it per shard;
 The `ZephyrContext` / Iris `job run` call is where you decide how the
 cluster spends its time. Two rules dominate.
 
-### `--worker-cpu 1`, scale via `--max-workers`
+### 1. `--worker-cpu 1`, scale via `--max-workers`
 
 Per-shard CPU is single-threaded Python once the in-shard thread pool
 overlaps the I/O. A worker with 4 CPUs just leaves 3 idle. Use the smallest
@@ -183,7 +196,7 @@ Note the *two* cpu/memory pairs: the **outer** `--cpu`/`--memory` on
 is wasteful but harmless; overspending on the workers multiplies by 500+
 and is not.
 
-### Pin `--region`, request `--preemptible`
+### 2. Pin `--region`, request `--preemptible`
 
 The shared marin Iris cluster straddles regions and continents (see the
 project root [`AGENTS.md`](../../../AGENTS.md) "Cross-region data transfers
@@ -221,7 +234,7 @@ exp53's
 added these knobs after the first full run got a multi-hour straggler tail
 from cross-continent on-demand spills.
 
-### Match output bucket to the cluster's region
+### 3. Match output bucket to the cluster's region
 
 `gs://marin-<region>/protein-structure/MarinFold/<exp>/` — the bucket
 **must** be in the same region as the workers, or every per-row PUT is a
@@ -437,10 +450,13 @@ requester-pays issue, the cross-region spill, the per-worker init bug.
 Run it on every change; don't skip it because "the local tests passed."
 
 Per-doc latency from the smoke is what you use to project full-run
-wall-clock: `n_docs / (workers × docs_per_sec_per_worker)`. exp5 measured
-~6 ms/doc → 1.6 M docs / (512 workers × 167 docs/s) ≈ 19 s of compute
-(actual wall-clock ~8 min with overhead). exp53 measured ~225 ms/doc
-(pyconfind-heavy) → 4.2 M docs / (512 × 4.45) ≈ 31 min.
+wall-clock: `n_docs / (workers × docs_per_sec_per_worker)`. **Treat
+this as an upper-bound estimate, not a guarantee** — startup overhead,
+preemption retries, straggler tails, and per-worker init costs all
+land on top of the per-doc rate, and the gap can be 2–5×. The
+projection's job is to flag "this is hours, not minutes" before you
+spend the cluster time finding out, not to predict the wall-clock to
+the minute.
 
 ---
 
@@ -514,10 +530,11 @@ gen_ms = 1000 * (time.perf_counter() - t) / N
 # which is itself the finding — something in the glue is non-trivial).
 ```
 
-This is how exp5's perf-engineering thread (which Tim ultimately rejected
-in favor of one source of truth — but the *measurement* was sound)
-narrowed the 9.5 → 5.7 ms/doc journey: each iteration measured parse and
-generate separately, so we knew which half a given change moved.
+Concretely: if your end-to-end is 7 ms/doc and your isolated parse +
+generate sum to 5 ms/doc, the missing 2 ms is somewhere in the glue
+(per-row dataclass churn, dict construction, JSON serialization,
+etc.) and that's where the next optimization opportunity lives —
+not in parse or generate themselves.
 
 ### 4. Multi-trial measurement; report min + median
 
@@ -552,12 +569,16 @@ write the prediction down. Then measure. Three possible outcomes:
   between expected and measured is itself a finding about where the
   cost actually lives.
 
-The exp5 perf thread had all three: the two-phase distance loop was
-predicted to save 0.3 ms/doc; measurement showed it broke even (gains
-from vectorization were eaten by Python-side plan-list construction).
-That's a "rollback" outcome — the code went into a different branch, and
-the *finding* (per-element numpy access has fixed overhead comparable to
-~12 scalar Python ops) made it into the surrounding decisions.
+A worked example of the "rollback" branch worth internalizing:
+splitting a hot Python loop into "pre-compute integer indices, then do
+the math in vectorized numpy" *sounds* faster, but for batch sizes in
+the low thousands, per-element numpy access has fixed overhead
+comparable to ~12 scalar Python ops — and the gains from vectorization
+get eaten by the Python-side cost of building the plan arrays. The
+right move when the measurement comes back flat is to revert, even
+when the rewrite looks more elegant. The finding (that there's a
+crossover point below which Python beats numpy for per-element
+access) is the keeper; the rewrite isn't.
 
 ### When to stop
 

--- a/.agents/skills/zephyr-pipeline-performance/SKILL.md
+++ b/.agents/skills/zephyr-pipeline-performance/SKILL.md
@@ -556,7 +556,7 @@ Use **min** as the "true" cost (least noise added) and **median** as
 environment is variable and worth fixing before continuing: background
 processes, disk cache state, and so on.
 
-### 5. Hypothesis-driven changes: predict, then measure, then report honestly
+### 5. Hypothesis-driven changes: predict, then measure, then report
 
 For each optimization, **predict the win before implementing it** and
 write the prediction down. Then measure. There are three possible

--- a/.agents/skills/zephyr-pipeline-performance/SKILL.md
+++ b/.agents/skills/zephyr-pipeline-performance/SKILL.md
@@ -1,0 +1,646 @@
+---
+name: zephyr-pipeline-performance
+description: Write a Zephyr/Iris data-generation pipeline that finishes in minutes, not hours. Use when authoring or reviewing an `exp<N>_data_*/cli.py` (or any `map_shard`-based job that fetches per-row inputs and emits parquet). Covers the per-row / per-shard / per-worker / per-job decisions that separate an 8-minute run from an overnight one.
+---
+
+# Skill: write performant Zephyr pipelines
+
+A Zephyr pipeline that *works* and one that *finishes in budget* differ on a
+small set of decisions you make once at the top of `cli.py`. Most of them
+are unobvious from the marin-zephyr docs because the costs aren't local —
+they show up as straggler tails, silently-truncated reads, or cluster bills,
+not as wrong output.
+
+This skill captures the lessons from two real MarinFold pipelines that
+chose differently:
+
+* [`experiments/exp5_data_contacts_and_distances_v2_zephyr/`](../../../experiments/exp5_data_contacts_and_distances_v2_zephyr/) —
+  1.6 M structures, ~8 min wall-clock end-to-end on Iris.
+* [`experiments/exp53_data_contacts_v1_zephyr/`](../../../experiments/exp53_data_contacts_v1_zephyr/) —
+  4.2 M structures (pyconfind-heavy), ~31 min projected after two hard-won fixes.
+  The pre-fix version of exp53 (commits prior to
+  [`43a0535`](https://github.com/Open-Athena/MarinFold/commit/43a0535)
+  and [`daa18e1`](https://github.com/Open-Athena/MarinFold/commit/daa18e1))
+  silently dropped 98 % of rows and re-parsed a multi-second per-worker
+  setup every shard — translating into hours of cluster wall-clock for the
+  same output.
+
+When you're done, your pipeline should clear every box in the
+[Pre-launch checklist](#pre-launch-checklist) at the end of this skill.
+
+---
+
+## TL;DR — the five decisions that dominate
+
+1. **Inside `map_shard`, run a `ThreadPoolExecutor` around the per-row
+   fetch+parse.** GCS GETs are ~30–80 ms; gemmi parse releases the GIL.
+   Threading them is the single biggest per-shard speedup — exp5's prior
+   sequential version landed at ~128 s/shard; threaded landed at ~few s.
+2. **`--worker-cpu 1`, scale via `--max-workers`.** Per-shard CPU is
+   single-threaded Python once the in-shard thread pool overlaps the I/O.
+   Asking for more cores per worker wastes cluster capacity.
+3. **Pin `--region` and use `--preemptible`.** Without region pinning, an
+   over-requested on-demand pool spills cross-continent (exp53 spilled to
+   `europe-west4` and got a multi-hour straggler tail). With preemptible
+   workers you get more in-region capacity at lower cost; Zephyr retries
+   preemptions.
+4. **Fetch per-row objects via
+   `marinfold.document_structures.io.read_object_bytes`** (a full
+   `cat_file` GET), not `fsspec.open().read()`. GCS objects with
+   `Content-Encoding: gzip` report compressed size in `Content-Length`;
+   a size-based read truncates large objects mid-content. The bug is
+   silent — your parser fails downstream with a confusing
+   "unexpected end" error, not an obvious I/O fault.
+5. **Source per-row data via the manifest's `gcs_uri` pointer column,
+   not the inline `cif_content` column.** Datasets like afdb-1.6M ship
+   every cif twice: a one-line `gcs_uri` pointer to AFDB's public GCS
+   bucket, *and* the full inline mmCIF text as `cif_content`. Reading
+   `gcs_uri` means a small fan-out of in-cloud (often in-region) GCS
+   GETs; reading `cif_content` means every worker streams the bulk
+   mmCIF back from HuggingFace cross-cloud per shard. Same downstream
+   output, ~2,000× less manifest I/O plus a fundamentally cheaper
+   per-row fetch. Default to `--cif-uri-column=gcs_uri`; reserve
+   `--cif-text-column` for local testing or inputs without a URI column.
+
+The rest of this skill walks through each layer of the pipeline (per-row →
+per-shard → per-job → per-output) with the code patterns these decisions
+imply.
+
+---
+
+## Per-shard: thread the I/O, memoize the heavy init
+
+A Zephyr `map_shard` body runs once per input shard. Two things matter:
+
+### 1. ThreadPoolExecutor inside `map_shard` for per-row fetches
+
+Without it, your per-shard wall-clock is the **sum** of per-row GCS GETs
+(sequential I/O). With it, fetches overlap each other *and* overlap the
+CPU work of rows already fetched. gemmi (and pyconfind) release the GIL
+during the C++ parse, so the threads make real progress in parallel.
+
+The pattern is captured as
+[`marinfold.document_structures.io.thread_per_row_in_shard`](../../../marinfold/marinfold/document_structures/io.py)
+so each new pipeline gets the correctness details (pool size cap,
+`pool.map` for input-order output, `None`-skip for failed rows) by
+construction rather than re-deriving them:
+
+```python
+from functools import partial
+from marinfold.document_structures.io import thread_per_row_in_shard
+
+def generate_shard(items, shard_info, *, cfg, fetch_concurrency=32, ...):
+    worker = partial(_generate_doc_for_row, cfg=cfg, ...)
+    yield from thread_per_row_in_shard(
+        items, worker=worker,
+        fetch_concurrency=fetch_concurrency,
+        thread_name_prefix="exp<N>-fetch",
+    )
+```
+
+**Default `--fetch-concurrency=32`** is well-calibrated for 30–80 ms GCS
+GETs and ~6 ms of CPU per row. Bump it if your CPU step is heavier (e.g.
+pyconfind-based contact computation: exp53 still uses 32, but its CPU
+dominates so the threads matter less).
+
+If you have *no* per-row I/O (inline cif text in the manifest), skip the
+helper — there's nothing to overlap and a thread pool is pure overhead.
+exp53's `generate_shard` shows the branch:
+
+```python
+if cif_text_column is not None:
+    # Inline path: no I/O to overlap, run sequentially.
+    for row in items:
+        out = worker(row)
+        if out is not None:
+            yield out
+    return
+# URI path: thread the fetches via the shared helper.
+yield from thread_per_row_in_shard(items, worker=worker, ...)
+```
+
+### 2. Memoize per-worker init in a module global
+
+A Zephyr worker process serves many shards over its lifetime. If your
+algorithm requires a heavy per-process resource (parsed reference library,
+loaded model, JIT-compiled kernel), **do not initialize it per shard or per
+row** — cache it in a module-level global so it's parsed once per worker.
+
+exp53's
+[commit `daa18e1`](https://github.com/Open-Athena/MarinFold/commit/daa18e1)
+is the canonical example: pyconfind's rotamer library takes tens of seconds
+to parse. Before the fix, every shard paid that cost. After:
+
+```python
+_ROTAMER_UNSET: Any = object()
+_ROTAMER_LIBRARY: Any = _ROTAMER_UNSET
+
+def _load_rotamer_library() -> Any | None:
+    global _ROTAMER_LIBRARY
+    if _ROTAMER_LIBRARY is not _ROTAMER_UNSET:
+        return _ROTAMER_LIBRARY  # second-and-onward shards: instant
+    try:
+        from pyconfind import load_library, cached_rotamer_library
+        _ROTAMER_LIBRARY = load_library(cached_rotamer_library())
+    except Exception as exc:
+        warnings.warn(f"preload failed ({exc}); per-call load", stacklevel=2)
+        _ROTAMER_LIBRARY = None
+    return _ROTAMER_LIBRARY
+```
+
+Use a sentinel (`_ROTAMER_UNSET`) rather than `None`, so the failure path
+(genuinely returned `None`) caches and doesn't retry on every call.
+
+This pattern compounds: a 30 s per-worker init across 500 workers × 100
+shards-per-worker is a **41-hour cluster bill** if you do it per shard;
+30 s × 500 once-per-worker is a 15-second blip.
+
+---
+
+## Per-job: cluster resources
+
+The `ZephyrContext` / Iris `job run` call is where you decide how the
+cluster spends its time. Two rules dominate.
+
+### `--worker-cpu 1`, scale via `--max-workers`
+
+Per-shard CPU is single-threaded Python once the in-shard thread pool
+overlaps the I/O. A worker with 4 CPUs just leaves 3 idle. Use the smallest
+worker that fits one Python process + your peak memory, then scale out:
+
+```bash
+uv run iris --cluster=marin job run --cpu 1 --memory 2GB -- \
+    python cli.py generate \
+        --worker-cpu 1 --worker-memory 4g --worker-disk 32g \
+        --max-workers 512 --fetch-concurrency 32 \
+        ...
+```
+
+Note the *two* cpu/memory pairs: the **outer** `--cpu`/`--memory` on
+`iris job run` size the **launcher container** (tiny); the **inner**
+`--worker-cpu`/`--worker-memory` (consumed by `ZephyrContext`) size each
+**worker pod**. They're not the same thing and overspending on the launcher
+is wasteful but harmless; overspending on the workers multiplies by 500+
+and is not.
+
+### Pin `--region`, request `--preemptible`
+
+The shared marin Iris cluster straddles regions and continents (see the
+project root [`AGENTS.md`](../../../AGENTS.md) "Cross-region data transfers
+& the shared Iris cluster"). Without pinning, large worker pools spill to
+fallback regions and your job's tail latency becomes "the slowest worker
+in `europe-west4` dragged across the Atlantic":
+
+```python
+ctx = ZephyrContext(
+    max_workers=args.max_workers,
+    resources=ResourceConfig(
+        cpu=args.worker_cpu,
+        ram=args.worker_memory,
+        disk=args.worker_disk,
+        regions=[args.region] if args.region else None,   # pin
+        preemptible=args.preemptible,                      # cheaper + more capacity
+    ),
+)
+```
+
+```python
+# argparse:
+p.add_argument("--region", type=str, default="us-central1",
+               help="Pin workers to this GCP region (match the iris cluster) "
+                    "so a large pool can't spill cross-region/continent.")
+p.add_argument("--preemptible", action=argparse.BooleanOptionalAction,
+               default=True,
+               help="Request preemptible/spot workers — far more in-region "
+                    "capacity + cheaper than on-demand; zephyr retries "
+                    "preemptions.")
+```
+
+exp53's
+[commit `7c19d5d`](https://github.com/Open-Athena/MarinFold/commit/7c19d5d)
+added these knobs after the first full run got a multi-hour straggler tail
+from cross-continent on-demand spills.
+
+### Match output bucket to the cluster's region
+
+`gs://marin-<region>/protein-structure/MarinFold/<exp>/` — the bucket
+**must** be in the same region as the workers, or every per-row PUT is a
+cross-region transfer (cost + latency). For the Iris cluster's
+`us-central1` default, that's `gs://marin-us-central1/...`. See the root
+[`AGENTS.md`](../../../AGENTS.md) "GCS bucket" section.
+
+---
+
+## Per-input: source via `gcs_uri`, project columns aggressively
+
+Two levers, in order of impact.
+
+### 1. Pick the right data-source column
+
+afdb-1.6M (and other AFDB-derived manifests on HuggingFace) ship every
+cif *twice*: as a one-line `gcs_uri` pointer to the public AFDB GCS
+bucket, **and** as the full inline mmCIF text in a `cif_content` column.
+
+The choice between them dominates everything else in this section:
+
+- **`gcs_uri`** → workers fetch from AFDB's GCS bucket directly. For a
+  GCP-based cluster (the marin Iris pool), that's in-cloud and usually
+  in-region — fast network, no cross-cloud egress charges. Reading the
+  manifest costs ~160 KB/shard (just the URI strings + provenance).
+- **`cif_content`** → every worker reads the bulky inline mmCIF back
+  from HuggingFace, cross-cloud, per row. Reading the manifest costs
+  ~70 MB/shard (~2,000× more I/O), and that bulk crosses the open
+  internet rather than staying inside GCP.
+
+Default to `--cif-uri-column=gcs_uri`. Reserve `--cif-text-column` for
+local tests (where inline cif keeps the path off the network entirely)
+or for input manifests that don't ship a URI column.
+
+A subtle related trap: if you have to enumerate the HF manifest's
+*shards* up front, do it through an authenticated `HfFileSystem` with a
+pre-warmed dircache + the `/resolve/` CDN URLs (one API call to list, N
+CDN reads for the data). Per-shard `hf://` reads make one `paths-info`
+API call each, which blows HF's 3,000 req / 5 min quota on a
+multi-thousand-shard manifest. See the "HuggingFace API quota" trap
+below.
+
+### 2. Read only the columns you need
+
+Parquet is columnar.
+`Dataset.from_files(input).load_parquet(columns=…)` reads only the
+requested columns. With `gcs_uri` picked, the minimal set is
+`[entry_id, gcs_uri, <optional passthrough>]` — ~160 KB/shard. Reading
+the full row (including `cif_content`) is ~70 MB/shard regardless of
+which fetch path you take downstream — column projection is what
+*activates* the data-source win.
+
+The exp5 pattern: peek the manifest schema once at submission time,
+decide which optional passthrough columns are present, then pass the
+closed-over list to every shard's load:
+
+```python
+_OPTIONAL_PASSTHROUGH = ("split", "seq_cluster_id", "struct_cluster_id",
+                         "uniprot_accession", "tax_id", "organism_name", "gcs_uri")
+
+def _resolve_input_columns(input_path, cif_col):
+    """Peek the first parquet file, intersect with desired columns."""
+    import pyarrow.parquet as pq
+    fs, _ = fsspec.core.url_to_fs(input_path)
+    matches = sorted(fs.glob(input_path))
+    with fsspec.open(fs.unstrip_protocol(matches[0]), "rb") as f:
+        present = set(pq.ParquetFile(f).schema_arrow.names)
+    # Validate required + collect optional passthrough.
+    if "entry_id" not in present or cif_col not in present:
+        raise ValueError(...)
+    passthrough = [c for c in _OPTIONAL_PASSTHROUGH if c in present]
+    columns = ["entry_id", cif_col] + [c for c in passthrough if c not in ("entry_id", cif_col)]
+    return columns, passthrough
+```
+
+The schema peek happens once on the controller, not 1,000 × on workers.
+The same column list is used for every shard so the output schema is
+stable across shards (downstream readers can concatenate without
+schema-merging).
+
+---
+
+## Per-output: one parquet per input shard
+
+Use a `{shard}` placeholder in `--out` so Zephyr writes one output file
+per input shard:
+
+```bash
+--out "gs://marin-us-central1/.../corpus-{shard:05d}-of-{total:05d}.parquet"
+```
+
+This is load-bearing for two reasons:
+
+1. **Streaming write throughput** — many small writers in parallel beat one
+   centralized writer's serialized output stream.
+2. **Provenance + restartability** — if shard 042 fails, you re-run with a
+   filter on input shard 042 and the rest of the output stays intact. See
+   `experiments/exp53_data_contacts_v1_zephyr/rerun_missing.py` for the
+   resume pattern.
+
+For smoke tests, omit `{shard}` (or pass `--num-docs N`) — that collapses
+to a single output file:
+
+```python
+if "{shard" not in args.out:
+    out_rows = out_rows.reshard(1)
+```
+
+The output ordering policy is up to you; exp5 + exp53 both use
+`executor.map` (preserves input order within a shard) for determinism.
+exp53 additionally orders Stage A's input shards in descending pLDDT-round
+order so the highest-quality data is read *last* by streaming consumers.
+
+---
+
+## I/O traps that silently destroy throughput
+
+### AFDB GCS objects are gzip-transcoded; use the shared reader
+
+`Content-Encoding: gzip` objects report their **compressed** size in the
+content-length header. A size-based read (`fsspec.open(uri, "rb").read()`
+or `compression="infer"` + slicing) reads only that many bytes of the
+decompressed stream — silently truncating large cifs mid-`_atom_site`.
+gemmi then raises `"Wrong number of values in loop _atom_site"`.
+
+The fix is to use a single full GET (the filesystem's `cat_file`) that
+reads to EOF. This is what
+[`marinfold.document_structures.io.read_object_bytes`](../../../marinfold/marinfold/document_structures/io.py)
+encapsulates — same `None`-on-failure contract as the threading helper
+above, so they compose directly:
+
+```python
+from marinfold.document_structures.io import (
+    read_object_bytes, thread_per_row_in_shard,
+)
+
+def _generate_doc_for_row(row, *, cif_uri_column, ...):
+    cif = read_object_bytes(row[cif_uri_column])  # full GET, gzip-safe
+    if cif is None:
+        return None
+    ...
+```
+
+Symptom check: if your smoke test produces a suspiciously low success rate
+(e.g. < 5 % of rows yielding output), **inspect a sample of failures**
+before scaling up. A near-total silent drop with an otherwise-working
+pipeline shape is a near-certain I/O truncation bug.
+
+### Requester-pays buckets (AFDB)
+
+The AFDB GCS bucket is requester-pays. Local user credentials get
+truncated reads; Iris workers' service account reads fine. Means:
+**the `gcs_uri` per-row fetch path is only validatable on-cluster**, not
+on your laptop. Plan a small `--num-docs 100` smoke on Iris before the full
+run (exp53 did this).
+
+### HuggingFace API quota when listing many shards
+
+afdb-24M has ~12,000 parquet shards. Per-shard `hf://` reads make one
+`paths-info` API call each, blowing through HF's 3,000 req / 5 min quota
+on a single dataset listing. The mitigation lives in exp53's
+[`fetch_manifest_columns.py`](../../../experiments/exp53_data_contacts_v1_zephyr/fetch_manifest_columns.py):
+use an authenticated `HfFileSystem` with a **pre-warmed dircache** + the
+`/resolve/` CDN URLs for the actual reads. One API call to list, N CDN
+reads for the data.
+
+### `httpx<1` for marin-iris
+
+The marin-iris GCP provider calls `httpx.Client(timeout=...)`, removed in
+the 1.0 prerelease. Pin `httpx<1` in your `pyproject.toml` base deps. (exp53
+discovered this in its HANDOFF; pin it preemptively.)
+
+---
+
+## Stage the work: cheap selection, then heavy generation
+
+Large data pipelines benefit from a **two-stage** layout:
+
+* **Stage A — selection** is metadata-only. Read a few small columns from
+  the input manifest (entry_id, pLDDT, cluster ids, ...), compute the
+  selection / shuffling / round assignment in Python or DuckDB, and emit a
+  *new* parquet manifest. This stage runs in seconds-to-minutes on one
+  process and is trivially re-runnable.
+* **Stage B — generation** consumes Stage A's manifest and does the
+  per-row fetch + heavy compute. This is the Zephyr/Iris stage with all
+  the lessons above.
+
+exp53 split this way: `selection.py` reduces 24 M structures → 4.2 M
+selected (entry, round) records in ~13 s, then `cli.py generate` runs the
+heavy per-row work on the 4.2 M-row manifest.
+
+**Why**: the selection logic changes more often than the generation logic
+(filter thresholds, split policies, round counts) and the iteration cost
+should match. Don't recompute structure parsing every time you want to
+test a new selection.
+
+---
+
+## Validation flow: smoke before full run
+
+```
+1. Local unit tests (no Zephyr): test_cli.py against file:// URIs.
+2. Local Zephyr smoke (in-process): ZephyrContext with 2-3 inline rows.
+3. Iris smoke: --num-docs 100, one input shard, single output file.
+   Verify success rate, per-doc latency, output schema.
+4. GATE: report measured rate + worker count + projected wall-clock to
+   the user. Don't auto-trigger the full run.
+5. Full run after explicit go-ahead.
+```
+
+Step 3 is the one that catches almost everything: the gzip truncation, the
+requester-pays issue, the cross-region spill, the per-worker init bug.
+Run it on every change; don't skip it because "the local tests passed."
+
+Per-doc latency from the smoke is what you use to project full-run
+wall-clock: `n_docs / (workers × docs_per_sec_per_worker)`. exp5 measured
+~6 ms/doc → 1.6 M docs / (512 workers × 167 docs/s) ≈ 19 s of compute
+(actual wall-clock ~8 min with overhead). exp53 measured ~225 ms/doc
+(pyconfind-heavy) → 4.2 M docs / (512 × 4.45) ≈ 31 min.
+
+---
+
+## Finding the next perf opportunity
+
+If your smoke run's projected wall-clock is out of budget — or you just
+want to know whether there's headroom — these are the steps that
+actually surface the right thing to fix, in order. The order matters:
+each step is cheap and rules out a class of bottlenecks the next step
+would otherwise misdiagnose.
+
+### 1. Project before optimizing
+
+Don't reach for cProfile yet. Compute the **per-row latency** from the
+smoke and break it into the parts you can change vs the parts you can't:
+
+```
+per_row = network_GET  +  parse  +  generate  +  write
+        ~30–80 ms      +  ms     +  ms        +  µs   (typical)
+```
+
+If the network GET dominates (it usually does for cif fetches), no amount
+of Python-side optimization moves the needle — `thread_per_row_in_shard`
+is your win, and you're done. If parse or generate dominates, then
+profiling is worthwhile. **Decide which regime you're in before
+investing in tools.** Most of the time the answer is "I/O dominates,
+thread it, ship."
+
+### 2. cProfile a representative single-row run, sorted by `tottime`
+
+Once you've decided the CPU side is worth investigating, profile one row
+on a *real* input (not a synthetic fixture — pathological-fast structures
+hide the very loops you want to find):
+
+```python
+import cProfile, pstats
+prof = cProfile.Profile()
+prof.enable()
+for _ in range(200):                       # amortize fixed overhead
+    generate_doc_for_row(real_row, ...)
+prof.disable()
+pstats.Stats(prof).strip_dirs().sort_stats("tottime").print_stats(15)
+```
+
+Read **`tottime`**, not `cumtime` — `tottime` is time spent *in* the
+function excluding callees, which is what points at the hot loop.
+`cumtime` is dominated by your top-level entry point and tells you
+nothing actionable. Run the loop ≥ 200 times so the per-call overhead of
+the profiler itself doesn't dominate cheap calls.
+
+### 3. Isolate the components
+
+End-to-end timing tells you the total; **component timing tells you
+where the total comes from**. Time each layer independently against the
+same input:
+
+```python
+# Component A: parse only
+t = time.perf_counter()
+for _ in range(N): parse_structure(path)
+parse_ms = 1000 * (time.perf_counter() - t) / N
+
+# Component B: generate only (over already-parsed structures)
+parsed = [parse_structure(path) for _ in range(N)]
+t = time.perf_counter()
+for s in parsed: generate_one(s, ...)
+gen_ms = 1000 * (time.perf_counter() - t) / N
+
+# Component C: end-to-end
+# ... and check that parse_ms + gen_ms ≈ end_to_end_ms (often it doesn't,
+# which is itself the finding — something in the glue is non-trivial).
+```
+
+This is how exp5's perf-engineering thread (which Tim ultimately rejected
+in favor of one source of truth — but the *measurement* was sound)
+narrowed the 9.5 → 5.7 ms/doc journey: each iteration measured parse and
+generate separately, so we knew which half a given change moved.
+
+### 4. Multi-trial measurement; report min + median
+
+Single-shot wall-clock numbers are noisy: cold caches, JIT-ish warmups,
+GC, system load. **Run ≥ 5 trials and report min + median.** First-run
+inflation can be 20-50 %; pretending the first run is representative
+will send you optimizing the wrong thing.
+
+```python
+trials = [time_one_run() for _ in range(5)]
+print(f"min={min(trials):.2f}  median={sorted(trials)[2]:.2f}  trials={trials}")
+```
+
+Use **min** as the "true" cost (least noise added) and **median** as
+"typical." When they diverge significantly, something in your environment
+is variable and worth fixing before continuing (background processes,
+disk cache state, etc.).
+
+### 5. Hypothesis-driven changes — predict, then measure, then report honestly
+
+For each optimization, **predict the win before implementing it** and
+write the prediction down. Then measure. Three possible outcomes:
+
+- **Predicted win materialized** → ship, update the skill if the lesson
+  generalizes.
+- **Predicted win was wrong (smaller, or zero)** → roll back. This is
+  the most important branch; the temptation to keep the change because
+  it's "cleaner" or "more correct in principle" leaks complexity into
+  the codebase for no measurable benefit.
+- **Predicted win was wrong in an *interesting* way** (different
+  bottleneck surfaced) → keep the prediction in your notes; the gap
+  between expected and measured is itself a finding about where the
+  cost actually lives.
+
+The exp5 perf thread had all three: the two-phase distance loop was
+predicted to save 0.3 ms/doc; measurement showed it broke even (gains
+from vectorization were eaten by Python-side plan-list construction).
+That's a "rollback" outcome — the code went into a different branch, and
+the *finding* (per-element numpy access has fixed overhead comparable to
+~12 scalar Python ops) made it into the surrounding decisions.
+
+### When to stop
+
+You're done optimizing when the remaining cost is one of:
+
+- **Real network latency** — `cat_file` of a 50 KB object across the
+  internet has a floor. Add concurrency, not cleverness.
+- **C-extension parse cost** (gemmi, pyconfind) — Python can't do
+  anything here; the GIL is already released, you're competing with C.
+- **Algorithmic floor** — the doc generator inherently has to do O(N²)
+  contact work over N residues; you can vectorize but not avoid it.
+- **The cluster's wall-clock is now bounded by something else** — at
+  some point shaving 0.5 ms/doc off a 4 ms/doc pipeline saves
+  ~minutes on a 30-minute run; cluster startup overhead and
+  Zephyr scheduling start dominating. Below that threshold, the
+  return on more profiling is essentially zero.
+
+Each of these is a perfectly acceptable stopping point — the goal isn't
+maximum theoretical throughput, it's "fits the budget the experiment
+needs." If your projected wall-clock is already under the user's
+tolerance, **don't optimize**; the time you'd spend has better uses.
+
+---
+
+## Pre-launch checklist
+
+Before triggering the full run, verify each of these:
+
+**Per-row**
+- [ ] Object bytes are fetched via
+      `marinfold.document_structures.io.read_object_bytes` (or
+      equivalent: a full `cat_file` GET that handles gzip-transcoded
+      objects), not `fsspec.open().read()` with size inference.
+- [ ] The worker returns `None` (not raises) on transient I/O / parse
+      failures so a single bad row can't kill a Zephyr worker.
+
+**Per-shard**
+- [ ] URI-path `map_shard` body delegates to
+      `marinfold.document_structures.io.thread_per_row_in_shard` (or
+      equivalent: a thread pool sized at `min(concurrency, len(rows))`
+      that yields in input order and skips `None`); inline-cif path
+      runs sequentially (no I/O to overlap, pool is pure overhead).
+- [ ] Any heavy per-process init (parsed libraries, JIT kernels) is
+      memoized at module scope with a sentinel, not re-run per shard.
+
+**Per-job**
+- [ ] `--worker-cpu 1`, `--worker-memory` set to peak working set + a
+      small margin (4 GB is fine for most gemmi/numpy workers).
+- [ ] `--max-workers` set explicitly. Default `None` means cluster
+      default, which may be too small for a full run.
+- [ ] `--region` pinned to the cluster's region (default `us-central1`
+      for the marin Iris cluster), `--preemptible` on by default.
+- [ ] Output bucket is `gs://marin-<same-region>/protein-structure/MarinFold/<exp>/`.
+
+**Per-input / per-output**
+- [ ] Input parquet is read with `columns=…` projected to only what the
+      worker needs (one schema peek at submission time).
+- [ ] `--out` contains `{shard:05d}-of-{total:05d}` for the full run;
+      smoke runs may omit it.
+
+**Validation**
+- [ ] Local unit tests pass.
+- [ ] Iris smoke run (`--num-docs 100`, single input shard) produced
+      ≥ 95 % valid docs and measured per-doc latency matches the
+      projection.
+- [ ] Smoke output sample manually inspected for shape + content.
+- [ ] User has gated the full run.
+
+If any of these is missing, fix it before scaling out. The cost of an
+unnecessary full run on 512 preemptible workers is real (cluster capacity
++ $) and the cost of *finding out at hour 3* that you needed the
+gzip-safe reader is realer.
+
+---
+
+## When you're done
+
+After the full run completes:
+
+1. Record the measured per-doc rate + wall-clock + worker count + region in
+   the experiment's README "Results" section. Include the output GCS URI.
+2. Commit a `data/timings.csv` (per the root `AGENTS.md` "Capture timings
+   for every predictor run" rule).
+3. If you discovered a new trap not in this skill, *open a PR adding it
+   here* — the cost of writing it down is much less than the cost of the
+   next agent rediscovering it.

--- a/.agents/skills/zephyr-pipeline-performance/SKILL.md
+++ b/.agents/skills/zephyr-pipeline-performance/SKILL.md
@@ -7,29 +7,29 @@ description: Write a Zephyr/Iris data-generation pipeline that finishes in minut
 
 A Zephyr pipeline that *works* and one that *finishes in budget* differ on a
 small set of decisions you make once at the top of `cli.py`. Most of them
-are unobvious from the marin-zephyr docs because the costs aren't local —
-they show up as straggler tails, silently-truncated reads, or cluster bills,
+are unobvious from the marin-zephyr docs because the costs aren't local.
+They show up as straggler tails, silently-truncated reads, or cluster bills,
 not as wrong output.
 
 This skill draws on lessons from two real MarinFold pipelines that
 chose differently:
 
-* `experiments/exp5_data_contacts_and_distances_v2_zephyr/` —
-  1.6 M structures. The README's success criterion documents a prior
+* `experiments/exp5_data_contacts_and_distances_v2_zephyr/` (1.6 M
+  structures). The README's success criterion documents a prior
   `gcs_uri`-mode production run (without intra-shard concurrency) at
-  **≤ 8 min wall-clock**; the current shape adds intra-shard threading
+  **≤ 8 min wall-clock**. The current shape adds intra-shard threading
   on top, so wall-clock should be no worse than that bound. **exp5
-  is currently on a PR branch, not yet on `main`** — if you need to
+  is currently on a PR branch, not yet on `main`**. If you need to
   read its code, locate the PR via `gh pr list` and check it out
   locally (or browse on github.com).
-* [`experiments/exp53_data_contacts_v1_zephyr/`](../../../experiments/exp53_data_contacts_v1_zephyr/) —
-  4.2 M structures (pyconfind-heavy). Two hard-won fixes mid-development
+* [`experiments/exp53_data_contacts_v1_zephyr/`](../../../experiments/exp53_data_contacts_v1_zephyr/)
+  (4.2 M structures, pyconfind-heavy). Two hard-won fixes mid-development
   prevented this one from running for many cluster-hours: the
   rotamer-library memoization
   ([`daa18e1`](https://github.com/Open-Athena/MarinFold/commit/daa18e1))
   and the gzip-truncation fix
-  ([`43a0535`](https://github.com/Open-Athena/MarinFold/commit/43a0535))
-  — without them, a smoke test produced only 2/100 valid documents.
+  ([`43a0535`](https://github.com/Open-Athena/MarinFold/commit/43a0535)).
+  Without them, a smoke test produced only 2/100 valid documents.
   Both lessons are documented as patterns below.
 
 When you're done, your pipeline should clear every box in the
@@ -37,15 +37,15 @@ When you're done, your pipeline should clear every box in the
 
 ---
 
-## TL;DR — the five decisions that dominate
+## TL;DR: the five decisions that dominate
 
 1. **Inside `map_shard`, run a `ThreadPoolExecutor` around the per-row
    fetch+parse.** GCS GETs are ~30–80 ms; gemmi parse releases the GIL.
-   Threading them is the single biggest per-shard speedup — exp5's prior
-   sequential version landed at ~128 s/shard; threaded should drop well
-   below that (estimated low-single-digit seconds at fetch-concurrency
-   32 over ~2,000 rows, but actual cluster wall-clock not yet
-   re-measured).
+   Threading them is the largest per-shard speedup available. exp5's
+   prior sequential version landed at ~128 s/shard; threaded should
+   drop well below that (estimated low-single-digit seconds at
+   fetch-concurrency 32 over ~2,000 rows, though actual cluster
+   wall-clock is not yet re-measured).
 2. **`--worker-cpu 1`, scale via `--max-workers`.** Per-shard CPU is
    single-threaded Python once the in-shard thread pool overlaps the I/O.
    Asking for more cores per worker wastes cluster capacity.
@@ -57,9 +57,9 @@ When you're done, your pipeline should clear every box in the
 4. **Fetch per-row objects via
    `marinfold.document_structures.io.read_object_bytes`** (a full
    `cat_file` GET), not `fsspec.open().read()`. GCS objects with
-   `Content-Encoding: gzip` report compressed size in `Content-Length`;
-   a size-based read truncates large objects mid-content. The bug is
-   silent — your parser fails downstream with a confusing
+   `Content-Encoding: gzip` report compressed size in `Content-Length`,
+   so a size-based read truncates large objects mid-content. The bug
+   is silent: your parser fails downstream with a confusing
    "unexpected end" error, not an obvious I/O fault.
 5. **Source per-row data via the manifest's `gcs_uri` pointer column,
    not the inline `cif_content` column.** Datasets like afdb-1.6M ship
@@ -72,9 +72,9 @@ When you're done, your pipeline should clear every box in the
    per-row fetch. Default to `--cif-uri-column=gcs_uri`; reserve
    `--cif-text-column` for local testing or inputs without a URI column.
 
-The rest of this skill walks through each layer of the pipeline (per-row →
-per-shard → per-job → per-output) with the code patterns these decisions
-imply.
+The rest of this skill walks through each layer of the pipeline
+(per-row, per-shard, per-job, per-output) with the code patterns
+these decisions imply.
 
 ---
 
@@ -112,13 +112,13 @@ def generate_shard(items, shard_info, *, cfg, fetch_concurrency=32, ...):
 case where the per-row GCS GET (~30–80 ms) is an order of magnitude
 larger than the per-row CPU step. If your CPU step is heavier (e.g.
 pyconfind-based contact computation in exp53, where per-doc CPU
-dominates), threading still helps but its marginal effect shrinks —
-the right concurrency knob is then closer to the worker's effective
+dominates), threading still helps but its marginal effect shrinks.
+The right concurrency knob is then closer to the worker's effective
 core count than to the I/O latency ratio.
 
-If you have *no* per-row I/O (inline cif text in the manifest), skip the
-helper — there's nothing to overlap and a thread pool is pure overhead.
-exp53's `generate_shard` shows the branch:
+If you have *no* per-row I/O (inline cif text in the manifest), skip
+the helper. There's nothing to overlap and a thread pool is pure
+overhead. exp53's `generate_shard` shows the branch:
 
 ```python
 if cif_text_column is not None:
@@ -135,38 +135,39 @@ yield from thread_per_row_in_shard(items, worker=worker, ...)
 ### 2. Memoize per-worker init in a module global
 
 A Zephyr worker process serves many shards over its lifetime. If your
-algorithm requires a heavy per-process resource (parsed reference library,
-loaded model, JIT-compiled kernel), **do not initialize it per shard or per
-row** — cache it in a module-level global so it's parsed once per worker.
+algorithm requires a heavy per-process resource (parsed reference
+library, loaded model, JIT-compiled kernel), **do not initialize it
+per shard or per row**. Cache it in a module-level global so it's
+parsed once per worker.
 
 exp53's
 [commit `daa18e1`](https://github.com/Open-Athena/MarinFold/commit/daa18e1)
-is the canonical example: pyconfind's rotamer library takes tens of seconds
-to parse. Before the fix, every shard paid that cost. After:
+is the canonical example: pyconfind's rotamer library takes tens of
+seconds to parse. Before the fix, every shard paid that cost. After
+(using ``functools.cache`` for the cross-shard memoization):
 
 ```python
-_ROTAMER_UNSET: Any = object()
-_ROTAMER_LIBRARY: Any = _ROTAMER_UNSET
+import functools
 
-def _load_rotamer_library() -> Any | None:
-    global _ROTAMER_LIBRARY
-    if _ROTAMER_LIBRARY is not _ROTAMER_UNSET:
-        return _ROTAMER_LIBRARY  # second-and-onward shards: instant
+@functools.cache
+def _load_rotamer_library():
     try:
         from pyconfind import load_library, cached_rotamer_library
-        _ROTAMER_LIBRARY = load_library(cached_rotamer_library())
+        return load_library(cached_rotamer_library())
     except Exception as exc:
         warnings.warn(f"preload failed ({exc}); per-call load", stacklevel=2)
-        _ROTAMER_LIBRARY = None
-    return _ROTAMER_LIBRARY
+        return None
 ```
 
-Use a sentinel (`_ROTAMER_UNSET`) rather than `None`, so the failure path
-(genuinely returned `None`) caches and doesn't retry on every call.
+The stdlib ``functools.cache`` covers the load-bearing part for free:
+it distinguishes "not yet called" from "called and returned None", so
+a worker whose preload genuinely returned ``None`` once doesn't retry
+per shard. Cache plus ``try/except`` together give you lazy init,
+cached failure, no per-shard retry, and no hand-rolled sentinel.
 
-This pattern compounds: a 30 s per-worker init across 500 workers × 100
-shards-per-worker is a **41-hour cluster bill** if you do it per shard;
-30 s × 500 once-per-worker is a 15-second blip.
+This pattern compounds. A 30 s per-worker init across 500 workers
+times 100 shards-per-worker is a **41-hour cluster bill** if you do
+it per shard; 30 s times 500 once-per-worker is a 15-second blip.
 
 ---
 
@@ -190,11 +191,11 @@ uv run iris --cluster=marin job run --cpu 1 --memory 2GB -- \
 ```
 
 Note the *two* cpu/memory pairs: the **outer** `--cpu`/`--memory` on
-`iris job run` size the **launcher container** (tiny); the **inner**
-`--worker-cpu`/`--worker-memory` (consumed by `ZephyrContext`) size each
-**worker pod**. They're not the same thing and overspending on the launcher
-is wasteful but harmless; overspending on the workers multiplies by 500+
-and is not.
+`iris job run` sizes the **launcher container** (tiny); the **inner**
+`--worker-cpu`/`--worker-memory` (consumed by `ZephyrContext`) sizes
+each **worker pod**. Overspending on the launcher is wasteful but
+harmless; overspending on the workers multiplies by 500+, which is
+not harmless at all.
 
 ### 2. Pin `--region`, request `--preemptible`
 
@@ -224,9 +225,9 @@ p.add_argument("--region", type=str, default="us-central1",
                     "so a large pool can't spill cross-region/continent.")
 p.add_argument("--preemptible", action=argparse.BooleanOptionalAction,
                default=True,
-               help="Request preemptible/spot workers — far more in-region "
-                    "capacity + cheaper than on-demand; zephyr retries "
-                    "preemptions.")
+               help="Request preemptible/spot workers. More in-region "
+                    "capacity than on-demand at lower cost; zephyr "
+                    "retries preemptions.")
 ```
 
 exp53's
@@ -236,11 +237,11 @@ from cross-continent on-demand spills.
 
 ### 3. Match output bucket to the cluster's region
 
-`gs://marin-<region>/protein-structure/MarinFold/<exp>/` — the bucket
-**must** be in the same region as the workers, or every per-row PUT is a
-cross-region transfer (cost + latency). For the Iris cluster's
-`us-central1` default, that's `gs://marin-us-central1/...`. See the root
-[`AGENTS.md`](../../../AGENTS.md) "GCS bucket" section.
+The output bucket `gs://marin-<region>/protein-structure/MarinFold/<exp>/`
+**must** be in the same region as the workers, or every per-row PUT
+is a cross-region transfer (cost and latency). For the Iris cluster's
+`us-central1` default, that's `gs://marin-us-central1/...`. See the
+root [`AGENTS.md`](../../../AGENTS.md) "GCS bucket" section.
 
 ---
 
@@ -254,38 +255,39 @@ afdb-1.6M (and other AFDB-derived manifests on HuggingFace) ship every
 cif *twice*: as a one-line `gcs_uri` pointer to the public AFDB GCS
 bucket, **and** as the full inline mmCIF text in a `cif_content` column.
 
-The choice between them dominates everything else in this section:
+The choice between them dominates everything else in this section.
 
-- **`gcs_uri`** → workers fetch from AFDB's GCS bucket directly. For a
-  GCP-based cluster (the marin Iris pool), that's in-cloud and usually
-  in-region — fast network, no cross-cloud egress charges. Reading the
-  manifest costs ~160 KB/shard (just the URI strings + provenance).
-- **`cif_content`** → every worker reads the bulky inline mmCIF back
-  from HuggingFace, cross-cloud, per row. Reading the manifest costs
-  ~70 MB/shard (~2,000× more I/O), and that bulk crosses the open
-  internet rather than staying inside GCP.
+With `gcs_uri`, workers fetch from AFDB's GCS bucket directly. For a
+GCP-based cluster (the marin Iris pool), that's in-cloud and usually
+in-region: fast network, no cross-cloud egress charges. Reading the
+manifest costs ~160 KB/shard (just the URI strings plus provenance).
+
+With `cif_content`, every worker reads the bulky inline mmCIF back
+from HuggingFace, cross-cloud, per row. Reading the manifest costs
+~70 MB/shard (~2,000× more I/O), and that bulk crosses the open
+internet rather than staying inside GCP.
 
 Default to `--cif-uri-column=gcs_uri`. Reserve `--cif-text-column` for
 local tests (where inline cif keeps the path off the network entirely)
 or for input manifests that don't ship a URI column.
 
-A subtle related trap: if you have to enumerate the HF manifest's
-*shards* up front, do it through an authenticated `HfFileSystem` with a
-pre-warmed dircache + the `/resolve/` CDN URLs (one API call to list, N
-CDN reads for the data). Per-shard `hf://` reads make one `paths-info`
-API call each, which blows HF's 3,000 req / 5 min quota on a
-multi-thousand-shard manifest. See the "HuggingFace API quota" trap
-below.
+A related trap: if you have to enumerate the HF manifest's *shards*
+up front, do it through an authenticated `HfFileSystem` with a
+pre-warmed dircache plus the `/resolve/` CDN URLs (one API call to
+list, N CDN reads for the data). Per-shard `hf://` reads make one
+`paths-info` API call each, which blows HF's 3,000 req / 5 min quota
+on a multi-thousand-shard manifest. See the "HuggingFace API quota"
+trap below.
 
 ### 2. Read only the columns you need
 
 Parquet is columnar.
 `Dataset.from_files(input).load_parquet(columns=…)` reads only the
 requested columns. With `gcs_uri` picked, the minimal set is
-`[entry_id, gcs_uri, <optional passthrough>]` — ~160 KB/shard. Reading
-the full row (including `cif_content`) is ~70 MB/shard regardless of
-which fetch path you take downstream — column projection is what
-*activates* the data-source win.
+`[entry_id, gcs_uri, <optional passthrough>]`, about 160 KB/shard.
+Reading the full row (including `cif_content`) is ~70 MB/shard
+regardless of which fetch path you take downstream, so column
+projection is what *activates* the data-source win.
 
 The exp5 pattern: peek the manifest schema once at submission time,
 decide which optional passthrough columns are present, then pass the
@@ -326,16 +328,15 @@ per input shard:
 --out "gs://marin-us-central1/.../corpus-{shard:05d}-of-{total:05d}.parquet"
 ```
 
-This is load-bearing for two reasons:
+This is load-bearing for two reasons. First, write throughput: many
+small writers in parallel beat one centralized writer's serialized
+output stream. Second, provenance and restartability: if shard 042
+fails, you re-run with a filter on input shard 042 and the rest of
+the output stays intact. See
+`experiments/exp53_data_contacts_v1_zephyr/rerun_missing.py` for the
+resume pattern.
 
-1. **Streaming write throughput** — many small writers in parallel beat one
-   centralized writer's serialized output stream.
-2. **Provenance + restartability** — if shard 042 fails, you re-run with a
-   filter on input shard 042 and the rest of the output stays intact. See
-   `experiments/exp53_data_contacts_v1_zephyr/rerun_missing.py` for the
-   resume pattern.
-
-For smoke tests, omit `{shard}` (or pass `--num-docs N`) — that collapses
+For smoke tests, omit `{shard}` (or pass `--num-docs N`) to collapse
 to a single output file:
 
 ```python
@@ -356,15 +357,16 @@ order so the highest-quality data is read *last* by streaming consumers.
 
 `Content-Encoding: gzip` objects report their **compressed** size in the
 content-length header. A size-based read (`fsspec.open(uri, "rb").read()`
-or `compression="infer"` + slicing) reads only that many bytes of the
-decompressed stream — silently truncating large cifs mid-`_atom_site`.
-gemmi then raises `"Wrong number of values in loop _atom_site"`.
+or `compression="infer"` plus slicing) reads only that many bytes of
+the decompressed stream and silently truncates large cifs
+mid-`_atom_site`. gemmi then raises `"Wrong number of values in loop
+_atom_site"`.
 
-The fix is to use a single full GET (the filesystem's `cat_file`) that
-reads to EOF. This is what
+The fix is a single full GET (the filesystem's `cat_file`) that reads
+to EOF. That's what
 [`marinfold.document_structures.io.read_object_bytes`](../../../marinfold/marinfold/document_structures/io.py)
-encapsulates — same `None`-on-failure contract as the threading helper
-above, so they compose directly:
+does. It has the same `None`-on-failure contract as the threading
+helper above, so they compose directly:
 
 ```python
 from marinfold.document_structures.io import (
@@ -403,33 +405,34 @@ reads for the data.
 
 ### `httpx<1` for marin-iris
 
-The marin-iris GCP provider calls `httpx.Client(timeout=...)`, removed in
-the 1.0 prerelease. Pin `httpx<1` in your `pyproject.toml` base deps. (exp53
-discovered this in its HANDOFF; pin it preemptively.)
+The marin-iris GCP provider calls `httpx.Client(timeout=...)`, removed
+in the 1.0 prerelease. Pin `httpx<1` in your `pyproject.toml` base
+deps. exp53 discovered this in its HANDOFF; pin it preemptively.
 
 ---
 
 ## Stage the work: cheap selection, then heavy generation
 
-Large data pipelines benefit from a **two-stage** layout:
+Large data pipelines benefit from a **two-stage** layout.
 
-* **Stage A — selection** is metadata-only. Read a few small columns from
-  the input manifest (entry_id, pLDDT, cluster ids, ...), compute the
-  selection / shuffling / round assignment in Python or DuckDB, and emit a
-  *new* parquet manifest. This stage runs in seconds-to-minutes on one
-  process and is trivially re-runnable.
-* **Stage B — generation** consumes Stage A's manifest and does the
-  per-row fetch + heavy compute. This is the Zephyr/Iris stage with all
-  the lessons above.
+Stage A (selection) is metadata-only. Read a few small columns from
+the input manifest (entry_id, pLDDT, cluster ids, ...), compute the
+selection, shuffling, or round assignment in Python or DuckDB, and
+emit a *new* parquet manifest. This stage runs in seconds to minutes
+on one process and is trivially re-runnable.
 
-exp53 split this way: `selection.py` reduces 24 M structures → 4.2 M
-selected (entry, round) records in ~13 s, then `cli.py generate` runs the
-heavy per-row work on the 4.2 M-row manifest.
+Stage B (generation) consumes Stage A's manifest and does the per-row
+fetch plus heavy compute. This is the Zephyr/Iris stage with all the
+lessons above.
 
-**Why**: the selection logic changes more often than the generation logic
-(filter thresholds, split policies, round counts) and the iteration cost
-should match. Don't recompute structure parsing every time you want to
-test a new selection.
+exp53 split this way: `selection.py` reduces 24 M structures to 4.2 M
+selected (entry, round) records in ~13 s, then `cli.py generate` runs
+the heavy per-row work on the 4.2 M-row manifest.
+
+The reason to split: selection logic changes more often than
+generation logic (filter thresholds, split policies, round counts),
+and the iteration cost should match. Don't recompute structure
+parsing every time you want to test a new selection.
 
 ---
 
@@ -451,7 +454,7 @@ Run it on every change; don't skip it because "the local tests passed."
 
 Per-doc latency from the smoke is what you use to project full-run
 wall-clock: `n_docs / (workers × docs_per_sec_per_worker)`. **Treat
-this as an upper-bound estimate, not a guarantee** — startup overhead,
+this as a lower-bound estimate, not a guarantee.** Startup overhead,
 preemption retries, straggler tails, and per-worker init costs all
 land on top of the per-doc rate, and the gap can be 2–5×. The
 projection's job is to flag "this is hours, not minutes" before you
@@ -462,11 +465,11 @@ the minute.
 
 ## Finding the next perf opportunity
 
-If your smoke run's projected wall-clock is out of budget — or you just
-want to know whether there's headroom — these are the steps that
-actually surface the right thing to fix, in order. The order matters:
-each step is cheap and rules out a class of bottlenecks the next step
-would otherwise misdiagnose.
+If your smoke run's projected wall-clock is out of budget (or if you
+just want to know whether there's headroom), these are the steps that
+surface the right thing to fix. The order matters: each step is cheap
+and rules out a class of bottlenecks the next step would otherwise
+misdiagnose.
 
 ### 1. Project before optimizing
 
@@ -478,8 +481,8 @@ per_row = network_GET  +  parse  +  generate  +  write
         ~30–80 ms      +  ms     +  ms        +  µs   (typical)
 ```
 
-If the network GET dominates (it usually does for cif fetches), no amount
-of Python-side optimization moves the needle — `thread_per_row_in_shard`
+If the network GET dominates (it usually does for cif fetches), no
+amount of Python-side optimization helps. `thread_per_row_in_shard`
 is your win, and you're done. If parse or generate dominates, then
 profiling is worthwhile. **Decide which regime you're in before
 investing in tools.** Most of the time the answer is "I/O dominates,
@@ -487,9 +490,9 @@ thread it, ship."
 
 ### 2. cProfile a representative single-row run, sorted by `tottime`
 
-Once you've decided the CPU side is worth investigating, profile one row
-on a *real* input (not a synthetic fixture — pathological-fast structures
-hide the very loops you want to find):
+Once you've decided the CPU side is worth investigating, profile one
+row on a *real* input. Synthetic fixtures are pathological-fast and
+hide the loops you want to find.
 
 ```python
 import cProfile, pstats
@@ -501,11 +504,11 @@ prof.disable()
 pstats.Stats(prof).strip_dirs().sort_stats("tottime").print_stats(15)
 ```
 
-Read **`tottime`**, not `cumtime` — `tottime` is time spent *in* the
+Read **`tottime`**, not `cumtime`. `tottime` is time spent *in* the
 function excluding callees, which is what points at the hot loop.
 `cumtime` is dominated by your top-level entry point and tells you
-nothing actionable. Run the loop ≥ 200 times so the per-call overhead of
-the profiler itself doesn't dominate cheap calls.
+nothing actionable. Run the loop ≥ 200 times so the per-call overhead
+of the profiler itself doesn't dominate cheap calls.
 
 ### 3. Isolate the components
 
@@ -527,14 +530,14 @@ gen_ms = 1000 * (time.perf_counter() - t) / N
 
 # Component C: end-to-end
 # ... and check that parse_ms + gen_ms ≈ end_to_end_ms (often it doesn't,
-# which is itself the finding — something in the glue is non-trivial).
+# which is itself the finding: something in the glue is non-trivial).
 ```
 
-Concretely: if your end-to-end is 7 ms/doc and your isolated parse +
-generate sum to 5 ms/doc, the missing 2 ms is somewhere in the glue
-(per-row dataclass churn, dict construction, JSON serialization,
-etc.) and that's where the next optimization opportunity lives —
-not in parse or generate themselves.
+If your end-to-end is 7 ms/doc and your isolated parse + generate sum
+to 5 ms/doc, the missing 2 ms is somewhere in the glue (per-row
+dataclass churn, dict construction, JSON serialization, etc.). That's
+where the next optimization opportunity lives, not in parse or
+generate themselves.
 
 ### 4. Multi-trial measurement; report min + median
 
@@ -549,57 +552,60 @@ print(f"min={min(trials):.2f}  median={sorted(trials)[2]:.2f}  trials={trials}")
 ```
 
 Use **min** as the "true" cost (least noise added) and **median** as
-"typical." When they diverge significantly, something in your environment
-is variable and worth fixing before continuing (background processes,
-disk cache state, etc.).
+"typical." When they diverge significantly, something in your
+environment is variable and worth fixing before continuing: background
+processes, disk cache state, and so on.
 
-### 5. Hypothesis-driven changes — predict, then measure, then report honestly
+### 5. Hypothesis-driven changes: predict, then measure, then report honestly
 
 For each optimization, **predict the win before implementing it** and
-write the prediction down. Then measure. Three possible outcomes:
+write the prediction down. Then measure. There are three possible
+outcomes.
 
-- **Predicted win materialized** → ship, update the skill if the lesson
-  generalizes.
-- **Predicted win was wrong (smaller, or zero)** → roll back. This is
-  the most important branch; the temptation to keep the change because
-  it's "cleaner" or "more correct in principle" leaks complexity into
-  the codebase for no measurable benefit.
-- **Predicted win was wrong in an *interesting* way** (different
-  bottleneck surfaced) → keep the prediction in your notes; the gap
-  between expected and measured is itself a finding about where the
-  cost actually lives.
+If the predicted win materialized, ship it, and update the skill if
+the lesson generalizes.
 
-A worked example of the "rollback" branch worth internalizing:
-splitting a hot Python loop into "pre-compute integer indices, then do
-the math in vectorized numpy" *sounds* faster, but for batch sizes in
-the low thousands, per-element numpy access has fixed overhead
-comparable to ~12 scalar Python ops — and the gains from vectorization
-get eaten by the Python-side cost of building the plan arrays. The
-right move when the measurement comes back flat is to revert, even
-when the rewrite looks more elegant. The finding (that there's a
-crossover point below which Python beats numpy for per-element
-access) is the keeper; the rewrite isn't.
+If the predicted win was wrong (smaller, or zero), roll back. This
+is the most important branch. The temptation to keep the change
+because it's "cleaner" or "more correct in principle" leaks
+complexity into the codebase for no measurable benefit.
+
+If the predicted win was wrong in an interesting way (a different
+bottleneck surfaced), keep the prediction in your notes. The gap
+between expected and measured is itself a finding about where the
+cost actually lives.
+
+A worked example of the rollback branch: splitting a hot Python loop
+into "pre-compute integer indices, then do the math in vectorized
+numpy" *sounds* faster. But for batch sizes in the low thousands,
+per-element numpy access has fixed overhead comparable to ~12 scalar
+Python ops, and the gains from vectorization get eaten by the
+Python-side cost of building the plan arrays. The right move when
+the measurement comes back flat is to revert, even when the rewrite
+looks more elegant. The finding (that there's a crossover point
+below which Python beats numpy for per-element access) is the
+keeper; the rewrite isn't.
 
 ### When to stop
 
-You're done optimizing when the remaining cost is one of:
+You're done optimizing when the remaining cost is one of these.
 
-- **Real network latency** — `cat_file` of a 50 KB object across the
-  internet has a floor. Add concurrency, not cleverness.
-- **C-extension parse cost** (gemmi, pyconfind) — Python can't do
-  anything here; the GIL is already released, you're competing with C.
-- **Algorithmic floor** — the doc generator inherently has to do O(N²)
-  contact work over N residues; you can vectorize but not avoid it.
-- **The cluster's wall-clock is now bounded by something else** — at
-  some point shaving 0.5 ms/doc off a 4 ms/doc pipeline saves
-  ~minutes on a 30-minute run; cluster startup overhead and
-  Zephyr scheduling start dominating. Below that threshold, the
-  return on more profiling is essentially zero.
+1. Real network latency. `cat_file` of a 50 KB object across the
+   internet has a floor. Add concurrency, not cleverness.
+2. C-extension parse cost (gemmi, pyconfind). Python can't help
+   here; the GIL is already released, and you're competing with C.
+3. Algorithmic floor. The doc generator inherently has to do O(N²)
+   contact work over N residues; you can vectorize but not avoid it.
+4. The cluster's wall-clock is now bounded by something else. At
+   some point shaving 0.5 ms/doc off a 4 ms/doc pipeline saves
+   ~minutes on a 30-minute run, and cluster startup overhead and
+   Zephyr scheduling start dominating. Below that threshold, the
+   return on more profiling is essentially zero.
 
-Each of these is a perfectly acceptable stopping point — the goal isn't
-maximum theoretical throughput, it's "fits the budget the experiment
-needs." If your projected wall-clock is already under the user's
-tolerance, **don't optimize**; the time you'd spend has better uses.
+Each of these is a fine stopping point. The goal is fitting the
+budget the experiment needs, not maximizing theoretical throughput.
+If your projected wall-clock is already under the user's tolerance,
+**don't optimize**; the time you'd spend has better uses.
 
 ---
 
@@ -647,10 +653,10 @@ Before triggering the full run, verify each of these:
 - [ ] Smoke output sample manually inspected for shape + content.
 - [ ] User has gated the full run.
 
-If any of these is missing, fix it before scaling out. The cost of an
-unnecessary full run on 512 preemptible workers is real (cluster capacity
-+ $) and the cost of *finding out at hour 3* that you needed the
-gzip-safe reader is realer.
+If any of these is missing, fix it before scaling out. The cost of
+an unnecessary full run on 512 preemptible workers is real (cluster
+capacity and $), and the cost of *finding out at hour 3* that you
+needed the gzip-safe reader is worse.
 
 ---
 
@@ -662,6 +668,6 @@ After the full run completes:
    the experiment's README "Results" section. Include the output GCS URI.
 2. Commit a `data/timings.csv` (per the root `AGENTS.md` "Capture timings
    for every predictor run" rule).
-3. If you discovered a new trap not in this skill, *open a PR adding it
-   here* — the cost of writing it down is much less than the cost of the
-   next agent rediscovering it.
+3. If you discovered a new trap not in this skill, *open a PR adding
+   it here*. The cost of writing it down is much less than the cost
+   of the next agent rediscovering it.

--- a/.agents/skills/zephyr-pipeline-performance/SKILL.md
+++ b/.agents/skills/zephyr-pipeline-performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zephyr-pipeline-performance
-description: Write a Zephyr/Iris data-generation pipeline that finishes in minutes, not hours. Use when authoring or reviewing an `exp<N>_data_*/cli.py` (or any `map_shard`-based job that fetches per-row inputs and emits parquet). Covers the per-row / per-shard / per-worker / per-job decisions that separate a fits-in-budget run from an overnight one.
+description: Write a Zephyr/Iris data-generation pipeline that finishes in minutes (not hours) and ships a clean corpus (not a silently-corrupted one). Use when authoring or reviewing an `exp<N>_data_*/cli.py` (or any `map_shard`-based job that fetches per-row inputs and emits parquet). Covers the per-row / per-shard / per-worker / per-job decisions for wall-clock plus the fail-loud default for data quality.
 ---
 
 # Skill: write performant Zephyr pipelines
@@ -37,7 +37,7 @@ When you're done, your pipeline should clear every box in the
 
 ---
 
-## TL;DR: the five decisions that dominate
+## TL;DR: the six decisions that dominate
 
 1. **Inside `map_shard`, run a `ThreadPoolExecutor` around the per-row
    fetch+parse.** GCS GETs are ~30–80 ms; gemmi parse releases the GIL.
@@ -71,10 +71,58 @@ When you're done, your pipeline should clear every box in the
    output, ~2,000× less manifest I/O plus a fundamentally cheaper
    per-row fetch. Default to `--cif-uri-column=gcs_uri`; reserve
    `--cif-text-column` for local testing or inputs without a URI column.
+6. **Default to fail-loud on data-quality failures.** When a fetch,
+   parse, or generate raises, let the Zephyr worker die with a real
+   stack trace. A killed worker forces you to triage the bug now,
+   when the cluster job is small; a silently-dropped row corrupts the
+   training corpus and surfaces weeks later as a model that behaves
+   slightly oddly, recovery path "re-run the entire pipeline." The
+   library helpers default to raise; opt into lenient mode
+   (`read_object_bytes(uri, missing_ok=True)`) only per call site,
+   with a comment tying the choice to a specific policy. Return
+   `None` only for *designed-in filter predicates* (the structure is
+   multi-chain, too small to fit, etc.), not for swallowed exceptions.
+   See the "Fail loud on data-quality failures" section below.
 
 The rest of this skill walks through each layer of the pipeline
 (per-row, per-shard, per-job, per-output) with the code patterns
 these decisions imply.
+
+---
+
+## Fail loud on data-quality failures
+
+The principle from TL;DR #6, in code. The library helpers default
+to raise; lenient mode is opt-in per call site, with a comment:
+
+```python
+# Pipeline policy is "drop, don't backfill" per issue #N; missing
+# AFDB cifs are expected for ~0.1% of cluster ids that were
+# retracted upstream.
+cif = read_object_bytes(uri, missing_ok=True)
+if cif is None:
+    return None
+```
+
+The two cases where returning ``None`` is correct (not a
+swallowed failure):
+
+1. **Designed-in filter predicates.** The worker has explicitly
+   determined the row is not eligible for output: a multi-chain
+   structure when single-chain is required, a sequence too short
+   to fit the context budget, etc. These look like
+   ``if structure.num_chains > 1: return None``, not exception
+   handlers around upstream calls. The smoke run audits these by
+   inspecting *which* rows returned ``None`` and confirming each
+   one matches the predicate.
+2. **Explicitly opted-in lenient mode** (as above), with a comment
+   tying the decision to a specific failure mode and a policy
+   document.
+
+Everything else should raise. If your smoke run drops rows you
+can't immediately explain via one of these two cases, the right
+move is to delay scaling and figure out why, even if it's only one
+row in a hundred.
 
 ---
 
@@ -365,8 +413,10 @@ _atom_site"`.
 The fix is a single full GET (the filesystem's `cat_file`) that reads
 to EOF. That's what
 [`marinfold.document_structures.io.read_object_bytes`](../../../marinfold/marinfold/document_structures/io.py)
-does. It has the same `None`-on-failure contract as the threading
-helper above, so they compose directly:
+does. It raises on I/O failure by default (per the "Fail loud"
+section above), so a corrupted fetch surfaces as a worker crash
+with a real stack trace rather than as a silently-missing row in
+the corpus:
 
 ```python
 from marinfold.document_structures.io import (
@@ -374,16 +424,18 @@ from marinfold.document_structures.io import (
 )
 
 def _generate_doc_for_row(row, *, cif_uri_column, ...):
-    cif = read_object_bytes(row[cif_uri_column])  # full GET, gzip-safe
-    if cif is None:
-        return None
-    ...
+    cif = read_object_bytes(row[cif_uri_column])  # gzip-safe; raises on failure
+    # ... parse, generate, etc. Exceptions from any of these also propagate.
 ```
 
-Symptom check: if your smoke test produces a suspiciously low success rate
-(e.g. < 5 % of rows yielding output), **inspect a sample of failures**
-before scaling up. A near-total silent drop with an otherwise-working
-pipeline shape is a near-certain I/O truncation bug.
+Symptom check: under the fail-loud default, a truncation bug surfaces
+as a crash on the first affected row, not a silent drop. If you find
+yourself reading "Wrong number of values in loop _atom_site" in a
+worker traceback, this is almost certainly the bug, and the fix is to
+ensure the per-row fetch goes through `read_object_bytes` (which
+uses `cat_file`) rather than a size-based `fsspec.open().read()`.
+If your pipeline runs in opt-in lenient mode and you instead see a
+suspiciously high *rate* of skipped rows, the same diagnosis applies.
 
 ### Requester-pays buckets (AFDB)
 
@@ -442,7 +494,9 @@ parsing every time you want to test a new selection.
 1. Local unit tests (no Zephyr): test_cli.py against file:// URIs.
 2. Local Zephyr smoke (in-process): ZephyrContext with 2-3 inline rows.
 3. Iris smoke: --num-docs 100, one input shard, single output file.
-   Verify success rate, per-doc latency, output schema.
+   Verify the smoke completed without crashing (fail-loud default
+   means no swallowed errors), every dropped row matches a
+   designed-in filter predicate, per-doc latency, output schema.
 4. GATE: report measured rate + worker count + projected wall-clock to
    the user. Don't auto-trigger the full run.
 5. Full run after explicit go-ahead.
@@ -618,8 +672,17 @@ Before triggering the full run, verify each of these:
       `marinfold.document_structures.io.read_object_bytes` (or
       equivalent: a full `cat_file` GET that handles gzip-transcoded
       objects), not `fsspec.open().read()` with size inference.
-- [ ] The worker returns `None` (not raises) on transient I/O / parse
-      failures so a single bad row can't kill a Zephyr worker.
+- [ ] The worker **raises** on I/O / parse / generate failures (the
+      default behavior of the library helpers). Killing one Zephyr
+      worker is much cheaper than silently shipping a corrupted
+      training corpus. Only return ``None`` for *designed-in filter
+      predicates* (multi-chain when single-chain is required,
+      structure too small to fit the context budget, etc.), where the
+      "no output" outcome is a known-and-expected property of the
+      input, not a swallowed error. If your pipeline genuinely needs
+      lenient mode for a specific failure mode, opt in explicitly at
+      the call site (`read_object_bytes(uri, missing_ok=True)`) and
+      add a comment explaining why.
 
 **Per-shard**
 - [ ] URI-path `map_shard` body delegates to
@@ -647,9 +710,18 @@ Before triggering the full run, verify each of these:
 
 **Validation**
 - [ ] Local unit tests pass.
-- [ ] Iris smoke run (`--num-docs 100`, single input shard) produced
-      ≥ 95 % valid docs and measured per-doc latency matches the
-      projection.
+- [ ] Iris smoke run (`--num-docs 100`, single input shard): **every
+      input row is accounted for**. A row either yields output, or
+      matches a designed-in filter predicate that returns ``None``
+      (multi-chain structure, too small to fit the context budget,
+      etc.). No swallowed exceptions: under the fail-loud default,
+      a smoke run that completes without crashing means there were
+      no I/O / parse / generate failures. The smoke set is small
+      enough to enumerate every dropped row and confirm it matches
+      a filter predicate, not a sample.
+- [ ] Measured per-doc latency on the smoke matches the projection
+      within ~2×; large gaps mean either the smoke isn't
+      representative or the projection's assumptions are wrong.
 - [ ] Smoke output sample manually inspected for shape + content.
 - [ ] User has gated the full run.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ See `experiments/README.md` for the workflow and graduation flow,
 and `marinfold/README.md` for the inference/CLI surface. For any
 data-generation pipeline that runs on the marin Iris cluster via
 Zephyr, read the [`zephyr-pipeline-performance`](.agents/skills/zephyr-pipeline-performance/SKILL.md)
-skill before drafting `cli.py` — it captures the handful of
-decisions that separate a fits-in-budget run from an overnight one.
+skill before drafting `cli.py`. It captures the handful of decisions
+that separate a fits-in-budget run from an overnight one.
 
 ## Shared coding practices
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,11 @@ promote it to the kind library once a second use case actually exists
 (not before).
 
 See `experiments/README.md` for the workflow and graduation flow,
-and `marinfold/README.md` for the inference/CLI surface.
+and `marinfold/README.md` for the inference/CLI surface. For any
+data-generation pipeline that runs on the marin Iris cluster via
+Zephyr, read the [`zephyr-pipeline-performance`](.agents/skills/zephyr-pipeline-performance/SKILL.md)
+skill before drafting `cli.py` — it captures the handful of
+decisions that separate a fits-in-budget run from an overnight one.
 
 ## Shared coding practices
 

--- a/experiments/AGENTS.md
+++ b/experiments/AGENTS.md
@@ -188,11 +188,12 @@ initiative — see rule #6.
 For any `exp<N>_data_*/` that runs a `map_shard` pipeline on the marin
 Iris cluster, read the
 [`zephyr-pipeline-performance`](../.agents/skills/zephyr-pipeline-performance/SKILL.md)
-skill **before** drafting `cli.py`. It captures the five decisions that
-dominate Zephyr pipeline wall-clock — source data via the manifest's
+skill **before** drafting `cli.py`. It covers the five decisions that
+dominate Zephyr pipeline wall-clock: source data via the manifest's
 `gcs_uri` pointer (not bulky inline cif), thread the per-row fetch, pin
 the region, memoize per-worker init, and use the shared gzip-safe
-reader — with the code patterns that imply them.
+reader. Each decision is paired with the code pattern that implements
+it.
 
 The skill exists because the same handful of mistakes keep eating
 hours-to-days of cluster time on each new data experiment. The cost of

--- a/experiments/AGENTS.md
+++ b/experiments/AGENTS.md
@@ -188,12 +188,14 @@ initiative — see rule #6.
 For any `exp<N>_data_*/` that runs a `map_shard` pipeline on the marin
 Iris cluster, read the
 [`zephyr-pipeline-performance`](../.agents/skills/zephyr-pipeline-performance/SKILL.md)
-skill **before** drafting `cli.py`. It covers the five decisions that
-dominate Zephyr pipeline wall-clock: source data via the manifest's
-`gcs_uri` pointer (not bulky inline cif), thread the per-row fetch, pin
-the region, memoize per-worker init, and use the shared gzip-safe
-reader. Each decision is paired with the code pattern that implements
-it.
+skill **before** drafting `cli.py`. It covers the six decisions that
+dominate Zephyr pipeline correctness and wall-clock: source data via
+the manifest's `gcs_uri` pointer (not bulky inline cif), thread the
+per-row fetch, pin the region, memoize per-worker init, use the
+shared gzip-safe reader, and default to fail-loud on data-quality
+failures (a silently-dropped row corrupts the training corpus
+weeks-of-debugging downstream). Each decision is paired with the
+code pattern that implements it.
 
 The skill exists because the same handful of mistakes keep eating
 hours-to-days of cluster time on each new data experiment. The cost of

--- a/experiments/AGENTS.md
+++ b/experiments/AGENTS.md
@@ -183,6 +183,24 @@ add a comment on the issue with a link to the PDF (raw GitHub URL or
 HuggingFace if it's too big to commit). Don't do this on your own
 initiative — see rule #6.
 
+## Writing a data-generation pipeline (Zephyr / Iris)
+
+For any `exp<N>_data_*/` that runs a `map_shard` pipeline on the marin
+Iris cluster, read the
+[`zephyr-pipeline-performance`](../.agents/skills/zephyr-pipeline-performance/SKILL.md)
+skill **before** drafting `cli.py`. It captures the five decisions that
+dominate Zephyr pipeline wall-clock — source data via the manifest's
+`gcs_uri` pointer (not bulky inline cif), thread the per-row fetch, pin
+the region, memoize per-worker init, and use the shared gzip-safe
+reader — with the code patterns that imply them.
+
+The skill exists because the same handful of mistakes keep eating
+hours-to-days of cluster time on each new data experiment. The cost of
+the 10 minutes it takes to read is much less than the cost of the next
+overnight run that fails on a known issue. **Both `exp5` (8 min for
+1.6 M structures) and `exp53` (31 min for 4.2 M)** are the reference
+implementations cited throughout.
+
 ## Importing from kind libraries
 
 An experiment that needs marin or a kind library has its own

--- a/experiments/exp53_data_contacts_v1_zephyr/generate_rows.py
+++ b/experiments/exp53_data_contacts_v1_zephyr/generate_rows.py
@@ -22,7 +22,6 @@ provenance columns (``round``, ``struct_cluster_id``, …).
 
 import warnings
 from collections.abc import Iterable, Iterator
-from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import Any
 
@@ -33,6 +32,10 @@ from marinfold.document_structures.contacts_v1 import (
     generate_document,
 )
 from marinfold.document_structures.contacts_v1.vocab import CONTEXT_LENGTH, NAME
+from marinfold.document_structures.io import (
+    read_object_bytes,
+    thread_per_row_in_shard,
+)
 
 # Manifest columns copied verbatim onto every output row (provenance: lets a
 # generated doc be traced back to its cluster / round / split / source).
@@ -99,27 +102,6 @@ def structure_from_cif(data: str | bytes, *, entry_id: str) -> gemmi.Structure:
     return structure
 
 
-def _fetch_cif_bytes(uri: str) -> bytes | None:
-    """Fetch a cif from a URI, reading the *whole* object. ``None`` on error.
-
-    Uses the filesystem's ``cat_file`` (a single full GET) rather than a
-    seekable ``open().read()``. The AFDB GCS objects are gzip-transcoded
-    (``Content-Encoding: gzip``) and report their *compressed* size, so a
-    size/range-based read returns only that many bytes of the decompressed
-    stream and silently truncates larger structures mid-``_atom_site`` loop
-    (gemmi then raises "Wrong number of values in loop _atom_site"). A plain
-    GET lets GCS decompressively transcode and we read to EOF -- the full mmCIF.
-    """
-    import fsspec
-
-    try:
-        fs, path = fsspec.core.url_to_fs(uri)
-        return fs.cat_file(path)
-    except (OSError, ValueError) as exc:
-        warnings.warn(f"fetch failed for {uri}: {exc}", stacklevel=2)
-        return None
-
-
 def build_output_row(row: dict, result, *, structure_name: str = NAME) -> dict[str, Any]:
     """Assemble one output row: contacts-v1 metadata + manifest provenance.
 
@@ -161,7 +143,7 @@ def generate_doc_for_row(
         uri = row.get(cif_uri_column)
         if not uri:
             return None
-        cif = _fetch_cif_bytes(uri)
+        cif = read_object_bytes(uri)
         if cif is None:
             return None
     try:
@@ -197,15 +179,11 @@ def generate_shard(
     Signature ``(items, shard_info, *, ...)`` matches zephyr's ``map_shard``
     contract, but the function is plain Python and unit-tested directly. The
     rotamer library is loaded once for the whole shard. For the URI path,
-    fetches run on a ``ThreadPoolExecutor`` so the per-row GCS GETs overlap
-    pyconfind's contact computation (pyconfind releases the GIL in its
-    compiled backend). For the inline-cif path there is no I/O to overlap,
-    so rows run sequentially. Output order mirrors input order
-    (``pool.map``), keeping per-shard output deterministic.
+    delegates to :func:`marinfold.document_structures.io.thread_per_row_in_shard`
+    so the per-row GCS GETs overlap pyconfind's contact computation
+    (pyconfind releases the GIL in its compiled backend). For the inline-cif
+    path there is no I/O to overlap, so rows run sequentially.
     """
-    rows = list(items)
-    if not rows:
-        return
     rotamer_library = _load_rotamer_library()
     worker = partial(
         generate_doc_for_row,
@@ -217,13 +195,13 @@ def generate_shard(
         structure_name=structure_name,
     )
     if cif_text_column is not None:
-        for row in rows:
+        for row in items:
             out = worker(row)
             if out is not None:
                 yield out
         return
-    workers = min(fetch_concurrency, len(rows))
-    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="exp53-fetch") as pool:
-        for out in pool.map(worker, rows):
-            if out is not None:
-                yield out
+    yield from thread_per_row_in_shard(
+        items, worker=worker,
+        fetch_concurrency=fetch_concurrency,
+        thread_name_prefix="exp53-fetch",
+    )

--- a/experiments/exp53_data_contacts_v1_zephyr/generate_rows.py
+++ b/experiments/exp53_data_contacts_v1_zephyr/generate_rows.py
@@ -128,16 +128,19 @@ def generate_doc_for_row(
     serializable range. Never raises on a single bad row — a dropped row
     just shrinks its round slightly (issue #53: drop, don't backfill).
     """
+    # exp53 ships in lenient mode: per issue #53 (drop, don't backfill),
+    # rows that fail to fetch or generate are dropped from the corpus
+    # rather than retried or backfilled.
     entry_id = row.get("entry_id")
     if cif_text_column is not None:
         cif = row.get(cif_text_column)
         if not cif:
-            return None
+            return None  # lenient: missing inline cif column → skip
     else:
         uri = row.get(cif_uri_column)
         if not uri:
-            return None
-        cif = read_object_bytes(uri)
+            return None  # lenient: missing URI in row → skip
+        cif = read_object_bytes(uri, missing_ok=True)  # lenient: skip on fetch failure
         if cif is None:
             return None
     try:
@@ -150,6 +153,8 @@ def generate_doc_for_row(
             rotamer_library=rotamer_library,
         )
     except (ValueError, RuntimeError) as exc:
+        # lenient: parse/generate failures (multi-chain, invalid cif,
+        # contacts-v1 out-of-range) are warned + dropped.
         warnings.warn(f"generate failed for {entry_id}: {exc}", stacklevel=2)
         return None
     if result is None:

--- a/experiments/exp53_data_contacts_v1_zephyr/generate_rows.py
+++ b/experiments/exp53_data_contacts_v1_zephyr/generate_rows.py
@@ -20,6 +20,7 @@ seed. The output row is contacts-v1's ``metadata_row()`` plus the manifest
 provenance columns (``round``, ``struct_cluster_id``, …).
 """
 
+import functools
 import warnings
 from collections.abc import Iterable, Iterator
 from functools import partial
@@ -54,28 +55,22 @@ PASSTHROUGH_COLUMNS: tuple[str, ...] = (
 DEFAULT_CIF_URI_COLUMN = "gcs_uri"
 
 
-# Process-wide cache of the parsed rotamer library (or None on failure). A
-# Zephyr worker processes many shards; parsing pyconfind's (large) EBL.out is
-# ~tens of seconds, so we do it once per worker process, not once per shard.
-_ROTAMER_UNSET: Any = object()
-_ROTAMER_LIBRARY: Any = _ROTAMER_UNSET
-
-
+@functools.cache
 def _load_rotamer_library() -> Any | None:
     """Parse pyconfind's Dunbrack rotamer library once per process (best effort).
 
-    Memoized process-wide and passed explicitly to every ``generate_document``
-    call so pyconfind does not re-parse the (large) ``EBL.out`` for each
-    structure or each shard, and so the shard's fetch threads don't race on
-    pyconfind's lazy process-wide default. ``cached_rotamer_library()``
-    downloads + caches the library per user and returns its path;
-    ``load_library`` parses it. Returns ``None`` on failure —
-    ``generate_document(rotamer_library=None)`` then falls back to pyconfind's
-    own lazy load (slower, but correct).
+    Memoized process-wide via ``functools.cache`` and passed explicitly to
+    every ``generate_document`` call so pyconfind does not re-parse the
+    (large) ``EBL.out`` for each structure or each shard, and so the
+    shard's fetch threads don't race on pyconfind's lazy process-wide
+    default. A Zephyr worker processes many shards; ``EBL.out`` parsing
+    is ~tens of seconds — once per worker, not once per shard.
+
+    Returns ``None`` on failure — ``generate_document(rotamer_library=None)``
+    then falls back to pyconfind's own lazy load (slower, but correct).
+    The None return is itself cached (next call is instant), so a worker
+    whose preload failed once doesn't retry per shard.
     """
-    global _ROTAMER_LIBRARY
-    if _ROTAMER_LIBRARY is not _ROTAMER_UNSET:
-        return _ROTAMER_LIBRARY
     try:
         from pyconfind import load_library
 
@@ -84,12 +79,11 @@ def _load_rotamer_library() -> Any | None:
         except ImportError:
             from pyconfind.data import cached_rotamer_library
 
-        _ROTAMER_LIBRARY = load_library(cached_rotamer_library())
+        return load_library(cached_rotamer_library())
     except Exception as exc:  # noqa: BLE001 — optional speedup, never fatal
         warnings.warn(f"rotamer-library preload failed ({exc}); per-call load",
                       stacklevel=2)
-        _ROTAMER_LIBRARY = None
-    return _ROTAMER_LIBRARY
+        return None
 
 
 def structure_from_cif(data: str | bytes, *, entry_id: str) -> gemmi.Structure:

--- a/marinfold/marinfold/document_structures/__init__.py
+++ b/marinfold/marinfold/document_structures/__init__.py
@@ -16,9 +16,18 @@ This subpackage holds the three pieces every impl shares:
   an ordered token list.
 - :func:`write_docs` / :func:`write_predictions` / :func:`write_eval`
   — parquet / jsonl writers for the three standard output shapes.
+- :func:`read_object_bytes` / :func:`thread_per_row_in_shard` — fetch
+  one object's bytes, and run a thread-pool ``map_shard`` body that
+  overlaps per-row I/O with CPU work. Together they cover the per-row
+  worker every data-generation pipeline ends up writing (see the
+  ``zephyr-pipeline-performance`` skill).
 """
 
 from marinfold.document_structures.core import EvalResult, build_tokenizer
+from marinfold.document_structures.io import (
+    read_object_bytes,
+    thread_per_row_in_shard,
+)
 from marinfold.document_structures.writers import (
     write_docs,
     write_eval,
@@ -28,6 +37,8 @@ from marinfold.document_structures.writers import (
 __all__ = [
     "EvalResult",
     "build_tokenizer",
+    "read_object_bytes",
+    "thread_per_row_in_shard",
     "write_docs",
     "write_eval",
     "write_predictions",

--- a/marinfold/marinfold/document_structures/io.py
+++ b/marinfold/marinfold/document_structures/io.py
@@ -54,11 +54,14 @@ def thread_per_row_in_shard(
     This matters when downstream readers want deterministic per-shard
     parquet content across runs.
 
-    The worker is expected to return ``None`` on a transient row-level
-    failure (bad fetch, unparseable cif, doesn't fit the token budget)
-    rather than raising; those rows are silently dropped here. A bad
-    row that raises instead would kill the Zephyr worker for the whole
-    shard.
+    Worker exceptions propagate. If the worker raises, the surrounding
+    Zephyr worker dies, which is the correct behavior for data-quality
+    failures (a silently-dropped row corrupts the downstream training
+    corpus). Use ``None`` *only* for designed-in filters: rows that the
+    worker has explicitly determined are not eligible (e.g. a structure
+    too small to fit the context budget). Lenient skip-on-error
+    behavior, when truly needed, lives at the call site (e.g.
+    ``read_object_bytes(uri, missing_ok=True)``), not here.
 
     Parameters
     ----------
@@ -113,13 +116,22 @@ def thread_per_row_in_shard(
                 yield out
 
 
-def read_object_bytes(uri: str, *, warn: bool = True) -> Optional[bytes]:
+def read_object_bytes(
+    uri: str, *, missing_ok: bool = False, warn: bool = True,
+) -> Optional[bytes]:
     """Read the full byte contents of a remote (or local) object via fsspec.
 
-    Returns ``None`` on any I/O failure (and, by default, emits a
-    warning) so a single bad object in a shard does not bring down the
-    surrounding worker. Pairs with :func:`thread_per_row_in_shard`,
-    which skips ``None`` results.
+    **Raises on I/O failure by default**. This is deliberate: in a
+    data-generation pipeline, a silently-dropped row corrupts the
+    training corpus, and the cost of discovering that weeks later (when
+    a model behaves oddly) far exceeds the cost of killing a Zephyr
+    worker on a single bad fetch.
+
+    Pass ``missing_ok=True`` only when a missing/unfetchable object is
+    expected and acceptable (e.g. enumerating which entries in a
+    candidate list are actually present in the bucket). Lenient mode
+    returns ``None`` instead of raising, and, by default, emits a
+    ``warnings.warn`` so the drop shows up in logs.
 
     Uses the filesystem's ``cat_file`` (a single full GET that reads to
     EOF) rather than a seekable ``open(...).read()``. The two differ in
@@ -142,16 +154,23 @@ def read_object_bytes(uri: str, *, warn: bool = True) -> Optional[bytes]:
     uri
         fsspec-recognised URI: a local path, ``file://``, ``gs://``,
         ``s3://``, ``hf://``, ``http(s)://``, etc.
+    missing_ok
+        Default ``False`` (raise on failure). Pass ``True`` only when
+        the caller has audited the failure modes and decided a silent
+        skip is correct. With ``True``, returns ``None`` instead of
+        raising.
     warn
-        Default ``True``. Emits a ``warnings.warn`` on I/O failure so
-        ops can spot patterns in worker logs. Pass ``warn=False`` for
-        bulk scans (e.g. enumerating known-missing objects) where the
-        log spam would drown out signal.
+        Only consulted when ``missing_ok=True``. Default emits a
+        ``warnings.warn`` on the drop so it shows up in worker logs.
+        Pass ``warn=False`` for bulk scans where the log spam would
+        drown out signal.
     """
     try:
         fs, path = fsspec.core.url_to_fs(uri)
         return fs.cat_file(path)
     except (OSError, ValueError) as exc:
+        if not missing_ok:
+            raise
         if warn:
             warnings.warn(f"fetch failed for {uri}: {exc}", stacklevel=2)
         return None

--- a/marinfold/marinfold/document_structures/io.py
+++ b/marinfold/marinfold/document_structures/io.py
@@ -26,6 +26,8 @@ from collections.abc import Callable, Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, TypeVar
 
+import fsspec
+
 T = TypeVar("T")
 U = TypeVar("U")
 
@@ -111,13 +113,13 @@ def thread_per_row_in_shard(
                 yield out
 
 
-def read_object_bytes(uri: str) -> Optional[bytes]:
+def read_object_bytes(uri: str, *, warn: bool = True) -> Optional[bytes]:
     """Read the full byte contents of a remote (or local) object via fsspec.
 
-    Returns ``None`` on any I/O failure, emitting a warning, so a single
-    bad object in a shard does not bring down the surrounding worker —
-    designed to pair with :func:`thread_per_row_in_shard`, which skips
-    ``None`` results.
+    Returns ``None`` on any I/O failure (and, by default, emits a warning),
+    so a single bad object in a shard does not bring down the surrounding
+    worker — designed to pair with :func:`thread_per_row_in_shard`, which
+    skips ``None`` results.
 
     Uses the filesystem's ``cat_file`` (a single full GET that reads to
     EOF) rather than a seekable ``open(...).read()``. The two differ in
@@ -134,12 +136,22 @@ def read_object_bytes(uri: str) -> Optional[bytes]:
     Common case: GCS objects uploaded with ``Content-Encoding: gzip``
     metadata, which GCS transparently decodes on serve (see the GCS
     "transcoding" docs).
-    """
-    import fsspec
 
+    Parameters
+    ----------
+    uri
+        fsspec-recognised URI: a local path, ``file://``, ``gs://``,
+        ``s3://``, ``hf://``, ``http(s)://``, etc.
+    warn
+        Default ``True``: emit a ``warnings.warn`` on I/O failure so
+        ops can spot patterns in worker logs. Pass ``warn=False`` for
+        bulk scans (e.g. enumerating known-missing objects) where the
+        log spam would drown out signal.
+    """
     try:
         fs, path = fsspec.core.url_to_fs(uri)
         return fs.cat_file(path)
     except (OSError, ValueError) as exc:
-        warnings.warn(f"fetch failed for {uri}: {exc}", stacklevel=2)
+        if warn:
+            warnings.warn(f"fetch failed for {uri}: {exc}", stacklevel=2)
         return None

--- a/marinfold/marinfold/document_structures/io.py
+++ b/marinfold/marinfold/document_structures/io.py
@@ -1,0 +1,145 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared I/O patterns for document-structure data-generation pipelines.
+
+This module's natural home is the per-row worker that runs inside a
+Zephyr ``map_shard`` body: most document-structure ``generate`` impls
+need the same pattern — fetch a per-row resource over the network,
+parse it, hand it to the algorithm, emit a row.
+
+Two helpers, designed to compose:
+
+- :func:`read_object_bytes` — fetch one object's bytes (returns ``None``
+  on I/O failure). Uses a full GET so transparently-gzip-transcoded
+  objects aren't silently truncated.
+- :func:`thread_per_row_in_shard` — the ``map_shard`` body that
+  overlaps per-row I/O with CPU work via a thread pool.
+
+See ``.agents/skills/zephyr-pipeline-performance/SKILL.md`` for the
+full performance rationale + the surrounding decisions
+(``--worker-cpu 1``, region pinning, etc.).
+"""
+
+import warnings
+from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+def thread_per_row_in_shard(
+    items: Iterable[T],
+    *,
+    worker: Callable[[T], Optional[U]],
+    fetch_concurrency: int = 32,
+    thread_name_prefix: str = "shard",
+) -> Iterator[U]:
+    """Run ``worker`` on each item via a ``ThreadPoolExecutor`` and yield
+    non-``None`` results in input order.
+
+    Intended as the body of a Zephyr ``map_shard`` callback when each row
+    requires a per-row network fetch (GCS GET, HF download, …) followed by
+    CPU work (parse + generate). The thread pool overlaps the fetches with
+    the CPU work of rows that have already arrived — the single biggest
+    per-shard speedup, because the GIL is released during both the network
+    syscall and most C-extension parsers (gemmi, pyconfind, ...).
+
+    The pool size is capped at ``len(items)`` so a small shard does not
+    spawn dozens of idle threads. Output uses ``pool.map`` (not
+    ``as_completed``), so the iteration order matches the input order —
+    important when downstream readers want deterministic per-shard
+    parquet content across runs.
+
+    The worker is expected to return ``None`` on a transient row-level
+    failure (bad fetch, unparseable cif, doesn't fit the token budget)
+    rather than raising; those rows are silently dropped here. Letting a
+    single bad row raise would kill the Zephyr worker for the whole
+    shard.
+
+    Parameters
+    ----------
+    items
+        The shard's per-row inputs (Zephyr passes a list-like).
+    worker
+        Per-row callable. Should return ``None`` to skip a row, or the
+        output value to yield. Must be picklable if the Zephyr backend
+        ships it cross-process — typically the call site builds one via
+        ``functools.partial(per_row_fn, **shard_constants)``.
+    fetch_concurrency
+        Max concurrent in-flight workers. ``32`` is well-calibrated for
+        30–80 ms GCS GETs paired with ~6 ms of CPU per row. Bump it when
+        the CPU step is heavier, but past ~64 the overhead starts to
+        dominate.
+    thread_name_prefix
+        Surfaces in thread dumps + logs — useful when babysitting a
+        running Zephyr job. Convention: ``"<exp-tag>-fetch"`` (e.g.
+        ``"exp5-fetch"``).
+
+    Example
+    -------
+    Inside an ``exp<N>_data_*/cli.py`` ``map_shard`` body:
+
+    .. code-block:: python
+
+        from functools import partial
+        from marinfold.document_structures.io import thread_per_row_in_shard
+
+        def generate_shard(items, shard_info, *, cfg, fetch_concurrency, ...):
+            worker = partial(_generate_doc_for_row, cfg=cfg, ...)
+            yield from thread_per_row_in_shard(
+                items, worker=worker,
+                fetch_concurrency=fetch_concurrency,
+                thread_name_prefix="exp<N>-fetch",
+            )
+
+    For pipelines that have *both* a URI-fetch path and an inline path
+    (e.g. ``--cif-text-column`` for local testing), branch at the call
+    site and use ``map`` for the inline path — there's no I/O to overlap,
+    so the thread pool is pure overhead.
+    """
+    rows = list(items)
+    if not rows:
+        return
+    workers = min(fetch_concurrency, len(rows))
+    with ThreadPoolExecutor(max_workers=workers,
+                            thread_name_prefix=thread_name_prefix) as pool:
+        for out in pool.map(worker, rows):
+            if out is not None:
+                yield out
+
+
+def read_object_bytes(uri: str) -> Optional[bytes]:
+    """Read the full byte contents of a remote (or local) object via fsspec.
+
+    Returns ``None`` on any I/O failure, emitting a warning, so a single
+    bad object in a shard does not bring down the surrounding worker —
+    designed to pair with :func:`thread_per_row_in_shard`, which skips
+    ``None`` results.
+
+    Uses the filesystem's ``cat_file`` (a single full GET that reads to
+    EOF) rather than a seekable ``open(...).read()``. The two differ in
+    one important case: **objects served with** ``Content-Encoding: gzip``
+    (server-side transcoded) **report their compressed size in the
+    ``Content-Length`` header**, while the body is decompressed on the
+    wire. A size-based read returns only that many bytes of the
+    decompressed stream and silently truncates large objects mid-content
+    — the kind of failure a downstream parser surfaces as a confusing
+    "unexpected end of input" error rather than as an obvious I/O fault.
+    ``cat_file`` reads to EOF, so the full decompressed object is
+    returned every time.
+
+    Common case: GCS objects uploaded with ``Content-Encoding: gzip``
+    metadata, which GCS transparently decodes on serve (see the GCS
+    "transcoding" docs).
+    """
+    import fsspec
+
+    try:
+        fs, path = fsspec.core.url_to_fs(uri)
+        return fs.cat_file(path)
+    except (OSError, ValueError) as exc:
+        warnings.warn(f"fetch failed for {uri}: {exc}", stacklevel=2)
+        return None

--- a/marinfold/marinfold/document_structures/io.py
+++ b/marinfold/marinfold/document_structures/io.py
@@ -3,21 +3,19 @@
 
 """Shared I/O patterns for document-structure data-generation pipelines.
 
-This module's natural home is the per-row worker that runs inside a
-Zephyr ``map_shard`` body: most document-structure ``generate`` impls
-need the same pattern — fetch a per-row resource over the network,
-parse it, hand it to the algorithm, emit a row.
+The per-row worker inside a Zephyr ``map_shard`` body usually follows
+the same pattern across document-structure ``generate`` impls: fetch a
+per-row resource over the network, parse it, hand it to the algorithm,
+emit a row. Two helpers here cover the parts that recur:
 
-Two helpers, designed to compose:
-
-- :func:`read_object_bytes` — fetch one object's bytes (returns ``None``
-  on I/O failure). Uses a full GET so transparently-gzip-transcoded
+- :func:`read_object_bytes`: fetch one object's bytes. Returns ``None``
+  on I/O failure. Uses a full GET so transparently-gzip-transcoded
   objects aren't silently truncated.
-- :func:`thread_per_row_in_shard` — the ``map_shard`` body that
-  overlaps per-row I/O with CPU work via a thread pool.
+- :func:`thread_per_row_in_shard`: a ``map_shard`` body that overlaps
+  per-row I/O with CPU work via a thread pool.
 
 See ``.agents/skills/zephyr-pipeline-performance/SKILL.md`` for the
-full performance rationale + the surrounding decisions
+full performance rationale and the surrounding decisions
 (``--worker-cpu 1``, region pinning, etc.).
 """
 
@@ -43,22 +41,23 @@ def thread_per_row_in_shard(
     non-``None`` results in input order.
 
     Intended as the body of a Zephyr ``map_shard`` callback when each row
-    requires a per-row network fetch (GCS GET, HF download, …) followed by
-    CPU work (parse + generate). The thread pool overlaps the fetches with
-    the CPU work of rows that have already arrived — the single biggest
-    per-shard speedup, because the GIL is released during both the network
-    syscall and most C-extension parsers (gemmi, pyconfind, ...).
+    requires a per-row network fetch (GCS GET, HF download, …) followed
+    by CPU work (parse + generate). The thread pool overlaps fetches
+    with the CPU work of rows that have already arrived. The GIL is
+    released during both the network syscall and most C-extension
+    parsers (gemmi, pyconfind, ...), so threading is the per-shard
+    speedup that matters most for I/O-bound workers.
 
     The pool size is capped at ``len(items)`` so a small shard does not
     spawn dozens of idle threads. Output uses ``pool.map`` (not
-    ``as_completed``), so the iteration order matches the input order —
-    important when downstream readers want deterministic per-shard
+    ``as_completed``), so the iteration order matches the input order.
+    This matters when downstream readers want deterministic per-shard
     parquet content across runs.
 
     The worker is expected to return ``None`` on a transient row-level
     failure (bad fetch, unparseable cif, doesn't fit the token budget)
-    rather than raising; those rows are silently dropped here. Letting a
-    single bad row raise would kill the Zephyr worker for the whole
+    rather than raising; those rows are silently dropped here. A bad
+    row that raises instead would kill the Zephyr worker for the whole
     shard.
 
     Parameters
@@ -68,15 +67,16 @@ def thread_per_row_in_shard(
     worker
         Per-row callable. Should return ``None`` to skip a row, or the
         output value to yield. Must be picklable if the Zephyr backend
-        ships it cross-process — typically the call site builds one via
+        ships it cross-process. The call site typically builds one via
         ``functools.partial(per_row_fn, **shard_constants)``.
     fetch_concurrency
-        Max concurrent in-flight workers. ``32`` is well-calibrated for
-        30–80 ms GCS GETs paired with ~6 ms of CPU per row. Bump it when
+        Max concurrent in-flight workers. ``32`` works well for the
+        common case where the per-row GCS GET (~30–80 ms) is an order
+        of magnitude larger than the per-row CPU step. Bump it when
         the CPU step is heavier, but past ~64 the overhead starts to
         dominate.
     thread_name_prefix
-        Surfaces in thread dumps + logs — useful when babysitting a
+        Surfaces in thread dumps and logs. Useful when babysitting a
         running Zephyr job. Convention: ``"<exp-tag>-fetch"`` (e.g.
         ``"exp5-fetch"``).
 
@@ -99,8 +99,8 @@ def thread_per_row_in_shard(
 
     For pipelines that have *both* a URI-fetch path and an inline path
     (e.g. ``--cif-text-column`` for local testing), branch at the call
-    site and use ``map`` for the inline path — there's no I/O to overlap,
-    so the thread pool is pure overhead.
+    site and use ``map`` for the inline path. There is no I/O to
+    overlap, so the thread pool is pure overhead.
     """
     rows = list(items)
     if not rows:
@@ -116,26 +116,26 @@ def thread_per_row_in_shard(
 def read_object_bytes(uri: str, *, warn: bool = True) -> Optional[bytes]:
     """Read the full byte contents of a remote (or local) object via fsspec.
 
-    Returns ``None`` on any I/O failure (and, by default, emits a warning),
-    so a single bad object in a shard does not bring down the surrounding
-    worker — designed to pair with :func:`thread_per_row_in_shard`, which
-    skips ``None`` results.
+    Returns ``None`` on any I/O failure (and, by default, emits a
+    warning) so a single bad object in a shard does not bring down the
+    surrounding worker. Pairs with :func:`thread_per_row_in_shard`,
+    which skips ``None`` results.
 
     Uses the filesystem's ``cat_file`` (a single full GET that reads to
     EOF) rather than a seekable ``open(...).read()``. The two differ in
-    one important case: **objects served with** ``Content-Encoding: gzip``
-    (server-side transcoded) **report their compressed size in the
-    ``Content-Length`` header**, while the body is decompressed on the
+    one important case: objects served with ``Content-Encoding: gzip``
+    (server-side transcoded) report their compressed size in the
+    ``Content-Length`` header, while the body is decompressed on the
     wire. A size-based read returns only that many bytes of the
-    decompressed stream and silently truncates large objects mid-content
-    — the kind of failure a downstream parser surfaces as a confusing
-    "unexpected end of input" error rather than as an obvious I/O fault.
-    ``cat_file`` reads to EOF, so the full decompressed object is
-    returned every time.
+    decompressed stream and silently truncates large objects
+    mid-content. The downstream parser then surfaces this as a
+    confusing "unexpected end of input" rather than as an I/O fault.
+    ``cat_file`` reads to EOF, so the full decompressed object comes
+    back every time.
 
-    Common case: GCS objects uploaded with ``Content-Encoding: gzip``
-    metadata, which GCS transparently decodes on serve (see the GCS
-    "transcoding" docs).
+    The common case is GCS objects uploaded with ``Content-Encoding:
+    gzip`` metadata, which GCS transparently decodes on serve (see the
+    GCS "transcoding" docs).
 
     Parameters
     ----------
@@ -143,7 +143,7 @@ def read_object_bytes(uri: str, *, warn: bool = True) -> Optional[bytes]:
         fsspec-recognised URI: a local path, ``file://``, ``gs://``,
         ``s3://``, ``hf://``, ``http(s)://``, etc.
     warn
-        Default ``True``: emit a ``warnings.warn`` on I/O failure so
+        Default ``True``. Emits a ``warnings.warn`` on I/O failure so
         ops can spot patterns in worker logs. Pass ``warn=False`` for
         bulk scans (e.g. enumerating known-missing objects) where the
         log spam would drown out signal.

--- a/marinfold/tests/document_structures/test_io.py
+++ b/marinfold/tests/document_structures/test_io.py
@@ -4,19 +4,25 @@
 """Tests for marinfold.document_structures.io.
 
 - ``read_object_bytes``: fetch one object's bytes via fsspec.
-  Contracts: returns the bytes on success; returns ``None`` on
-  failure (never raises); emits a warning by default; can be silenced
-  with ``warn=False``.
+  Contracts: returns the bytes on success; **raises on failure by
+  default** (fail-loud, so corrupted data can't propagate silently
+  into a training corpus); ``missing_ok=True`` returns ``None``
+  instead and emits a warning; ``missing_ok=True, warn=False``
+  silences the warning.
 
 - ``thread_per_row_in_shard``: per-shard worker fan-out. Contracts:
-  yields in input order; skips ``None`` results; empty input is a
-  no-op (does not spawn a pool).
+  yields in input order; skips ``None`` results (for designed-in
+  filters); empty input is a no-op (does not spawn a pool); worker
+  exceptions propagate (verified implicitly via read_object_bytes's
+  default behavior).
 
 Tests use the local filesystem (via plain paths and ``file://`` URIs)
 so they have no network dependency and run in milliseconds.
 """
 
 import warnings
+
+import pytest
 
 from marinfold.document_structures.io import (
     read_object_bytes,
@@ -34,20 +40,28 @@ def test_read_object_bytes_returns_full_contents(tmp_path):
     assert read_object_bytes(str(path)) == b"hello world"
 
 
-def test_read_object_bytes_returns_none_and_warns_on_failure():
-    """Failure contract: never raises; returns None; emits a warning."""
+def test_read_object_bytes_raises_on_failure_by_default():
+    """Fail-loud default: I/O failures propagate. A silently-dropped row
+    would corrupt a training corpus; loud failures force triage."""
+    with pytest.raises((OSError, ValueError)):
+        read_object_bytes("/no/such/path/that/exists")
+
+
+def test_read_object_bytes_missing_ok_returns_none_and_warns():
+    """Opt-in lenient mode: returns None and emits a warning."""
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        result = read_object_bytes("/no/such/path/that/exists")
+        result = read_object_bytes("/no/such/path", missing_ok=True)
     assert result is None
     assert any("fetch failed" in str(w.message) for w in caught)
 
 
-def test_read_object_bytes_warn_false_silences_warning():
-    """``warn=False`` suppresses the per-failure log (for bulk scans)."""
+def test_read_object_bytes_missing_ok_warn_false_silences_warning():
+    """``warn=False`` (with missing_ok=True) suppresses the per-failure
+    log, for bulk scans where the spam would drown out signal."""
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        result = read_object_bytes("/no/such/path", warn=False)
+        result = read_object_bytes("/no/such/path", missing_ok=True, warn=False)
     assert result is None
     assert not any("fetch failed" in str(w.message) for w in caught)
 

--- a/marinfold/tests/document_structures/test_io.py
+++ b/marinfold/tests/document_structures/test_io.py
@@ -1,0 +1,74 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for marinfold.document_structures.io.
+
+- ``read_object_bytes`` — fetch one object's bytes via fsspec.
+  Contracts: returns the bytes on success; returns ``None`` on
+  failure (never raises); emits a warning by default; can be silenced
+  with ``warn=False``.
+
+- ``thread_per_row_in_shard`` — per-shard worker fan-out.
+  Contracts: yields in input order; skips ``None`` results; empty
+  input is a no-op (does not spawn a pool).
+
+Tests use the local filesystem (via plain paths and ``file://`` URIs)
+so they have no network dependency and run in milliseconds.
+"""
+
+import warnings
+
+from marinfold.document_structures.io import (
+    read_object_bytes,
+    thread_per_row_in_shard,
+)
+
+
+# ---------- read_object_bytes ----------------------------------------------
+
+
+def test_read_object_bytes_returns_full_contents(tmp_path):
+    """Happy path: bytes round-trip through the fsspec dispatch."""
+    path = tmp_path / "hello.bin"
+    path.write_bytes(b"hello world")
+    assert read_object_bytes(str(path)) == b"hello world"
+
+
+def test_read_object_bytes_returns_none_and_warns_on_failure():
+    """Failure contract: never raises; returns None; emits a warning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = read_object_bytes("/no/such/path/that/exists")
+    assert result is None
+    assert any("fetch failed" in str(w.message) for w in caught)
+
+
+def test_read_object_bytes_warn_false_silences_warning():
+    """``warn=False`` suppresses the per-failure log (for bulk scans)."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = read_object_bytes("/no/such/path", warn=False)
+    assert result is None
+    assert not any("fetch failed" in str(w.message) for w in caught)
+
+
+# ---------- thread_per_row_in_shard ----------------------------------------
+
+
+def test_thread_per_row_preserves_input_order_and_skips_none():
+    """Output is in input order; rows whose worker returns None drop out.
+
+    Bundles two contracts in one assertion because they're co-equal
+    promises: a caller relying on either alone is relying on both.
+    """
+    result = list(thread_per_row_in_shard(
+        [1, 2, 3, 4, 5],
+        worker=lambda x: None if x % 2 == 0 else x * 10,
+        fetch_concurrency=3,
+    ))
+    assert result == [10, 30, 50]
+
+
+def test_thread_per_row_empty_input_is_no_op():
+    """Empty input yields nothing without trying to spawn a 0-size pool."""
+    assert list(thread_per_row_in_shard([], worker=lambda x: x)) == []

--- a/marinfold/tests/document_structures/test_io.py
+++ b/marinfold/tests/document_structures/test_io.py
@@ -3,14 +3,14 @@
 
 """Tests for marinfold.document_structures.io.
 
-- ``read_object_bytes`` — fetch one object's bytes via fsspec.
+- ``read_object_bytes``: fetch one object's bytes via fsspec.
   Contracts: returns the bytes on success; returns ``None`` on
   failure (never raises); emits a warning by default; can be silenced
   with ``warn=False``.
 
-- ``thread_per_row_in_shard`` — per-shard worker fan-out.
-  Contracts: yields in input order; skips ``None`` results; empty
-  input is a no-op (does not spawn a pool).
+- ``thread_per_row_in_shard``: per-shard worker fan-out. Contracts:
+  yields in input order; skips ``None`` results; empty input is a
+  no-op (does not spawn a pool).
 
 Tests use the local filesystem (via plain paths and ``file://`` URIs)
 so they have no network dependency and run in milliseconds.


### PR DESCRIPTION
Added a performance-oriented Zephyr pipeline construction skill. From an earlier draft of the skill, I identified two library functions that are useful to pull out into the marinfold package (under a new `io.py` file). This skill writes down lessons from tuning zephyr pipelines with Claude. It also includes a meta process of how to profile pipelines and choose which improvements to include in the final result. 