### PR TITLE
Add contacts-v1-exp75-1.5B model to MODELS.yaml

### DIFF
--- a/marinfold/marinfold/MODELS.yaml
+++ b/marinfold/marinfold/MODELS.yaml
@@ -9,3 +9,8 @@
   wandb_url: https://wandb.ai/timodonnell/marin/runs/protein-contacts-1_5b-distance-masked-70f8f5
   document_structures:
     - contacts-and-distances-v1
+- nickname: contacts-v1-exp75-1.5B
+  url: https://huggingface.co/buckets/open-athena/MarinFold/tree/checkpoints/prot-exp75-cv1-1_5b-e8-lr1e-3-wd0p2-v1-bc3084/hf/step-35679
+  wandb_url: https://wandb.ai/eric-czech/marin/runs/prot-exp75-cv1-1_5b-e8-lr1e-3-wd0p2-v1-bc3084
+  document_structures:
+    - contacts-v1


### PR DESCRIPTION
Adds the current best contacts-v1 model to `MODELS.yaml` so it can be selected by nickname on the CLI.

## Model
- **Nickname:** `contacts-v1-exp75-1.5B`
- **Run:** marin `prot-exp75-cv1-1_5b-e8-lr1e-3-wd0p2-v1-bc3084`, step-35679 (eric-czech/marin)
- **`eval/contacts-v1-val/loss` = 2.756602** — current best LM-only contacts-v1 model
- **Weights:** public `open-athena/MarinFold` bucket at `checkpoints/prot-exp75-cv1-1_5b-e8-lr1e-3-wd0p2-v1-bc3084/hf/step-35679` (Qwen3 1.47B, exported by exp89 with the contacts-v1 tokenizer)

## Notes
- Document structure is `contacts-v1` (contacts-only), distinct from the existing `1B`/`1.5B` entries which are `contacts-and-distances-v1`.
- Not marked `default` — the `1B` entry remains the default.
- Verified: bucket tree URL returns 200, W&B loss confirmed live, and `registry.list_model_entries()` parses the entry cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)