### PR TITLE
exp112: 3B Qwen3 on CoreWeave via NVIDIA NeMo — MFU comparison vs Levanter

### DIFF
--- a/experiments/exp112_models_qwen_3b_nemo_mfu/README.md
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/README.md
@@ -143,9 +143,40 @@ uv run iris --cluster=cw-rno2a job run --no-wait --priority batch \
 
 ## Results
 
-_(Fill in after the benchmark: tokens/s, tokens/s/GPU, s/step, model-TFLOP/s/GPU,
-MFU; side-by-side with exp108's ~52k tok/s / ~15% MFU.)_
+Single **8×H100** node on `cw-rno2a`, batch **128 × seq 8192** (= exp108),
+**bf16**, gradient checkpointing **on** (as exp108), **mock** data, NeMo 2.3.2 /
+`nvcr.io/nvidia/nemo:25.04.02`. The whole novel path worked first try on the
+cluster: nvcr.io image pull (~4.5 min), binary `torchrun` entrypoint at **batch**
+band, base64-inlined script, 8-GPU bringup, and S3 result upload. Model built with
+the exact geometry (48L / 2048h / 32h·8kv GQA / QK-norm / RMSNorm / SwiGLU / RoPE,
+vocab 2845). JSON summaries under `…/exp112_qwen_3b_nemo_mfu/results/`.
+
+| run | micro-batch | s/step | tokens/s | tokens/s/GPU | model TFLOP/s/GPU | **MFU** |
+|-----|:-----------:|:------:|:--------:|:------------:|:-----------------:|:-------:|
+| NeMo (smoke, 40 steps) | 1 | 11.69 | 89,737 | 11,217 | 251 | 25.4% |
+| NeMo (50 steps) | 2 | 11.34 | 92,465 | 11,558 | 259 | 26.2% |
+| **NeMo (50 steps)** | **4** | **11.29** | **92,861** | **11,608** | **260** | **26.3%** |
+| **exp108 Levanter** (baseline) | — | ~20 | ~52,000 | ~6,500 | — | **~15%** |
+
+**NeMo ≈ 1.75–1.79× Levanter** on identical model / shape / hardware:
+**~26% MFU vs ~15%**, **~93k vs ~52k tok/s**, **~11.3 vs ~20 s/step**. Micro-batch
+barely moves it (memory-bound at this shape with grad checkpointing), so mbs 1 is a
+fine default. MFU is computed as model-FLOPs ÷ (step_time × 8 × 989 TFLOP/s); the
+*throughput* columns are formula-free and carry the comparison on their own.
 
 ## Conclusion
 
-_(Fill in — did NeMo beat Levanter's MFU, and by how much; recommend go/no-go on the full run.)_
+**Yes — NeMo/Megatron-Core is materially more efficient than Levanter here (~1.75×),
+out of the box.** That directly answers #112. Two honest caveats: the number is
+**~26% MFU, not** the ~35–40% one might hope for a 3B on H100 — the ceiling here is
+set by the **mandatory activation recompute** (48L × seq 8192 doesn't fit without it,
+same tax exp108 paid), **bf16** (no fp8), and **DP-replicated** params (no TP/FSDP).
+Each is a known lever: **fp8** (Transformer-Engine, plausibly another ~1.3–1.8×),
+**TP/FSDP** to drop grad checkpointing, and larger effective batch — all deferred.
+
+**Recommendation:** the throughput win is real and large enough to justify moving the
+**full 16-epoch training run to NeMo** if we want the trained model sooner — a 4-node
+NeMo run should land in **~2–2.5 days vs exp108's ~4** at the same node count. Before
+that: wire the real `.bin/.idx` data path (block cross-doc attention; verify Megatron
+#2357) and solve multi-node `torchrun` rendezvous over `IRIS_TASK_ID` (both in
+*Deferred*). Left to the humans to decide (issue stays open).

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/README.md
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/README.md
@@ -1,0 +1,151 @@
+---
+marinfold_experiment:
+  issue: 112
+  title: "exp: train a 3B qwen3 model on coreweave but use nvidia nemo framework for mfu comparison"
+  kind: models
+  branch: claude/exp112-nemo-mfu
+---
+
+# exp: 3B Qwen3 on CoreWeave via **NVIDIA NeMo** — MFU comparison vs Levanter
+
+**Issue:** [#112](https://github.com/Open-Athena/MarinFold/issues/112) · **Kind:** `models` · **Branch:** `claude/exp112-nemo-mfu`
+
+## Question
+
+exp108 trained the 3B Qwen3 contacts-v1 model on the CoreWeave `cw-rno2a` H100
+cluster with JAX/**Levanter** and got only **~15% MFU** (~20 s/step, ~52k tok/s,
+batch 128 × seq 8192 on one 8×H100 node). Does the **NVIDIA NeMo / Megatron-Core**
+stack do materially better on the *same* model / seq / batch / hardware?
+
+## Hypothesis
+
+NeMo/Megatron-Core on H100 typically lands **~30–40% MFU** for ~3–8B dense
+models, so we expect a **2–3× throughput win** over exp108's Levanter run.
+
+## Approach
+
+**Benchmark first, then decide** (per issue scope): land a single-node MFU number,
+and only invest in a full 16-epoch run if the win justifies it.
+
+- **Same model as exp108** (so the comparison is apples-to-apples): Qwen3 ~2.9B —
+  hidden 2048, ffn 8192, 32 heads / 8 KV groups (GQA), head_dim 64, **48 layers**,
+  seq 8192; RMSNorm, SwiGLU, QK-layernorm, RoPE. Real contacts-v1 vocab (2845,
+  Megatron-padded to 2944). Built as a Megatron-backed `llm.GPTConfig`.
+- **Mock/synthetic data for the benchmark.** MFU is compute-bound and
+  data-content-independent — this is exactly how NVIDIA publishes its perf tables.
+  This removes the entire tokenize→`.bin/.idx` pipeline from the critical path.
+  (Real data is a documented follow-up; see *Deferred*.)
+- **Single 8×H100 node**, `torchrun --standalone --nproc-per-node=8`. Single-node
+  sidesteps the one iris limitation for PyTorch: it exposes no torchrun rendezvous
+  / coordinator API (only `IRIS_TASK_ID`/`IRIS_NUM_TASKS`), which JAX has built in.
+- **Launch = direct batch-priority Fray dispatch of a foreign container.** iris
+  lets a job override its image (`ResourceConfig.image` → `nvcr.io/nvidia/nemo`)
+  and run a **binary** `torchrun` entrypoint (`Entrypoint.from_binary`). The NeMo
+  container has no repo checkout, so `dispatch_nemo.py` **base64-inlines** the
+  training script into the bootstrap bash. Batch band via `JobRequest.priority=3`
+  (identical to exp108). See *Design* below.
+- **Primary metric = throughput** (tokens/s, s/step) — formula-free and directly
+  comparable to exp108. **MFU** (÷ 989 TFLOP/s H100 bf16 peak) is reported as a
+  cross-check; both an analytical count *and* NeMo's native number where available.
+
+## Success criteria
+
+A trustworthy single-node **tokens/s + MFU** for NeMo on the exp112 Qwen3-3B, and
+a head-to-head vs exp108's ~52k tok/s / ~15% MFU. (No eval-loss target here — that
+belongs to the deferred full run.)
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `common.py` | Launcher constants: NeMo image tag, S3 prefix, model geometry, 8×H100 `ResourceConfig`, H100 peak. |
+| `nemo_train_qwen3.py` | **In-container** (base64-inlined): builds the Qwen3-3B `GPTConfig`, mock data, Trainer; runs under `torchrun`; emits a throughput/MFU JSON summary. Self-contained (no `common.py` import). |
+| `dispatch_nemo.py` | Direct **batch-priority** Fray dispatch: NeMo image + `torchrun` binary entrypoint; inlines the train script; best-effort uploads the summary to S3. |
+| `pyproject.toml` / `uv.lock` | **Launcher-only** deps (`marin-iris[controller]`, `marin-fray`, boto3/s3fs). No training stack — NeMo lives in the container. |
+
+## Design — batch-priority dispatch of a foreign NeMo container
+
+The novelty vs exp108 is the *payload*, not the *submission*:
+
+- exp108 dispatched a **levanter callable** into marin's default iris-task image.
+- exp112 dispatches a **`bash -lc`/`torchrun` binary** into
+  `nvcr.io/nvidia/nemo`, which has neither our repo nor the fray task harness.
+
+`dispatch_nemo.build_request` sets:
+- `resources = ResourceConfig.with_gpu("H100", count=8, replicas=1, image=<nemo>)`;
+- `environment = create_environment(docker_image=<nemo>, env_vars=…)` — passing
+  `docker_image` (not `workspace`) is essential: otherwise `create_environment`
+  defaults `workspace` to the launcher dir and would try to `uv sync` our pyproject
+  **inside** the NeMo image;
+- `entrypoint = Entrypoint.from_binary("bash", ["-lc", BOOTSTRAP])`, where
+  `BOOTSTRAP` base64-decodes the inlined `nemo_train_qwen3.py`, runs
+  `torchrun --standalone --nnodes=1 --nproc-per-node=8`, and best-effort uploads
+  the MFU summary JSON to S3 (creds injected by iris; the summary is also in logs);
+- `priority=3` (iris **batch** band) + an import-time assert that this fray build
+  actually has `JobRequest.priority`.
+
+Everything lands under one removable prefix
+`s3://marin-us-east-02a/MarinFold/exp112_qwen_3b_nemo_mfu/` (issue #108 convention).
+
+## Runbook
+
+**0. Prereqs** (same as exp108, already on Tim's box): kubeconfig
+`~/.kube/coreweave-iris-rno2a`, object-storage key in `~/.config/marin/cw-rno2a.env`,
+`kubectl` on PATH, `marin-iris[controller]` in this env.
+
+**1. Local validation (no cluster):**
+```bash
+uv sync
+python nemo_train_qwen3.py --help                    # argparse (NeMo import is lazy)
+EXP112_DRY_RUN=1 python -m dispatch_nemo              # build the JobRequest, no submit
+# API smoke against the NeMo container on a local GPU (tiny model):
+docker run --rm --gpus all -v "$PWD:/w" -w /w nvcr.io/nvidia/nemo:25.04.02 \
+    torchrun --standalone --nproc-per-node=1 nemo_train_qwen3.py --tiny --max-steps 5
+```
+
+**2. Cluster smoke (~50 steps, batch priority):**
+```bash
+set -a; source ~/.config/marin/cw-rno2a.env; set +a
+WK=$(python -c "import netrc; print(netrc.netrc().authenticators('api.wandb.ai')[2])")
+uv run iris --cluster=cw-rno2a job run --no-wait --priority batch \
+    --cpu=2 --memory=6GB --disk=16GB \
+    -e WANDB_API_KEY "$WK" -e EXP112_MAX_STEPS 50 -e EXP112_RUN_NAME plm-exp112-smoke \
+    -- python -m dispatch_nemo
+# Monitor: uv run iris --cluster=cw-rno2a job list | grep exp112
+#          uv run iris --cluster=cw-rno2a job logs <job> --max-lines N
+# Verify batch band: uv run iris --cluster=cw-rno2a job status <child-job-id>
+```
+
+**3. Benchmark (~300 steps):** as above with `-e EXP112_MAX_STEPS 300 -e EXP112_RUN_NAME plm-exp112-cv1-3b-nemo-bench`. Sweep `-e EXP112_MICRO_BATCH {1,2,4}` to find the MFU-max micro-batch.
+
+## Watch-items / risks
+
+- **Binary-entrypoint × foreign image on iris has no precedent here** — the smoke
+  run must prove: nvcr.io image pull (a CoreWeave node **pull secret** may be
+  needed — if `ImagePullBackOff`, mirror the image to a pullable registry), `bash`
+  exec, batch band, injected S3 creds.
+- **NeMo 2.0 API** (`llm.GPTConfig`/`GPTModel`/`MockDataModule`/`llm.train`) is
+  validated against the pinned container tag by the local `--tiny` smoke; class/field
+  names can drift across tags.
+- **QK-norm / RoPE details** (`qk_layernorm`, `rotary_base`) match Qwen3 for the
+  benchmark's FLOPs; reconcile bit-for-bit only before a real run.
+- **FLOP-formula parity** — we lead with *throughput* to avoid it; treat the MFU
+  ratio as indicative unless both frameworks' FLOP formulas are reconciled.
+
+## Deferred (only if the MFU win justifies a full run)
+
+- **Real data:** contacts-v1 parquet `document` → JSONL → `preprocess_data.py`
+  (HF tokenizer, `--append-eod`) → `.bin/.idx` on S3; train with
+  `reset_attention_mask`/`reset_position_ids` (block cross-doc attention; verify vs
+  Megatron #2357 on the TE path). The `--data <prefix>` path in the script is stubbed for this.
+- **Multi-node:** needs a custom torchrun rendezvous over S3/`IRIS_TASK_ID`.
+- **Full 16-epoch run + eval-loss** comparison / beat 2.7 + HF export.
+
+## Results
+
+_(Fill in after the benchmark: tokens/s, tokens/s/GPU, s/step, model-TFLOP/s/GPU,
+MFU; side-by-side with exp108's ~52k tok/s / ~15% MFU.)_
+
+## Conclusion
+
+_(Fill in — did NeMo beat Levanter's MFU, and by how much; recommend go/no-go on the full run.)_

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/README.md
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/README.md
@@ -132,14 +132,42 @@ uv run iris --cluster=cw-rno2a job run --no-wait --priority batch \
 - **FLOP-formula parity** — we lead with *throughput* to avoid it; treat the MFU
   ratio as indicative unless both frameworks' FLOP formulas are reconciled.
 
-## Deferred (only if the MFU win justifies a full run)
+## Full 16-epoch training run (multi-node) — implemented
 
-- **Real data:** contacts-v1 parquet `document` → JSONL → `preprocess_data.py`
-  (HF tokenizer, `--append-eod`) → `.bin/.idx` on S3; train with
-  `reset_attention_mask`/`reset_position_ids` (block cross-doc attention; verify vs
-  Megatron #2357 on the TE path). The `--data <prefix>` path in the script is stubbed for this.
-- **Multi-node:** needs a custom torchrun rendezvous over S3/`IRIS_TASK_ID`.
-- **Full 16-epoch run + eval-loss** comparison / beat 2.7 + HF export.
+Because the MFU win was compelling, the deferred full run was built out and
+**launched at 4 nodes (32 H100)**: `plm-exp112-cv1-3b-nemo-e16-lr1e-3-wd0p2`,
+**71,312 steps** (= exp108, from 4,672,623,743 train tokens), LR 1e-3, wd 0.2,
+10% warmup, global batch 128, real contacts-v1 data. Target: beat #75's eval
+loss 2.7566. Run it with `EXP112_DATA=real EXP112_REPLICAS=4` (see the top of
+`dispatch_nemo.py`); `prepare_megatron_data.py` produced the `.bin/.idx` corpus.
+
+This required solving several **real multi-node / no-shared-FS** problems on
+`cw-rno2a` (all validated live on a 2-node smoke incl. a kill→resume):
+
+- **Data:** parquet `document` → JSONL → `preprocess_data.py` (HF tokenizer,
+  `--append-eod` = `<eos>` boundary) → `.bin/.idx` on S3; `reset_attention_mask` +
+  `reset_position_ids` for block cross-doc attention.
+- **torchrun rendezvous:** iris has no coordinator API for torchrun, so rank-0
+  publishes `IRIS_ADVERTISE_HOST` to S3 and peers poll (static rendezvous). Two
+  gotchas: the injected LOTA endpoint negative-caches a cross-node
+  poll-before-write → use the **consistent** `cwobject.com` endpoint for the
+  rendezvous object; and a preemption-restart reuses the key, so the poller
+  rejects a **stale** master IP by S3 `LastModified` freshness.
+- **Gloo:** Megatron's CPU process groups + distributed optimizer need Gloo, whose
+  cross-node full-mesh fails unless `GLOO_SOCKET_IFNAME` is pinned to the host-eth
+  iface — found via Python stdlib `SIOCGIFADDR` (the NeMo container has no `ip`).
+- **Dataset index (no shared FS):** Megatron builds the sample `.npy` on global
+  rank-0 into a node-local dir; a monkeypatch makes `get_rank()` report the LOCAL
+  rank *during the build* so each node's local-0 builds its own cache.
+- **Checkpoint + resume:** Megatron writes a sharded (DCP) checkpoint; each node
+  syncs its own shards to S3 (union = complete), rank-0 prunes + commits
+  `latest.txt`, throttled to one upload per `checkpoint_every` steps. On (re)start
+  each node mirrors the latest checkpoint back and `AutoResume` continues — batch
+  priority is preemptible, so the gang auto-restarts (`max_retries_preemption`) and
+  resumes; the CPU driver is non-preemptible and outlives it.
+
+Deferred still: **HF export** of the final checkpoint (custom arch → needs an
+exporter/state-dict remap) + the downstream contacts eval.
 
 ## Results
 
@@ -163,6 +191,13 @@ vocab 2845). JSON summaries under `…/exp112_qwen_3b_nemo_mfu/results/`.
 barely moves it (memory-bound at this shape with grad checkpointing), so mbs 1 is a
 fine default. MFU is computed as model-FLOPs ÷ (step_time × 8 × 989 TFLOP/s); the
 *throughput* columns are formula-free and carry the comparison on their own.
+
+### Full training run (4 nodes / 32 H100)
+
+_Launched `plm-exp112-cv1-3b-nemo-e16-lr1e-3-wd0p2`, 71,312 steps. Checkpoints
+under `…/exp112_qwen_3b_nemo_mfu/checkpoints/<run>/`, W&B `open-athena/MarinFold`.
+Fill in final **val loss** vs #75's 2.7566, wall-clock, and 32-GPU throughput/MFU
+when it completes._
 
 ## Conclusion
 

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/build_summary.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/build_summary.py
@@ -1,0 +1,258 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build ``plots/summary.pdf`` — this experiment's living presentation.
+
+Run from the experiment dir::
+
+    uv run python build_summary.py    # if the experiment has a pyproject
+    python build_summary.py           # otherwise (pure-analysis dirs)
+
+Contract (see ``experiments/AGENTS.md`` for the full story):
+
+- Narrative section first: sourced from ``summary_narrative.md`` —
+  one ``## `` heading per slide, body text below it. Edit this as
+  the experiment progresses; it reflects what we're doing, why, and
+  the current state of the results.
+- Plot appendix last: auto-discovered from ``plots/*.{png,jpg,jpeg}``.
+  Each plot's caption + generating script + args come from a
+  sidecar ``plots/<plot>.<ext>.meta.json`` written by the plotting
+  script via :func:`save_plot_with_meta` below.
+- Plots without a sidecar still appear, with a placeholder caption
+  nudging you to wire ``save_plot_with_meta`` in.
+
+Regeneration is meant to be fast: no analysis is rerun, only PNGs
+and text are assembled. Build time scales linearly with slide count.
+"""
+
+import json
+import re
+import sys
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+
+# ---------------------------------------------------------------------------
+# Helper for plotting scripts to call when they save a plot.
+# Importable without pulling in matplotlib (those imports are lazy in main()).
+# ---------------------------------------------------------------------------
+
+def save_plot_with_meta(
+    fig,
+    path: str | Path,
+    *,
+    caption: str,
+    script: str | None = None,
+    args: Sequence[str] | None = None,
+    **savefig_kwargs,
+) -> Path:
+    """Save ``fig`` to ``path`` plus a ``<path>.meta.json`` sidecar.
+
+    The sidecar carries the generating script's name, its argv, and a
+    human-readable caption. ``build_summary.py`` reads these when
+    assembling the slide appendix so the PDF can print, in small text
+    on each plot page, exactly how to rerun the script.
+
+    Defaults: ``script`` = ``sys.argv[0]``, ``args`` = ``sys.argv[1:]``.
+    Any extra kwargs (``dpi``, ``transparent``, ...) pass through to
+    ``fig.savefig``. ``bbox_inches="tight"`` is the default unless you
+    override it.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    savefig_kwargs.setdefault("bbox_inches", "tight")
+    fig.savefig(path, **savefig_kwargs)
+
+    script = script if script is not None else Path(sys.argv[0]).name
+    args = list(args) if args is not None else list(sys.argv[1:])
+
+    sidecar = path.with_suffix(path.suffix + ".meta.json")
+    sidecar.write_text(json.dumps(
+        {"script": script, "args": args, "caption": caption},
+        indent=2,
+    ))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Module-level config.
+# ---------------------------------------------------------------------------
+
+HERE = Path(__file__).resolve().parent
+PLOTS_DIR = HERE / "plots"
+NARRATIVE_PATH = HERE / "summary_narrative.md"
+OUTPUT_PATH = PLOTS_DIR / "summary.pdf"
+
+# Letter landscape, in inches.
+SLIDE_W, SLIDE_H = 13.33, 7.5
+
+PLOT_EXTENSIONS = (".png", ".jpg", ".jpeg")
+
+
+# ---------------------------------------------------------------------------
+# Narrative parsing.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Slide:
+    title: str
+    body: str
+
+
+def parse_narrative(path: Path) -> list[Slide]:
+    if not path.exists():
+        return [Slide(
+            title="(narrative missing)",
+            body=(
+                f"Create `{path.name}` in the experiment dir.\n\n"
+                "One `## ` heading per slide. Keep it updated as the experiment progresses."
+            ),
+        )]
+    text = path.read_text()
+    slides: list[Slide] = []
+    current_title: str | None = None
+    buf: list[str] = []
+    for line in text.splitlines():
+        m = re.match(r"^##\s+(.*)$", line)
+        if m:
+            if current_title is not None:
+                slides.append(Slide(title=current_title, body="\n".join(buf).strip()))
+            current_title = m.group(1).strip()
+            buf = []
+        elif current_title is not None:
+            buf.append(line)
+    if current_title is not None:
+        slides.append(Slide(title=current_title, body="\n".join(buf).strip()))
+    if not slides:
+        return [Slide(
+            title="(empty narrative)",
+            body=f"Add `## ` headings to `{path.name}`.",
+        )]
+    return slides
+
+
+# ---------------------------------------------------------------------------
+# Plot discovery.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PlotEntry:
+    path: Path
+    caption: str
+    script: str
+    args: list[str] = field(default_factory=list)
+
+    @property
+    def invocation(self) -> str:
+        if not self.args:
+            return self.script
+        return self.script + " " + " ".join(self.args)
+
+
+def load_plots(plots_dir: Path) -> list[PlotEntry]:
+    if not plots_dir.exists():
+        return []
+    paths: list[Path] = [
+        p for p in plots_dir.iterdir()
+        if p.suffix.lower() in PLOT_EXTENSIONS
+    ]
+    paths.sort(key=lambda p: p.name)
+
+    entries: list[PlotEntry] = []
+    for img in paths:
+        meta_path = img.with_suffix(img.suffix + ".meta.json")
+        if meta_path.exists():
+            meta = json.loads(meta_path.read_text())
+            caption = str(meta.get("caption", ""))
+            script = str(meta.get("script", "?"))
+            args = [str(a) for a in meta.get("args", [])]
+        else:
+            caption = (
+                "(metadata missing — call `save_plot_with_meta(...)` in "
+                "the generating script; see build_summary.py)"
+            )
+            script = "?"
+            args = []
+        entries.append(PlotEntry(path=img, caption=caption, script=script, args=args))
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# PDF rendering. matplotlib is imported lazily inside main() so that
+# importers of `save_plot_with_meta` don't pay the matplotlib startup cost.
+# ---------------------------------------------------------------------------
+
+def _new_slide(plt):
+    fig = plt.figure(figsize=(SLIDE_W, SLIDE_H))
+    fig.patch.set_facecolor("white")
+    return fig
+
+
+def render_text_slide(plt, slide: Slide):
+    fig = _new_slide(plt)
+    fig.text(0.05, 0.92, slide.title, fontsize=26, fontweight="bold", va="top")
+
+    paragraphs = [p.strip() for p in (slide.body or "").split("\n\n") if p.strip()]
+    wrapped = "\n\n".join(textwrap.fill(p, width=90) for p in paragraphs)
+    fig.text(0.05, 0.82, wrapped, fontsize=14, va="top")
+    return fig
+
+
+def render_plot_slide(plt, mpimg, entry: PlotEntry):
+    fig = _new_slide(plt)
+    fig.text(0.05, 0.94, entry.path.name, fontsize=18, fontweight="bold", va="top")
+    if entry.caption:
+        fig.text(
+            0.05, 0.88,
+            textwrap.fill(entry.caption, width=130),
+            fontsize=11, va="top",
+        )
+
+    ax = fig.add_axes([0.06, 0.10, 0.88, 0.74])
+    ax.set_axis_off()
+    img = mpimg.imread(entry.path)
+    ax.imshow(img)
+
+    fig.text(
+        0.05, 0.04,
+        f"$ {entry.invocation}",
+        fontsize=8, family="monospace", color="#555",
+    )
+    return fig
+
+
+def main() -> int:
+    # Lazy imports so `from build_summary import save_plot_with_meta`
+    # stays cheap for plotting scripts.
+    import matplotlib.image as mpimg
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+
+    narrative_slides = parse_narrative(NARRATIVE_PATH)
+    plot_entries = load_plots(PLOTS_DIR)
+
+    PLOTS_DIR.mkdir(exist_ok=True)
+    with PdfPages(OUTPUT_PATH) as pdf:
+        for slide in narrative_slides:
+            fig = render_text_slide(plt, slide)
+            pdf.savefig(fig)
+            plt.close(fig)
+        for entry in plot_entries:
+            fig = render_plot_slide(plt, mpimg, entry)
+            pdf.savefig(fig)
+            plt.close(fig)
+
+    try:
+        rel = OUTPUT_PATH.relative_to(HERE.parent)
+    except ValueError:
+        rel = OUTPUT_PATH
+    print(f"Wrote {rel}")
+    print(f"  Narrative slides: {len(narrative_slides)}")
+    print(f"  Plot slides:      {len(plot_entries)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/common.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/common.py
@@ -56,15 +56,17 @@ WANDB_ENTITY = "open-athena"
 WANDB_PROJECT = "MarinFold"
 
 # ---------------------------------------------------------------------------
-# Model — Qwen3 ~2.9B, IDENTICAL geometry to exp108 (#75's 1.5B width, depth
-# doubled 24 -> 48). These are the FLOP-determining dims, so keeping them exact
-# is what makes the MFU number comparable to exp108's Levanter run.
+# Model — **#75's exact 1.47B Qwen3** (replicate the best contacts-v1 model, but
+# 16 epochs instead of 8). Authoritative config (marin `eac/plm-exp75`, W&B
+# `eric-czech/marin`; = exp67/exp85's `protein_llama_1_5b` width, Qwen3 variant):
 #   hidden 2048 / ffn 8192 (=4h) / 32 heads / 8 KV groups (GQA) / head_dim 64 /
-#   48 layers / seq 8192. Qwen3 specifics: RMSNorm, SwiGLU, QK-layernorm,
-#   Llama/GPT-NeoX-noninterleaved RoPE, untied embeddings.
+#   **24 layers** / seq 8192. Qwen3: RMSNorm, SwiGLU, QK-layernorm, RoPE
+#   (**Llama3 theta 500000**; see ROTARY_BASE), untied embeddings. ~1.47B params.
+# (An earlier revision of this dir ran a 48-layer ~2.9B by-depth model for the
+# MFU benchmark; the full training run replicates #75's actual 1.5B instead.)
 # ---------------------------------------------------------------------------
 MODEL = dict(
-    num_layers=48,
+    num_layers=24,
     hidden_size=2048,
     ffn_hidden_size=8192,
     num_attention_heads=32,
@@ -72,6 +74,11 @@ MODEL = dict(
     kv_channels=64,       # head_dim (= 2048/32); set explicit to be safe
     seq_length=8192,
 )
+# #75's RoPE theta (levanter Llama3RotaryEmbeddingsConfig.theta). NeMo's generic
+# GPTConfig exposes rotary_base but not the Llama3 low/high-freq SCALING (a
+# context-extension feature, dubious at train seq == original 8192); we match the
+# dominant base theta. One documented divergence from #75's exact rope.
+ROTARY_BASE = 500000.0
 
 # Recipe (tracks #75 / exp108). Not all matter for MFU, but keep them faithful
 # for the deferred real run.

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/common.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/common.py
@@ -60,8 +60,11 @@ WANDB_PROJECT = "MarinFold"
 # 16 epochs instead of 8). Authoritative config (marin `eac/plm-exp75`, W&B
 # `eric-czech/marin`; = exp67/exp85's `protein_llama_1_5b` width, Qwen3 variant):
 #   hidden 2048 / ffn 8192 (=4h) / 32 heads / 8 KV groups (GQA) / head_dim 64 /
-#   **24 layers** / seq 8192. Qwen3: RMSNorm, SwiGLU, QK-layernorm, RoPE
-#   (**Llama3 theta 500000**; see ROTARY_BASE), untied embeddings. ~1.47B params.
+#   **24 layers** / seq 8192. RMSNorm (eps **1e-5**), SwiGLU, RoPE (**Llama3 theta
+#   500000**, factor 8/low 1/high 4/orig 8192; see ROTARY_BASE). Per #75's LOGGED
+#   W&B config (eric-czech/marin): **use_qk_norm=False, tie_word_embeddings=False**
+#   (untied lm_head, which IS weight-decayed). Reference ckpt Qwen/Qwen3-0.6B but
+#   with QK-norm OFF and embeddings untied. ~1.47B params.
 # (An earlier revision of this dir ran a 48-layer ~2.9B by-depth model for the
 # MFU benchmark; the full training run replicates #75's actual 1.5B instead.)
 # ---------------------------------------------------------------------------

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/common.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/common.py
@@ -37,6 +37,13 @@ NEMO_IMAGE = os.environ.get("EXP112_IMAGE", "nvcr.io/nvidia/nemo:25.04.02")
 # the deferred real run would put checkpoints here.
 # ---------------------------------------------------------------------------
 EXP112_S3_PREFIX = "s3://marin-us-east-02a/MarinFold/exp112_qwen_3b_nemo_mfu"
+# Megatron .bin/.idx corpus (produced by prepare_megatron_data.py); the bootstrap
+# downloads these to node-local disk before torchrun.
+EXP112_DATA_S3 = f"{EXP112_S3_PREFIX}/tokenized_megatron"
+# Sharded checkpoints (synced per-node; the only durable store — no shared FS).
+EXP112_CKPT_S3_BASE = f"{EXP112_S3_PREFIX}/checkpoints"
+# Multi-node torchrun rendezvous: rank-0 publishes its IP here (attempt-scoped).
+EXP112_RDZV_S3_BASE = f"{EXP112_S3_PREFIX}/rdzv"
 
 # contacts-v1 tokenizer (2845 real tokens; Megatron pads the embedding up to a
 # multiple of `make_vocab_size_divisible_by`). Loaded from HF inside the
@@ -71,19 +78,31 @@ MODEL = dict(
 GLOBAL_BATCH_SIZE = 128   # sequences; 128 * 8192 ~= 1.05M tokens/step (= exp108)
 WEIGHT_DECAY = 0.2
 WARMUP_FRACTION = 0.1
-LEARNING_RATE = 1e-3      # #75's winner (only used by the deferred real run)
+LEARNING_RATE = 1e-3      # #75's winner
+
+# 16-epoch schedule (identical to exp108). Computed from the contacts-v1 train
+# token count so it stays correct if the batch changes.
+TRAIN_TOKENS = 4_672_623_743  # exp53 generation_stats: 4,129,682 docs
+EPOCHS = 16
+SEQ_LEN = MODEL["seq_length"]
+
+
+def num_train_steps(global_batch: int = GLOBAL_BATCH_SIZE, epochs: int = EPOCHS) -> int:
+    import math
+    return epochs * math.ceil(TRAIN_TOKENS / (global_batch * SEQ_LEN))  # ≈71,312 @ bs128
 
 # ---------------------------------------------------------------------------
 # Device: a single 8xH100 node on cw-rno2a. torchrun --standalone drives the 8
 # local GPUs (no multi-node rendezvous -> sidesteps iris's missing coordinator
 # API). One iris task == one pod == one node; replicas=1.
 # ---------------------------------------------------------------------------
-def h100_resources(image: str = NEMO_IMAGE) -> ResourceConfig:
-    """One 8xH100 node in the NeMo container."""
+def h100_resources(image: str = NEMO_IMAGE, replicas: int = 1) -> ResourceConfig:
+    """`replicas` × 8xH100 nodes in the NeMo container (gang-scheduled). The full
+    run uses replicas=4 (32 GPU); the benchmark used replicas=1."""
     return ResourceConfig.with_gpu(
         "H100",
         count=8,
-        replicas=1,
+        replicas=replicas,
         image=image,
         cpu=64,
         ram="512g",

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/common.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/common.py
@@ -1,0 +1,111 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared constants for the exp112 NeMo Qwen3-3B MFU benchmark (issue #112).
+
+exp112 asks the same question as #108 — train the 3B Qwen3 contacts-v1 model on
+the CoreWeave RNO2A H100 cluster — but on the **NVIDIA NeMo / Megatron-Core**
+stack instead of JAX/Levanter, to see whether we beat exp108's poor **~15% MFU**.
+
+Unlike exp108, the *training* stack does NOT live in this Python environment: it
+runs inside the ``nvcr.io/nvidia/nemo`` container. This module + ``dispatch_nemo``
+are the **launcher** only — they submit a single 8xH100 iris job (batch priority)
+whose container runs ``torchrun`` over the in-container training script
+(``nemo_train_qwen3.py``). See the README.
+
+The model geometry mirrors exp108 exactly (depth-doubled #75 1.5B width -> ~2.9B),
+so the MFU comparison is apples-to-apples: same params / seq / global batch /
+hardware, only the framework differs.
+"""
+
+import os
+
+from fray import ResourceConfig
+
+# ---------------------------------------------------------------------------
+# Container: the NeMo NGC image carries Megatron-Core + Transformer Engine +
+# NeMo 2.0. Pinned to an exact patch tag for reproducibility; override with
+# EXP112_IMAGE. (nvcr.io/nvidia/nemo:25.04.02 is anonymously pullable; whether
+# the CoreWeave nodes can pull nvcr.io without a pull secret is verified by the
+# smoke run — see README "Watch-items".)
+# ---------------------------------------------------------------------------
+NEMO_IMAGE = os.environ.get("EXP112_IMAGE", "nvcr.io/nvidia/nemo:25.04.02")
+
+# ---------------------------------------------------------------------------
+# Storage: everything under one removable `MarinFold/` prefix (issue #108's
+# convention, inherited). The benchmark writes only W&B + a tiny JSON summary;
+# the deferred real run would put checkpoints here.
+# ---------------------------------------------------------------------------
+EXP112_S3_PREFIX = "s3://marin-us-east-02a/MarinFold/exp112_qwen_3b_nemo_mfu"
+
+# contacts-v1 tokenizer (2845 real tokens; Megatron pads the embedding up to a
+# multiple of `make_vocab_size_divisible_by`). Loaded from HF inside the
+# container (public, tiny) so even the mock-data benchmark uses the REAL vocab
+# size -> faithful embedding/LM-head FLOPs. Bare id (no @rev) on the HF load path.
+CONTACTS_V1_TOKENIZER = "timodonnell/contacts-v1-tokenizer"
+
+# W&B routing (matches exp108 / the MarinFold project).
+WANDB_ENTITY = "open-athena"
+WANDB_PROJECT = "MarinFold"
+
+# ---------------------------------------------------------------------------
+# Model — Qwen3 ~2.9B, IDENTICAL geometry to exp108 (#75's 1.5B width, depth
+# doubled 24 -> 48). These are the FLOP-determining dims, so keeping them exact
+# is what makes the MFU number comparable to exp108's Levanter run.
+#   hidden 2048 / ffn 8192 (=4h) / 32 heads / 8 KV groups (GQA) / head_dim 64 /
+#   48 layers / seq 8192. Qwen3 specifics: RMSNorm, SwiGLU, QK-layernorm,
+#   Llama/GPT-NeoX-noninterleaved RoPE, untied embeddings.
+# ---------------------------------------------------------------------------
+MODEL = dict(
+    num_layers=48,
+    hidden_size=2048,
+    ffn_hidden_size=8192,
+    num_attention_heads=32,
+    num_query_groups=8,   # GQA; Megatron's name for HF num_key_value_heads
+    kv_channels=64,       # head_dim (= 2048/32); set explicit to be safe
+    seq_length=8192,
+)
+
+# Recipe (tracks #75 / exp108). Not all matter for MFU, but keep them faithful
+# for the deferred real run.
+GLOBAL_BATCH_SIZE = 128   # sequences; 128 * 8192 ~= 1.05M tokens/step (= exp108)
+WEIGHT_DECAY = 0.2
+WARMUP_FRACTION = 0.1
+LEARNING_RATE = 1e-3      # #75's winner (only used by the deferred real run)
+
+# ---------------------------------------------------------------------------
+# Device: a single 8xH100 node on cw-rno2a. torchrun --standalone drives the 8
+# local GPUs (no multi-node rendezvous -> sidesteps iris's missing coordinator
+# API). One iris task == one pod == one node; replicas=1.
+# ---------------------------------------------------------------------------
+def h100_resources(image: str = NEMO_IMAGE) -> ResourceConfig:
+    """One 8xH100 node in the NeMo container."""
+    return ResourceConfig.with_gpu(
+        "H100",
+        count=8,
+        replicas=1,
+        image=image,
+        cpu=64,
+        ram="512g",
+        disk="512g",
+    )
+
+
+# H100 SXM bf16 dense peak (TFLOP/s), for MFU = achieved_TFLOPs / PEAK. NVIDIA's
+# convention (their perf tables quote model-TFLOP/s/GPU; divide by this for MFU).
+H100_BF16_PEAK_TFLOPS = 989.0
+
+__all__ = [
+    "NEMO_IMAGE",
+    "EXP112_S3_PREFIX",
+    "CONTACTS_V1_TOKENIZER",
+    "WANDB_ENTITY",
+    "WANDB_PROJECT",
+    "MODEL",
+    "GLOBAL_BATCH_SIZE",
+    "WEIGHT_DECAY",
+    "WARMUP_FRACTION",
+    "LEARNING_RATE",
+    "h100_resources",
+    "H100_BF16_PEAK_TFLOPS",
+]

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
@@ -1,0 +1,224 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct batch-priority Fray dispatch of the exp112 NeMo benchmark (issue #112).
+
+Submits ONE 8xH100 iris job at **batch** priority whose container is the NeMo
+NGC image and whose entrypoint is a ``torchrun`` **binary** command — NOT a
+Python callable, and NOT the marin executor. This is the novelty vs exp108:
+
+  * exp108 dispatched a *levanter* callable (``run_levanter_train_lm``) into the
+    default marin iris-task image;
+  * exp112 dispatches a *bash/torchrun* binary into the ``nvcr.io/nvidia/nemo``
+    image, which has no repo checkout and no fray task harness.
+
+Because the container has no checkout, we **base64-inline** the in-container
+training script (``nemo_train_qwen3.py``) into the bootstrap bash, which decodes
+it and runs ``torchrun --standalone`` over the node's 8 GPUs. Single node ->
+``--standalone`` handles rendezvous locally, sidestepping iris's missing
+multi-node torchrun coordinator API.
+
+Batch band is set exactly as exp108: ``JobRequest.priority=3`` (iris
+``PRIORITY_BAND_BATCH``). We assert at import that this fray build actually has
+``JobRequest.priority`` (the frozen ``0.99.dev`` build silently drops it ->
+interactive band, which would disrupt the users batch priority protects).
+
+Run (as a tiny CPU **driver** job, like exp108/grug — ``current_client`` then
+resolves to the in-cluster controller)::
+
+    set -a; source ~/.config/marin/cw-rno2a.env; set +a
+    WK=$(python -c "import netrc; print(netrc.netrc().authenticators('api.wandb.ai')[2])")
+    uv run iris --cluster=cw-rno2a job run --no-wait --priority batch \
+        --cpu=2 --memory=6GB --disk=16GB \
+        -e WANDB_API_KEY "$WK" -e EXP112_MAX_STEPS 300 \
+        -- python -m dispatch_nemo
+
+Smoke first: add ``-e EXP112_MAX_STEPS 50``. Dry-run locally (build + print the
+JobRequest, no submit): ``EXP112_DRY_RUN=1 python -m dispatch_nemo``.
+"""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import logging
+import os
+from pathlib import Path
+
+from fray import ResourceConfig
+from fray.current_client import current_client
+from fray.types import Entrypoint, JobRequest, create_environment
+
+from common import (
+    EXP112_S3_PREFIX,
+    GLOBAL_BATCH_SIZE,
+    MODEL,
+    NEMO_IMAGE,
+    WANDB_ENTITY,
+    WANDB_PROJECT,
+    h100_resources,
+)
+
+logger = logging.getLogger(__name__)
+
+# iris PriorityBand enum value (iris/rpc/job.proto: PRIORITY_BAND_BATCH = 3).
+IRIS_PRIORITY_BAND_BATCH = 3
+
+assert "priority" in {f.name for f in dataclasses.fields(JobRequest)}, (
+    "This fray build lacks JobRequest.priority; batch-band dispatch requires the "
+    "0.2.x.dev fray line (exp112's pins), not the frozen 0.99.dev build."
+)
+
+# Perf/runtime env forwarded from the driver onto the GPU task (iris tasks don't
+# inherit the submitter's shell; the task pod is separate). Same idea as exp108.
+_FORWARD_ENV_PREFIXES = ("NCCL_", "TORCH_", "NVTE_", "CUDA_", "TRANSFORMERS_", "HF_")
+_FORWARD_ENV_EXCLUDE = ("CUDA_VISIBLE_DEVICES",)
+
+
+def _forwarded_env() -> dict[str, str]:
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if k.startswith(_FORWARD_ENV_PREFIXES) and k not in _FORWARD_ENV_EXCLUDE
+    }
+
+
+TRAIN_SCRIPT = Path(__file__).with_name("nemo_train_qwen3.py")
+
+
+def build_bootstrap(*, nproc_per_node: int, run_name: str, results_s3: str, train_args: list[str]) -> str:
+    """Bash bootstrap for the NeMo pod: decode the inlined script, torchrun it,
+    then best-effort upload the MFU summary JSON to S3 (so it survives the pod).
+    """
+    script_b64 = base64.b64encode(TRAIN_SCRIPT.read_bytes()).decode()
+    results_local = "/tmp/exp112_mfu.json"
+    train_argline = " ".join(train_args)
+    # NOTE: keep this POSIX-sh friendly; the NeMo image's /bin/bash is fine.
+    return f"""
+set -euo pipefail
+echo "[exp112-bootstrap] host=$(hostname) python=$(command -v python) torchrun=$(command -v torchrun)"
+echo "[exp112-bootstrap] nvidia-smi:"; nvidia-smi -L || true
+mkdir -p /tmp/exp112
+echo {script_b64} | base64 -d > /tmp/exp112/nemo_train_qwen3.py
+echo "[exp112-bootstrap] decoded train script ($(wc -l < /tmp/exp112/nemo_train_qwen3.py) lines); launching torchrun"
+export EXP112_RESULTS_JSON={results_local}
+export EXP112_RUN_NAME={run_name}
+set +e
+torchrun --standalone --nnodes=1 --nproc-per-node={nproc_per_node} \
+    /tmp/exp112/nemo_train_qwen3.py {train_argline}
+rc=$?
+set -e
+echo "[exp112-bootstrap] torchrun exited rc=$rc"
+# Best-effort: push the MFU summary to S3 (creds injected by iris). Logs already
+# carry the summary, so failure here is non-fatal.
+if [ -f {results_local} ]; then
+  python - <<'PYEOF' || echo "[exp112-bootstrap] S3 upload skipped/failed (summary is still in logs)"
+import os, boto3
+from botocore.config import Config
+src = "{results_local}"
+uri = "{results_s3}"
+assert uri.startswith("s3://")
+bucket, key = uri[5:].split("/", 1)
+s3 = boto3.client("s3", endpoint_url=os.environ.get("AWS_ENDPOINT_URL"),
+                  config=Config(s3={{"addressing_style": "virtual"}}))
+s3.upload_file(src, bucket, key)
+print("[exp112-bootstrap] uploaded", uri)
+PYEOF
+fi
+exit $rc
+""".strip()
+
+
+def build_train_args(*, max_steps: int, micro_batch_size: int, global_batch_size: int,
+                     data: str, run_name: str) -> list[str]:
+    return [
+        f"--max-steps={max_steps}",
+        f"--micro-batch-size={micro_batch_size}",
+        f"--global-batch-size={global_batch_size}",
+        f"--seq-length={MODEL['seq_length']}",
+        f"--num-layers={MODEL['num_layers']}",
+        f"--hidden-size={MODEL['hidden_size']}",
+        f"--ffn-hidden-size={MODEL['ffn_hidden_size']}",
+        f"--num-attention-heads={MODEL['num_attention_heads']}",
+        f"--num-query-groups={MODEL['num_query_groups']}",
+        f"--kv-channels={MODEL['kv_channels']}",
+        f"--data={data}",
+        f"--wandb-project={WANDB_PROJECT}",
+        f"--wandb-entity={WANDB_ENTITY}",
+        f"--wandb-name={run_name}",
+    ]
+
+
+def build_request(
+    *,
+    run_name: str,
+    max_steps: int,
+    micro_batch_size: int,
+    global_batch_size: int = GLOBAL_BATCH_SIZE,
+    data: str = "mock",
+    image: str = NEMO_IMAGE,
+    env_vars: dict[str, str] | None = None,
+) -> JobRequest:
+    resources = h100_resources(image=image)
+    nproc = resources.device.count  # 8 GPUs on the node
+
+    results_s3 = f"{EXP112_S3_PREFIX}/results/{run_name}.json"
+    train_args = build_train_args(
+        max_steps=max_steps, micro_batch_size=micro_batch_size,
+        global_batch_size=global_batch_size, data=data, run_name=run_name,
+    )
+    bootstrap = build_bootstrap(
+        nproc_per_node=nproc, run_name=run_name, results_s3=results_s3, train_args=train_args,
+    )
+
+    task_env = {**_forwarded_env(), **(env_vars or {})}
+    # docker_image (NOT workspace) so create_environment does NOT bundle/sync the
+    # launcher's pyproject INTO the NeMo container (which would break the image);
+    # the container IS the environment. Mirror it on resources.image too.
+    environment = create_environment(docker_image=image, env_vars=task_env)
+
+    return JobRequest(
+        name=run_name,
+        entrypoint=Entrypoint.from_binary("bash", ["-lc", bootstrap]),
+        resources=resources,
+        environment=environment,
+        priority=IRIS_PRIORITY_BAND_BATCH,   # -> iris BATCH band
+        processes_per_task=1,                # torchrun forks the 8 ranks itself
+        max_retries_failure=0,
+    )
+
+
+def main() -> None:
+    run_name = os.environ.get("EXP112_RUN_NAME", "plm-exp112-cv1-3b-nemo-bench")
+    max_steps = int(os.environ.get("EXP112_MAX_STEPS", "300"))
+    micro_batch = int(os.environ.get("EXP112_MICRO_BATCH", "1"))
+    global_batch = int(os.environ.get("EXP112_GLOBAL_BATCH", str(GLOBAL_BATCH_SIZE)))
+    data = os.environ.get("EXP112_DATA", "mock")
+
+    env_vars = {"WANDB_ENTITY": WANDB_ENTITY, "WANDB_PROJECT": WANDB_PROJECT}
+    if os.environ.get("WANDB_API_KEY"):
+        env_vars["WANDB_API_KEY"] = os.environ["WANDB_API_KEY"]
+
+    request = build_request(
+        run_name=run_name, max_steps=max_steps, micro_batch_size=micro_batch,
+        global_batch_size=global_batch, data=data, env_vars=env_vars,
+    )
+
+    print(f"[exp112] dispatch: {run_name} | image={NEMO_IMAGE} | 8xH100 batch-band | "
+          f"gbs{global_batch} mbs{micro_batch} steps{max_steps} data={data}")
+
+    if os.environ.get("EXP112_DRY_RUN"):
+        print("[exp112] DRY RUN — JobRequest built, not submitting.")
+        print(f"  priority={request.priority} image={request.resources.image} "
+              f"nproc={request.resources.device.count} "
+              f"entrypoint=bash -lc <{len(request.entrypoint.binary_entrypoint.args[1])} char bootstrap>")
+        return
+
+    job = current_client().submit(request)
+    print(f"[exp112] submitted {run_name}; awaiting completion (driver must outlive the gang).")
+    job.wait(raise_on_failure=True)
+    print(f"[exp112] {run_name}: SUCCEEDED — MFU summary in the job logs + {EXP112_S3_PREFIX}/results/")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
@@ -332,7 +332,11 @@ def build_request(
 def main() -> None:
     data = os.environ.get("EXP112_DATA", "mock")
     replicas = int(os.environ.get("EXP112_REPLICAS", "1"))
-    run_default = "plm-exp112-cv1-1_5b-nemo-e16-lr1e-3-wd0p2" if data == "real" else "plm-exp112-cv1-3b-nemo-bench"
+    # -v2 = #75-faithful config fix (no wd on embeddings/output, tied embeddings,
+    # Llama3 rope scaling, RMSNorm eps 1e-6) — the v1 run converged to 3.12 vs #75's
+    # 2.7566 because Megatron decayed the embeddings at wd 0.2. Fresh run name so it
+    # doesn't resume the v1 checkpoint.
+    run_default = "plm-exp112-cv1-1_5b-nemo-e16-lr1e-3-wd0p2-v2" if data == "real" else "plm-exp112-cv1-3b-nemo-bench"
     run_name = os.environ.get("EXP112_RUN_NAME", run_default)
     micro_batch = int(os.environ.get("EXP112_MICRO_BATCH", "1"))
     global_batch = int(os.environ.get("EXP112_GLOBAL_BATCH", str(GLOBAL_BATCH_SIZE)))

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
@@ -122,7 +122,7 @@ def build_bootstrap(*, nproc_per_node: int, replicas: int, run_name: str, result
     return f"""
 set -euo pipefail
 TID="${{IRIS_TASK_ID:-/x/0}}"
-export NODE_RANK="${{TID##*/}}"
+NR="${{TID%%:*}}"; export NODE_RANK="${{NR##*/}}"   # strip ":attempt" if present (iris is inconsistent), then take the rank
 export NNODES="${{IRIS_NUM_TASKS:-1}}"
 export MASTER_PORT="{MASTER_PORT}"
 echo "[exp112-bootstrap] host=$(hostname) task=$TID node_rank=$NODE_RANK nnodes=$NNODES ip=${{IRIS_ADVERTISE_HOST:-?}}"

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
@@ -50,13 +50,20 @@ from fray.current_client import current_client
 from fray.types import Entrypoint, JobRequest, create_environment
 
 from common import (
+    EXP112_CKPT_S3_BASE,
+    EXP112_DATA_S3,
+    EXP112_RDZV_S3_BASE,
     EXP112_S3_PREFIX,
     GLOBAL_BATCH_SIZE,
+    LEARNING_RATE,
     MODEL,
     NEMO_IMAGE,
     WANDB_ENTITY,
     WANDB_PROJECT,
+    WARMUP_FRACTION,
+    WEIGHT_DECAY,
     h100_resources,
+    num_train_steps,
 )
 
 logger = logging.getLogger(__name__)
@@ -86,43 +93,97 @@ def _forwarded_env() -> dict[str, str]:
 TRAIN_SCRIPT = Path(__file__).with_name("nemo_train_qwen3.py")
 
 
-def build_bootstrap(*, nproc_per_node: int, run_name: str, results_s3: str, train_args: list[str]) -> str:
-    """Bash bootstrap for the NeMo pod: decode the inlined script, torchrun it,
-    then best-effort upload the MFU summary JSON to S3 (so it survives the pod).
+DATA_LOCAL = "/tmp/exp112/data"
+MASTER_PORT = int(os.environ.get("EXP112_MASTER_PORT", "29500"))
+
+
+def build_bootstrap(*, nproc_per_node: int, replicas: int, run_name: str, results_s3: str,
+                    data_mode: str, train_args: list[str]) -> str:
+    """Bash bootstrap for the NeMo pod(s). Single node -> torchrun --standalone.
+    Multi-node -> S3 rendezvous (rank-0 publishes IRIS_ADVERTISE_HOST to an
+    attempt-scoped key; peers poll) + static torchrun. Real data -> each node
+    downloads the bin/idx first. Benchmark (mock) -> upload the MFU summary after.
     """
     script_b64 = base64.b64encode(TRAIN_SCRIPT.read_bytes()).decode()
     results_local = "/tmp/exp112_mfu.json"
     train_argline = " ".join(train_args)
-    # NOTE: keep this POSIX-sh friendly; the NeMo image's /bin/bash is fine.
+    rdzv_prefix = f"{EXP112_RDZV_S3_BASE}/{run_name}"
+    files = "train_document.bin train_document.idx val_document.bin val_document.idx"
     return f"""
 set -euo pipefail
-echo "[exp112-bootstrap] host=$(hostname) python=$(command -v python) torchrun=$(command -v torchrun)"
-echo "[exp112-bootstrap] nvidia-smi:"; nvidia-smi -L || true
-mkdir -p /tmp/exp112
+TID="${{IRIS_TASK_ID:-/x/0:0}}"
+NR="${{TID%%:*}}"; export NODE_RANK="${{NR##*/}}"; export ATTEMPT="${{TID##*:}}"
+export NNODES="${{IRIS_NUM_TASKS:-1}}"
+export MASTER_PORT="{MASTER_PORT}"
+echo "[exp112-bootstrap] host=$(hostname) task=$TID node_rank=$NODE_RANK nnodes=$NNODES ip=${{IRIS_ADVERTISE_HOST:-?}}"
+nvidia-smi -L || true
+mkdir -p /tmp/exp112 {DATA_LOCAL}
 echo {script_b64} | base64 -d > /tmp/exp112/nemo_train_qwen3.py
-echo "[exp112-bootstrap] decoded train script ($(wc -l < /tmp/exp112/nemo_train_qwen3.py) lines); launching torchrun"
+echo "[exp112-bootstrap] decoded train script ($(wc -l < /tmp/exp112/nemo_train_qwen3.py) lines)"
+
+if [ "$NNODES" -gt 1 ]; then
+  echo "[exp112-bootstrap] multi-node rendezvous (attempt $ATTEMPT) via S3"
+  python - <<PYEOF
+import os, time, boto3
+from botocore.config import Config
+s3 = boto3.client("s3", endpoint_url=os.environ.get("AWS_ENDPOINT_URL"),
+                  config=Config(s3={{"addressing_style": "virtual"}}))
+uri = "{rdzv_prefix}/%s/master" % os.environ["ATTEMPT"]
+b, k = uri[5:].split("/", 1)
+nr = int(os.environ["NODE_RANK"]); ip = os.environ.get("IRIS_ADVERTISE_HOST", "127.0.0.1")
+if nr == 0:
+    s3.put_object(Bucket=b, Key=k, Body=ip.encode()); m = ip
+    print("[exp112] published MASTER_ADDR", ip)
+else:
+    m = None
+    for _ in range(600):
+        try:
+            m = s3.get_object(Bucket=b, Key=k)["Body"].read().decode(); break
+        except Exception:
+            time.sleep(2)
+    if not m:
+        raise SystemExit("[exp112] rendezvous timeout waiting for rank-0 IP")
+    print("[exp112] got MASTER_ADDR", m)
+open("/tmp/exp112/master_addr", "w").write(m)
+PYEOF
+  MASTER_ADDR="$(cat /tmp/exp112/master_addr)"
+  LAUNCH="torchrun --nnodes=$NNODES --node-rank=$NODE_RANK --master-addr=$MASTER_ADDR --master-port=$MASTER_PORT --nproc-per-node={nproc_per_node}"
+else
+  LAUNCH="torchrun --standalone --nnodes=1 --nproc-per-node={nproc_per_node}"
+fi
+
+if [ "{data_mode}" = "real" ]; then
+  echo "[exp112-bootstrap] downloading bin/idx -> {DATA_LOCAL}"
+  python - <<PYEOF
+import os, boto3
+from botocore.config import Config
+s3 = boto3.client("s3", endpoint_url=os.environ.get("AWS_ENDPOINT_URL"),
+                  config=Config(s3={{"addressing_style": "virtual"}}))
+base = "{EXP112_DATA_S3}"; b, pre = base[5:].split("/", 1)
+for f in "{files}".split():
+    dst = "{DATA_LOCAL}/" + f
+    if not os.path.exists(dst) or os.path.getsize(dst) == 0:
+        s3.download_file(b, pre + "/" + f, dst); print("[exp112] downloaded", f, os.path.getsize(dst))
+PYEOF
+fi
+
 export EXP112_RESULTS_JSON={results_local}
 export EXP112_RUN_NAME={run_name}
+echo "[exp112-bootstrap] launching: $LAUNCH"
 set +e
-torchrun --standalone --nnodes=1 --nproc-per-node={nproc_per_node} \
-    /tmp/exp112/nemo_train_qwen3.py {train_argline}
+$LAUNCH /tmp/exp112/nemo_train_qwen3.py {train_argline}
 rc=$?
 set -e
 echo "[exp112-bootstrap] torchrun exited rc=$rc"
-# Best-effort: push the MFU summary to S3 (creds injected by iris). Logs already
-# carry the summary, so failure here is non-fatal.
-if [ -f {results_local} ]; then
-  python - <<'PYEOF' || echo "[exp112-bootstrap] S3 upload skipped/failed (summary is still in logs)"
+# Benchmark only: push the MFU summary (real runs persist via checkpoints).
+if [ "$NODE_RANK" = "0" ] && [ -f {results_local} ]; then
+  python - <<PYEOF || echo "[exp112-bootstrap] summary upload skipped (also in logs)"
 import os, boto3
 from botocore.config import Config
-src = "{results_local}"
-uri = "{results_s3}"
-assert uri.startswith("s3://")
-bucket, key = uri[5:].split("/", 1)
 s3 = boto3.client("s3", endpoint_url=os.environ.get("AWS_ENDPOINT_URL"),
                   config=Config(s3={{"addressing_style": "virtual"}}))
-s3.upload_file(src, bucket, key)
-print("[exp112-bootstrap] uploaded", uri)
+b, k = "{results_s3}"[5:].split("/", 1)
+s3.upload_file("{results_local}", b, k); print("[exp112-bootstrap] uploaded {results_s3}")
 PYEOF
 fi
 exit $rc
@@ -130,11 +191,15 @@ exit $rc
 
 
 def build_train_args(*, max_steps: int, micro_batch_size: int, global_batch_size: int,
-                     data: str, run_name: str) -> list[str]:
-    return [
+                     data: str, run_name: str, devices: int, num_nodes: int,
+                     checkpoint_s3: str = "", checkpoint_every: int = 500,
+                     val_check_interval: int = 1000, limit_val_batches: int = 50) -> list[str]:
+    args = [
         f"--max-steps={max_steps}",
         f"--micro-batch-size={micro_batch_size}",
         f"--global-batch-size={global_batch_size}",
+        f"--devices={devices}",
+        f"--num-nodes={num_nodes}",
         f"--seq-length={MODEL['seq_length']}",
         f"--num-layers={MODEL['num_layers']}",
         f"--hidden-size={MODEL['hidden_size']}",
@@ -147,6 +212,20 @@ def build_train_args(*, max_steps: int, micro_batch_size: int, global_batch_size
         f"--wandb-entity={WANDB_ENTITY}",
         f"--wandb-name={run_name}",
     ]
+    if data == "real":
+        args += [
+            f"--train-data-prefix={DATA_LOCAL}/train_document",
+            f"--val-data-prefix={DATA_LOCAL}/val_document",
+            f"--checkpoint-s3={checkpoint_s3}",
+            f"--checkpoint-every={checkpoint_every}",
+            f"--val-check-interval={val_check_interval}",
+            f"--limit-val-batches={limit_val_batches}",
+            f"--lr={LEARNING_RATE}",
+            f"--weight-decay={WEIGHT_DECAY}",
+            f"--warmup-fraction={WARMUP_FRACTION}",
+            "--resume",  # idempotent: no S3 checkpoint yet => fresh start
+        ]
+    return args
 
 
 def build_request(
@@ -156,25 +235,31 @@ def build_request(
     micro_batch_size: int,
     global_batch_size: int = GLOBAL_BATCH_SIZE,
     data: str = "mock",
+    replicas: int = 1,
     image: str = NEMO_IMAGE,
+    checkpoint_every: int = 500,
+    val_check_interval: int = 1000,
     env_vars: dict[str, str] | None = None,
 ) -> JobRequest:
-    resources = h100_resources(image=image)
-    nproc = resources.device.count  # 8 GPUs on the node
+    resources = h100_resources(image=image, replicas=replicas)
+    nproc = resources.device.count  # 8 GPUs per node
 
     results_s3 = f"{EXP112_S3_PREFIX}/results/{run_name}.json"
+    checkpoint_s3 = f"{EXP112_CKPT_S3_BASE}/{run_name}"
     train_args = build_train_args(
         max_steps=max_steps, micro_batch_size=micro_batch_size,
         global_batch_size=global_batch_size, data=data, run_name=run_name,
+        devices=nproc, num_nodes=replicas, checkpoint_s3=checkpoint_s3,
+        checkpoint_every=checkpoint_every, val_check_interval=val_check_interval,
     )
     bootstrap = build_bootstrap(
-        nproc_per_node=nproc, run_name=run_name, results_s3=results_s3, train_args=train_args,
+        nproc_per_node=nproc, replicas=replicas, run_name=run_name, results_s3=results_s3,
+        data_mode=data, train_args=train_args,
     )
 
     task_env = {**_forwarded_env(), **(env_vars or {})}
-    # docker_image (NOT workspace) so create_environment does NOT bundle/sync the
-    # launcher's pyproject INTO the NeMo container (which would break the image);
-    # the container IS the environment. Mirror it on resources.image too.
+    # docker_image (NOT workspace) so create_environment does NOT sync the
+    # launcher's pyproject INTO the NeMo container; the container IS the environment.
     environment = create_environment(docker_image=image, env_vars=task_env)
 
     return JobRequest(
@@ -182,18 +267,26 @@ def build_request(
         entrypoint=Entrypoint.from_binary("bash", ["-lc", bootstrap]),
         resources=resources,
         environment=environment,
-        priority=IRIS_PRIORITY_BAND_BATCH,   # -> iris BATCH band
-        processes_per_task=1,                # torchrun forks the 8 ranks itself
-        max_retries_failure=0,
+        replicas=replicas,                        # gang of `replicas` × 8×H100 nodes
+        priority=IRIS_PRIORITY_BAND_BATCH,        # -> iris BATCH band
+        processes_per_task=1,                     # torchrun forks the 8 ranks per node
+        max_retries_failure=0,                    # a code bug shouldn't retry
+        max_retries_preemption=100,               # but auto-restart on preemption (resume from S3)
     )
 
 
 def main() -> None:
-    run_name = os.environ.get("EXP112_RUN_NAME", "plm-exp112-cv1-3b-nemo-bench")
-    max_steps = int(os.environ.get("EXP112_MAX_STEPS", "300"))
+    data = os.environ.get("EXP112_DATA", "mock")
+    replicas = int(os.environ.get("EXP112_REPLICAS", "1"))
+    run_default = "plm-exp112-cv1-3b-nemo-e16-lr1e-3-wd0p2" if data == "real" else "plm-exp112-cv1-3b-nemo-bench"
+    run_name = os.environ.get("EXP112_RUN_NAME", run_default)
     micro_batch = int(os.environ.get("EXP112_MICRO_BATCH", "1"))
     global_batch = int(os.environ.get("EXP112_GLOBAL_BATCH", str(GLOBAL_BATCH_SIZE)))
-    data = os.environ.get("EXP112_DATA", "mock")
+    # Full 16-epoch step count for the real run (overridable for a smoke).
+    default_steps = num_train_steps(global_batch) if data == "real" else 300
+    max_steps = int(os.environ.get("EXP112_MAX_STEPS", str(default_steps)))
+    checkpoint_every = int(os.environ.get("EXP112_CKPT_EVERY", "500"))
+    val_interval = int(os.environ.get("EXP112_VAL_INTERVAL", "1000"))
 
     env_vars = {"WANDB_ENTITY": WANDB_ENTITY, "WANDB_PROJECT": WANDB_PROJECT}
     if os.environ.get("WANDB_API_KEY"):
@@ -201,23 +294,27 @@ def main() -> None:
 
     request = build_request(
         run_name=run_name, max_steps=max_steps, micro_batch_size=micro_batch,
-        global_batch_size=global_batch, data=data, env_vars=env_vars,
+        global_batch_size=global_batch, data=data, replicas=replicas,
+        checkpoint_every=checkpoint_every, val_check_interval=val_interval, env_vars=env_vars,
     )
 
-    print(f"[exp112] dispatch: {run_name} | image={NEMO_IMAGE} | 8xH100 batch-band | "
-          f"gbs{global_batch} mbs{micro_batch} steps{max_steps} data={data}")
+    print(f"[exp112] dispatch: {run_name} | image={NEMO_IMAGE} | {replicas}×8="
+          f"{replicas * 8} H100 batch-band | gbs{global_batch} mbs{micro_batch} "
+          f"steps{max_steps} data={data} ckpt_every={checkpoint_every}")
 
     if os.environ.get("EXP112_DRY_RUN"):
         print("[exp112] DRY RUN — JobRequest built, not submitting.")
-        print(f"  priority={request.priority} image={request.resources.image} "
-              f"nproc={request.resources.device.count} "
-              f"entrypoint=bash -lc <{len(request.entrypoint.binary_entrypoint.args[1])} char bootstrap>")
+        print(f"  priority={request.priority} replicas={request.replicas} "
+              f"image={request.resources.image} nproc={request.resources.device.count} "
+              f"max_retries_preemption={request.max_retries_preemption} "
+              f"bootstrap={len(request.entrypoint.binary_entrypoint.args[1])} chars")
         return
 
     job = current_client().submit(request)
-    print(f"[exp112] submitted {run_name}; awaiting completion (driver must outlive the gang).")
+    print(f"[exp112] submitted {run_name} ({replicas} nodes); awaiting completion "
+          f"(driver must outlive the gang).")
     job.wait(raise_on_failure=True)
-    print(f"[exp112] {run_name}: SUCCEEDED — MFU summary in the job logs + {EXP112_S3_PREFIX}/results/")
+    print(f"[exp112] {run_name}: SUCCEEDED — checkpoints under {EXP112_CKPT_S3_BASE}/{run_name}/")
 
 
 if __name__ == "__main__":

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
@@ -196,6 +196,10 @@ print(sel)
 " || true)
   if [ -n "$IFACE" ]; then export GLOO_SOCKET_IFNAME="$IFACE"; fi
   echo "[exp112-bootstrap] GLOO_SOCKET_IFNAME=${{GLOO_SOCKET_IFNAME:-unset}} (ip=${{IRIS_ADVERTISE_HOST:-?}})"
+  # NCCL robustness: tolerate slow/flaky IB links + a longer collective watchdog so
+  # a transient inter-node stall doesn't SIGABRT the gang (the main failure mode at
+  # 4 nodes over many hours). Driver-side resubmit still catches genuine failures.
+  export NCCL_IB_TIMEOUT=22 NCCL_IB_RETRY_CNT=13 TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=1800
   LAUNCH="torchrun --nnodes=$NNODES --node-rank=$NODE_RANK --master-addr=$MASTER_ADDR --master-port=$MASTER_PORT --nproc-per-node={nproc_per_node}"
 else
   LAUNCH="torchrun --standalone --nnodes=1 --nproc-per-node={nproc_per_node}"
@@ -368,11 +372,28 @@ def main() -> None:
               f"bootstrap={len(request.entrypoint.binary_entrypoint.args[1])} chars")
         return
 
-    job = current_client().submit(request)
-    print(f"[exp112] submitted {run_name} ({replicas} nodes); awaiting completion "
-          f"(driver must outlive the gang).")
-    job.wait(raise_on_failure=True)
-    print(f"[exp112] {run_name}: SUCCEEDED — checkpoints under {EXP112_CKPT_S3_BASE}/{run_name}/")
+    # Driver-side retry loop. At 4 nodes over ~1 day the cluster throws periodic
+    # NCCL collective timeouts (a node's inter-node collective stalls -> SIGABRT).
+    # iris's own max_retries doesn't recover us because job.wait(raise_on_failure)
+    # raises on the first gang failure and the driver would exit. Instead the
+    # (non-preemptible CPU) driver RESUBMITS the gang on each failure; every new
+    # gang resumes from the latest S3 checkpoint (bootstrap restore + AutoResume),
+    # and the rendezvous freshness check handles the new attempt's IP.
+    import time
+    max_gang_retries = int(os.environ.get("EXP112_GANG_RETRIES", "60"))
+    for attempt in range(1, max_gang_retries + 1):
+        job = current_client().submit(request)
+        print(f"[exp112] submitted {run_name} ({replicas} nodes) — attempt {attempt}/{max_gang_retries}", flush=True)
+        try:
+            job.wait(raise_on_failure=True)
+            print(f"[exp112] {run_name}: SUCCEEDED — checkpoints under {EXP112_CKPT_S3_BASE}/{run_name}/")
+            return
+        except Exception as e:  # noqa: BLE001 — resubmit + resume from S3 checkpoint
+            print(f"[exp112] attempt {attempt} failed: {e}", flush=True)
+            if attempt < max_gang_retries:
+                print("[exp112] resubmitting (resumes from the latest S3 checkpoint)…", flush=True)
+                time.sleep(30)
+    raise SystemExit(f"[exp112] {run_name}: exhausted {max_gang_retries} gang attempts")
 
 
 if __name__ == "__main__":

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
@@ -95,6 +95,10 @@ TRAIN_SCRIPT = Path(__file__).with_name("nemo_train_qwen3.py")
 
 DATA_LOCAL = "/tmp/exp112/data"
 MASTER_PORT = int(os.environ.get("EXP112_MASTER_PORT", "29500"))
+# Strongly-consistent object endpoint for the tiny rendezvous object (the injected
+# LOTA cache negative-caches a cross-node poll-before-write). Pods reach it (they
+# already pull nvcr.io / HF). Data + checkpoints keep using the fast injected LOTA.
+RDZV_ENDPOINT = os.environ.get("EXP112_RDZV_ENDPOINT", "https://cwobject.com")
 
 
 def build_bootstrap(*, nproc_per_node: int, replicas: int, run_name: str, results_s3: str,
@@ -107,12 +111,17 @@ def build_bootstrap(*, nproc_per_node: int, replicas: int, run_name: str, result
     script_b64 = base64.b64encode(TRAIN_SCRIPT.read_bytes()).decode()
     results_local = "/tmp/exp112_mfu.json"
     train_argline = " ".join(train_args)
-    rdzv_prefix = f"{EXP112_RDZV_S3_BASE}/{run_name}"
+    # Gang-common rendezvous key. IRIS_TASK_ID is `/user/job/<gang>/<node_rank>`
+    # (NO `:attempt` suffix in the pod), so we key on run_name (unique per run,
+    # identical for every node). rank-0 OVERWRITES its current IP each attempt;
+    # on a preemption-restart a stale IP just yields a fast connection-refused and
+    # the gang retries (self-heals), rather than a silent key mismatch.
+    rdzv_key = f"{EXP112_RDZV_S3_BASE}/{run_name}/master"
     files = "train_document.bin train_document.idx val_document.bin val_document.idx"
     return f"""
 set -euo pipefail
-TID="${{IRIS_TASK_ID:-/x/0:0}}"
-NR="${{TID%%:*}}"; export NODE_RANK="${{NR##*/}}"; export ATTEMPT="${{TID##*:}}"
+TID="${{IRIS_TASK_ID:-/x/0}}"
+export NODE_RANK="${{TID##*/}}"
 export NNODES="${{IRIS_NUM_TASKS:-1}}"
 export MASTER_PORT="{MASTER_PORT}"
 echo "[exp112-bootstrap] host=$(hostname) task=$TID node_rank=$NODE_RANK nnodes=$NNODES ip=${{IRIS_ADVERTISE_HOST:-?}}"
@@ -122,31 +131,60 @@ echo {script_b64} | base64 -d > /tmp/exp112/nemo_train_qwen3.py
 echo "[exp112-bootstrap] decoded train script ($(wc -l < /tmp/exp112/nemo_train_qwen3.py) lines)"
 
 if [ "$NNODES" -gt 1 ]; then
-  echo "[exp112-bootstrap] multi-node rendezvous (attempt $ATTEMPT) via S3"
+  echo "[exp112-bootstrap] multi-node rendezvous via S3 (node_rank=$NODE_RANK)"
   python - <<PYEOF
 import os, time, boto3
 from botocore.config import Config
-s3 = boto3.client("s3", endpoint_url=os.environ.get("AWS_ENDPOINT_URL"),
+# Rendezvous uses the CONSISTENT external endpoint, NOT the injected LOTA cache
+# (cwlota.com): LOTA negative-caches a cross-node poll-before-write, so a peer
+# never sees rank-0's just-written IP. Tiny object, so external latency is fine.
+s3 = boto3.client("s3", endpoint_url="{RDZV_ENDPOINT}",
                   config=Config(s3={{"addressing_style": "virtual"}}))
-uri = "{rdzv_prefix}/%s/master" % os.environ["ATTEMPT"]
-b, k = uri[5:].split("/", 1)
+b, k = "{rdzv_key}"[5:].split("/", 1)
 nr = int(os.environ["NODE_RANK"]); ip = os.environ.get("IRIS_ADVERTISE_HOST", "127.0.0.1")
 if nr == 0:
     s3.put_object(Bucket=b, Key=k, Body=ip.encode()); m = ip
-    print("[exp112] published MASTER_ADDR", ip)
+    print("[exp112] published MASTER_ADDR", ip, flush=True)
 else:
     m = None
-    for _ in range(600):
+    for i in range(600):
         try:
             m = s3.get_object(Bucket=b, Key=k)["Body"].read().decode(); break
         except Exception:
+            if i % 15 == 0:
+                print("[exp112] waiting for rank-0 IP…", flush=True)
             time.sleep(2)
     if not m:
         raise SystemExit("[exp112] rendezvous timeout waiting for rank-0 IP")
-    print("[exp112] got MASTER_ADDR", m)
+    print("[exp112] got MASTER_ADDR", m, flush=True)
 open("/tmp/exp112/master_addr", "w").write(m)
 PYEOF
   MASTER_ADDR="$(cat /tmp/exp112/master_addr)"
+  # Gloo (Megatron makes CPU/metadata process-groups over it) needs the host-eth
+  # interface explicitly; without GLOO_SOCKET_IFNAME it auto-picks a wrong iface
+  # (IB / link-local) -> "connectFullMesh failed" across nodes. Derive the iface
+  # owning this node's routable IP (falls back to the default-route iface).
+  # Find the interface owning this node's routable IP via Python stdlib
+  # (SIOCGIFADDR) — the NeMo container has no working `ip` command. Gloo (used by
+  # Megatron's CPU process groups + the distributed optimizer) needs
+  # GLOO_SOCKET_IFNAME pinned to that host-eth iface or connectFullMesh fails.
+  IFACE=$(python -c "
+import os, socket, fcntl, struct, sys
+want = os.environ.get('IRIS_ADVERTISE_HOST', '')
+sel = ''
+for n in sorted(os.listdir('/sys/class/net')):
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        ip = socket.inet_ntoa(fcntl.ioctl(s.fileno(), 0x8915, struct.pack('256s', n[:15].encode()))[20:24])
+        sys.stderr.write(' iface %s %s\\n' % (n, ip))
+        if ip == want:
+            sel = n
+    except Exception:
+        pass
+print(sel)
+" || true)
+  if [ -n "$IFACE" ]; then export GLOO_SOCKET_IFNAME="$IFACE"; fi
+  echo "[exp112-bootstrap] GLOO_SOCKET_IFNAME=${{GLOO_SOCKET_IFNAME:-unset}} (ip=${{IRIS_ADVERTISE_HOST:-?}})"
   LAUNCH="torchrun --nnodes=$NNODES --node-rank=$NODE_RANK --master-addr=$MASTER_ADDR --master-port=$MASTER_PORT --nproc-per-node={nproc_per_node}"
 else
   LAUNCH="torchrun --standalone --nnodes=1 --nproc-per-node={nproc_per_node}"

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
@@ -58,6 +58,7 @@ from common import (
     LEARNING_RATE,
     MODEL,
     NEMO_IMAGE,
+    ROTARY_BASE,
     WANDB_ENTITY,
     WANDB_PROJECT,
     WARMUP_FRACTION,
@@ -255,6 +256,7 @@ def build_train_args(*, max_steps: int, micro_batch_size: int, global_batch_size
         f"--num-attention-heads={MODEL['num_attention_heads']}",
         f"--num-query-groups={MODEL['num_query_groups']}",
         f"--kv-channels={MODEL['kv_channels']}",
+        f"--rotary-base={ROTARY_BASE}",
         f"--data={data}",
         f"--wandb-project={WANDB_PROJECT}",
         f"--wandb-entity={WANDB_ENTITY}",
@@ -326,7 +328,7 @@ def build_request(
 def main() -> None:
     data = os.environ.get("EXP112_DATA", "mock")
     replicas = int(os.environ.get("EXP112_REPLICAS", "1"))
-    run_default = "plm-exp112-cv1-3b-nemo-e16-lr1e-3-wd0p2" if data == "real" else "plm-exp112-cv1-3b-nemo-bench"
+    run_default = "plm-exp112-cv1-1_5b-nemo-e16-lr1e-3-wd0p2" if data == "real" else "plm-exp112-cv1-3b-nemo-bench"
     run_name = os.environ.get("EXP112_RUN_NAME", run_default)
     micro_batch = int(os.environ.get("EXP112_MICRO_BATCH", "1"))
     global_batch = int(os.environ.get("EXP112_GLOBAL_BATCH", str(GLOBAL_BATCH_SIZE)))

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
@@ -143,17 +143,27 @@ s3 = boto3.client("s3", endpoint_url="{RDZV_ENDPOINT}",
 b, k = "{rdzv_key}"[5:].split("/", 1)
 nr = int(os.environ["NODE_RANK"]); ip = os.environ.get("IRIS_ADVERTISE_HOST", "127.0.0.1")
 if nr == 0:
+    # Overwrite with THIS attempt's IP (a preemption-restart reuses the key).
     s3.put_object(Bucket=b, Key=k, Body=ip.encode()); m = ip
     print("[exp112] published MASTER_ADDR", ip, flush=True)
 else:
+    # Reject a STALE master (a previous attempt's dead IP) by freshness: stamp a
+    # probe to read the S3 server clock, then only trust `master` if it was
+    # written around/after our boot (this attempt), not minutes ago.
+    s3.put_object(Bucket=b, Key=k + ".probe", Body=b"x")
+    t_ref = s3.head_object(Bucket=b, Key=k + ".probe")["LastModified"]
     m = None
     for i in range(600):
         try:
-            m = s3.get_object(Bucket=b, Key=k)["Body"].read().decode(); break
+            age = (t_ref - s3.head_object(Bucket=b, Key=k)["LastModified"]).total_seconds()
+            if age < 120:  # written this attempt (node-0 writes ~concurrently)
+                m = s3.get_object(Bucket=b, Key=k)["Body"].read().decode(); break
+            if i % 15 == 0:
+                print("[exp112] rendezvous key is stale (age %ds); waiting for fresh" % int(age), flush=True)
         except Exception:
             if i % 15 == 0:
                 print("[exp112] waiting for rank-0 IP…", flush=True)
-            time.sleep(2)
+        time.sleep(2)
     if not m:
         raise SystemExit("[exp112] rendezvous timeout waiting for rank-0 IP")
     print("[exp112] got MASTER_ADDR", m, flush=True)

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/dispatch_nemo.py
@@ -320,8 +320,12 @@ def build_request(
         replicas=replicas,                        # gang of `replicas` × 8×H100 nodes
         priority=IRIS_PRIORITY_BAND_BATCH,        # -> iris BATCH band
         processes_per_task=1,                     # torchrun forks the 8 ranks per node
-        max_retries_failure=0,                    # a code bug shouldn't retry
-        max_retries_preemption=100,               # but auto-restart on preemption (resume from S3)
+        # The code is validated (ran 35k+ steps), so a mid-run gang failure is
+        # almost always a transient node/NCCL hiccup, not a bug. Retry on failure
+        # too (each retry resumes from the S3 checkpoint), not just on preemption
+        # — a single sibling failing otherwise kills the whole run.
+        max_retries_failure=20,
+        max_retries_preemption=100,               # auto-restart on preemption (resume from S3)
     )
 
 

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
@@ -1,0 +1,374 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-container NeMo 2.0 training/benchmark entrypoint for exp112 (issue #112).
+
+Runs **inside** the ``nvcr.io/nvidia/nemo`` container under
+``torchrun --standalone --nproc-per-node=<G>``. It is SELF-CONTAINED (imports
+only NeMo/Megatron/torch, never the launcher's ``common.py``) because
+``dispatch_nemo.py`` base64-inlines this file into the pod's bootstrap — there is
+no repo checkout in the container.
+
+Builds the exp112 Qwen3 ~2.9B model (geometry identical to exp108, so the MFU
+number is apples-to-apples), trains a few hundred steps on **mock/synthetic data**
+by default (MFU is compute-bound and data-content-independent — this is how
+NVIDIA publishes its perf tables), and writes a throughput/MFU summary.
+
+Primary metric is **throughput** (tokens/s, s/step) — formula-free and directly
+comparable to exp108's Levanter numbers (~52k tok/s, ~20 s/step, ~15% MFU).
+Framework/analytical **MFU** is reported as a cross-check.
+
+Example (real benchmark, on the pod)::
+
+    torchrun --standalone --nproc-per-node=8 nemo_train_qwen3.py \
+        --max-steps 300 --micro-batch-size 1 --global-batch-size 128
+
+Example (local API smoke on 1 small GPU)::
+
+    torchrun --standalone --nproc-per-node=1 nemo_train_qwen3.py \
+        --tiny --max-steps 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="exp112 NeMo Qwen3-3B MFU benchmark")
+    # Parallelism / trainer
+    p.add_argument("--devices", type=int, default=int(os.environ.get("EXP112_DEVICES", "8")))
+    p.add_argument("--num-nodes", type=int, default=1)
+    p.add_argument("--tensor-parallel", type=int, default=1)
+    p.add_argument("--pipeline-parallel", type=int, default=1)
+    p.add_argument("--max-steps", type=int, default=int(os.environ.get("EXP112_MAX_STEPS", "300")))
+    p.add_argument("--precision", default=os.environ.get("EXP112_PRECISION", "bf16-mixed"))
+    # Batch / sequence
+    p.add_argument("--micro-batch-size", type=int, default=int(os.environ.get("EXP112_MICRO_BATCH", "1")))
+    p.add_argument("--global-batch-size", type=int, default=int(os.environ.get("EXP112_GLOBAL_BATCH", "128")))
+    p.add_argument("--seq-length", type=int, default=8192)
+    # Model geometry (defaults = exp112/exp108 Qwen3 ~2.9B)
+    p.add_argument("--num-layers", type=int, default=48)
+    p.add_argument("--hidden-size", type=int, default=2048)
+    p.add_argument("--ffn-hidden-size", type=int, default=8192)
+    p.add_argument("--num-attention-heads", type=int, default=32)
+    p.add_argument("--num-query-groups", type=int, default=8)
+    p.add_argument("--kv-channels", type=int, default=64)
+    p.add_argument("--rotary-base", type=float, default=1_000_000.0)
+    p.add_argument("--no-grad-ckpt", action="store_true",
+                   help="disable activation checkpointing (exp108 needed it ON to fit)")
+    # Optim (only meaningful for a real run; harmless for the benchmark)
+    p.add_argument("--lr", type=float, default=1e-3)
+    p.add_argument("--weight-decay", type=float, default=0.2)
+    p.add_argument("--warmup-fraction", type=float, default=0.1)
+    # Data
+    p.add_argument("--data", default=os.environ.get("EXP112_DATA", "mock"),
+                   help="'mock' (default) or a Megatron .bin/.idx dataset path prefix")
+    p.add_argument("--tokenizer", default=os.environ.get("EXP112_TOKENIZER", "timodonnell/contacts-v1-tokenizer"))
+    # Logging / output
+    p.add_argument("--wandb-project", default=os.environ.get("WANDB_PROJECT", "MarinFold"))
+    p.add_argument("--wandb-entity", default=os.environ.get("WANDB_ENTITY", "open-athena"))
+    p.add_argument("--wandb-name", default=os.environ.get("EXP112_RUN_NAME", "plm-exp112-cv1-3b-nemo-bench"))
+    p.add_argument("--results-json", default=os.environ.get("EXP112_RESULTS_JSON", "/tmp/exp112_mfu.json"))
+    p.add_argument("--measure-warmup-steps", type=int, default=int(os.environ.get("EXP112_WARMUP_MEASURE", "10")),
+                   help="steps to skip before timing steady-state (compile/cache warmup)")
+    # Local API smoke: shrink everything so it fits a tiny GPU
+    p.add_argument("--tiny", action="store_true", help="tiny model+seq for a local API smoke test")
+    return p.parse_args()
+
+
+def apply_tiny(args: argparse.Namespace) -> None:
+    args.num_layers = 4
+    args.hidden_size = 256
+    args.ffn_hidden_size = 1024
+    args.num_attention_heads = 8
+    args.num_query_groups = 4
+    args.kv_channels = 32
+    args.seq_length = 256
+    args.micro_batch_size = 1
+    args.global_batch_size = max(1, args.devices)
+    args.measure_warmup_steps = 1
+
+
+# --------------------------------------------------------------------------- #
+# Throughput / MFU
+# --------------------------------------------------------------------------- #
+def model_flops_per_token(args: argparse.Namespace, vocab_size: int) -> float:
+    """Analytical **model** FLOPs per token (fwd+bwd, causal), Megatron/PaLM-style.
+
+    'Model' FLOPs = the useful work, EXCLUDING activation-recompute — so
+    gradient checkpointing lowers MFU by lengthening step time, not by inflating
+    this count (the standard MFU convention, matching Levanter's).
+
+    Per token (multiply by tokens for per-step): the 6*N term is folded into the
+    explicit per-layer GEMMs so GQA (kv heads < q heads) and SwiGLU (3 FFN
+    matmuls) are counted correctly.
+    """
+    h = args.hidden_size
+    L = args.num_layers
+    s = args.seq_length
+    f = args.ffn_hidden_size
+    hq = args.num_attention_heads * args.kv_channels          # q projection out-dim
+    hkv = args.num_query_groups * args.kv_channels            # k,v projection out-dim
+    # Per layer, per token, forward matmul MACs -> *2 for FLOPs, *3 for fwd+bwd.
+    # Attention projections: q(h*hq) + k(h*hkv) + v(h*hkv) + out(hq*h)
+    attn_proj = h * hq + 2 * (h * hkv) + hq * h
+    # Attention scores+context are seq-dependent: ~2 * s * hq per token (QK^T + AV),
+    # causal halves it -> s * hq.
+    attn_sdp = s * hq
+    # SwiGLU MLP: gate(h*f) + up(h*f) + down(f*h)
+    mlp = 3 * (h * f)
+    per_layer = 2 * (attn_proj + attn_sdp + mlp)  # 2 = MAC->FLOP
+    # Embedding + LM head (tied? we keep untied -> lm head): 2 * h * V (fwd)
+    head = 2 * h * vocab_size
+    fwd = L * per_layer + head
+    return 3.0 * fwd  # fwd + bwd ~= 3x forward
+
+
+class ThroughputState:
+    """Plain timing state (NOT a Lightning Callback — a thin Callback subclass
+    delegates to it inside main()). Kept separate so multiple-inheritance MRO
+    can't let Lightning's base-``Callback`` no-op hooks shadow our timers.
+
+    Records median steady-state per-global-step wall time -> tokens/s + MFU.
+    """
+
+    def __init__(self, args, tokens_per_step, flops_per_step, world_size, peak_tflops=989.0):
+        self.args = args
+        self.tokens_per_step = tokens_per_step
+        self.flops_per_step = flops_per_step
+        self.world_size = world_size
+        self.peak = peak_tflops * 1e12
+        self._t = None
+        self._durations = []
+        self._step = 0
+
+    def start(self):
+        import torch
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        self._t = time.perf_counter()
+
+    def stop(self):
+        import torch
+        if self._t is None:
+            return
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        dt = time.perf_counter() - self._t
+        self._step += 1
+        if self._step > self.args.measure_warmup_steps:
+            self._durations.append(dt)
+
+    def summary(self) -> dict:
+        if not self._durations:
+            return {"measured_steps": 0}
+        step_time = statistics.median(self._durations)
+        toks = self.tokens_per_step / step_time
+        achieved_flops = self.flops_per_step / step_time
+        return {
+            "measured_steps": len(self._durations),
+            "median_step_time_s": round(step_time, 4),
+            "tokens_per_step": self.tokens_per_step,
+            "tokens_per_s": round(toks, 1),
+            "tokens_per_s_per_gpu": round(toks / self.world_size, 1),
+            "model_tflops_per_gpu": round(achieved_flops / self.world_size / 1e12, 2),
+            "mfu": round(achieved_flops / (self.peak * self.world_size), 4),
+        }
+
+
+def main() -> None:
+    args = parse_args()
+    if args.tiny:
+        apply_tiny(args)
+
+    import torch
+    import torch.nn.functional as F
+    from nemo import lightning as nl
+    from nemo.collections import llm
+    from nemo.collections.llm.gpt.data.mock import MockDataModule
+
+    # Tokenizer (tiny, from HF) -> real vocab size for faithful head FLOPs.
+    from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
+    tokenizer = AutoTokenizer(pretrained_model_name=args.tokenizer)
+    vocab_size = tokenizer.vocab_size
+
+    # --- Model: Qwen3 geometry via the generic Megatron-backed GPTConfig ------
+    config = llm.GPTConfig(
+        num_layers=args.num_layers,
+        hidden_size=args.hidden_size,
+        ffn_hidden_size=args.ffn_hidden_size,
+        num_attention_heads=args.num_attention_heads,
+        num_query_groups=args.num_query_groups,   # GQA
+        kv_channels=args.kv_channels,
+        seq_length=args.seq_length,
+        # Qwen3 specifics
+        normalization="RMSNorm",
+        qk_layernorm=True,
+        gated_linear_unit=True,
+        activation_func=F.silu,
+        add_bias_linear=False,
+        position_embedding_type="rope",
+        rotary_base=args.rotary_base,
+        rotary_percent=1.0,
+        share_embeddings_and_output_weights=False,
+        make_vocab_size_divisible_by=128,
+        bf16=True,
+        # Activation checkpointing (exp108 needed it ON to fit 48L*seq8192).
+        recompute_granularity=None if args.no_grad_ckpt else "full",
+        recompute_method=None if args.no_grad_ckpt else "uniform",
+        recompute_num_layers=None if args.no_grad_ckpt else 1,
+    )
+    model = llm.GPTModel(config, tokenizer=tokenizer)
+
+    # --- Data -----------------------------------------------------------------
+    if args.data == "mock":
+        data = MockDataModule(
+            seq_length=args.seq_length,
+            tokenizer=tokenizer,
+            micro_batch_size=args.micro_batch_size,
+            global_batch_size=args.global_batch_size,
+        )
+    else:
+        # Deferred real-run path: Megatron .bin/.idx via PreTrainingDataModule.
+        from nemo.collections.llm.gpt.data import PreTrainingDataModule
+        data = PreTrainingDataModule(
+            paths=[args.data],
+            seq_length=args.seq_length,
+            tokenizer=tokenizer,
+            micro_batch_size=args.micro_batch_size,
+            global_batch_size=args.global_batch_size,
+            reset_attention_mask=True,     # block cross-document attention
+            reset_position_ids=True,
+            eod_mask_loss=False,
+        )
+
+    # --- Optimizer / schedule (tracks #75; irrelevant to MFU) -----------------
+    from megatron.core.optimizer import OptimizerConfig
+    from nemo.lightning.pytorch.optim import CosineAnnealingScheduler, MegatronOptimizerModule
+    opt = MegatronOptimizerModule(
+        config=OptimizerConfig(
+            optimizer="adam",
+            lr=args.lr,
+            weight_decay=args.weight_decay,
+            adam_beta1=0.9,
+            adam_beta2=0.95,
+            bf16=True,
+            use_distributed_optimizer=True,
+            clip_grad=1.0,
+        ),
+        lr_scheduler=CosineAnnealingScheduler(
+            warmup_steps=max(1, int(args.warmup_fraction * args.max_steps)),
+            constant_steps=0,
+            min_lr=args.lr * 0.1,
+        ),
+    )
+
+    # --- Trainer --------------------------------------------------------------
+    strategy = nl.MegatronStrategy(
+        tensor_model_parallel_size=args.tensor_parallel,
+        pipeline_model_parallel_size=args.pipeline_parallel,
+        sequence_parallel=False,
+        ckpt_async_save=False,
+    )
+    world_size = args.devices * args.num_nodes
+    tokens_per_step = args.global_batch_size * args.seq_length
+    flops_per_step = model_flops_per_token(args, vocab_size) * tokens_per_step
+
+    # Build the throughput callback as a real PTL Callback subclass that DELEGATES
+    # to the plain state object (no MRO trap). NeMo 2.0 moved to the
+    # `lightning.pytorch` namespace; fall back to `pytorch_lightning`.
+    try:
+        from lightning.pytorch import Callback
+    except ImportError:
+        from pytorch_lightning import Callback
+
+    tp_state = ThroughputState(args, tokens_per_step, flops_per_step, world_size, peak_tflops=989.0)
+
+    class ThroughputCallback(Callback):
+        def on_train_batch_start(self, *a, **k):
+            tp_state.start()
+
+        def on_train_batch_end(self, *a, **k):
+            tp_state.stop()
+
+    cb = ThroughputCallback()
+
+    trainer = nl.Trainer(
+        devices=args.devices,
+        num_nodes=args.num_nodes,
+        accelerator="gpu",
+        strategy=strategy,
+        max_steps=args.max_steps,
+        limit_val_batches=0,
+        val_check_interval=args.max_steps,  # effectively no mid-run val
+        num_sanity_val_steps=0,
+        log_every_n_steps=1,
+        enable_checkpointing=False,
+        callbacks=[cb],
+        plugins=nl.MegatronMixedPrecision(precision=args.precision),
+    )
+
+    # --- W&B (optional; only if a key was forwarded) --------------------------
+    wandb_logger = None
+    if os.environ.get("WANDB_API_KEY"):
+        try:
+            try:
+                from lightning.pytorch.loggers import WandbLogger
+            except ImportError:
+                from pytorch_lightning.loggers import WandbLogger
+            wandb_logger = WandbLogger(
+                project=args.wandb_project, entity=args.wandb_entity, name=args.wandb_name,
+                tags=["exp112", "qwen3", "3b", "nemo", "mfu", "contacts-v1", "coreweave"],
+            )
+        except Exception as e:  # noqa: BLE001
+            print(f"[exp112] W&B logger unavailable: {e}")
+
+    nemo_logger = nl.NeMoLogger(name=args.wandb_name, wandb=wandb_logger, log_dir="/tmp/exp112_nemo_logs")
+
+    print(f"[exp112] Qwen3 {args.num_layers}L h{args.hidden_size} ffn{args.ffn_hidden_size} "
+          f"{args.num_attention_heads}h/{args.num_query_groups}kv seq{args.seq_length} vocab{vocab_size} | "
+          f"gbs{args.global_batch_size} mbs{args.micro_batch_size} | {world_size} GPU | "
+          f"data={args.data} max_steps={args.max_steps} | est {flops_per_step/1e12:.1f} TFLOP/step")
+
+    llm.train(
+        model=model,
+        data=data,
+        trainer=trainer,
+        log=nemo_logger,
+        optim=opt,
+        tokenizer="data",
+        resume=None,
+    )
+
+    # --- Report (rank 0) ------------------------------------------------------
+    is_rank0 = int(os.environ.get("RANK", "0")) == 0
+    if is_rank0:
+        summary = tp_state.summary()
+        summary.update(
+            run_name=args.wandb_name,
+            world_size=world_size,
+            num_layers=args.num_layers,
+            hidden_size=args.hidden_size,
+            seq_length=args.seq_length,
+            global_batch_size=args.global_batch_size,
+            micro_batch_size=args.micro_batch_size,
+            vocab_size=vocab_size,
+            grad_ckpt=(not args.no_grad_ckpt),
+        )
+        print("[exp112] ===== MFU SUMMARY =====")
+        print(json.dumps(summary, indent=2))
+        try:
+            with open(args.results_json, "w") as fh:
+                json.dump(summary, fh, indent=2)
+            print(f"[exp112] wrote {args.results_json}")
+        except Exception as e:  # noqa: BLE001
+            print(f"[exp112] could not write results json: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import statistics
 import time
 
@@ -67,8 +68,25 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--warmup-fraction", type=float, default=0.1)
     # Data
     p.add_argument("--data", default=os.environ.get("EXP112_DATA", "mock"),
-                   help="'mock' (default) or a Megatron .bin/.idx dataset path prefix")
+                   help="'mock' (benchmark) or 'real' (Megatron .bin/.idx via --train/--val-data-prefix)")
+    p.add_argument("--train-data-prefix", default=os.environ.get("EXP112_TRAIN_DATA", "/tmp/exp112/data/train_document"),
+                   help="local Megatron .bin/.idx prefix for training (bootstrap downloads it from S3)")
+    p.add_argument("--val-data-prefix", default=os.environ.get("EXP112_VAL_DATA", "/tmp/exp112/data/val_document"),
+                   help="local Megatron .bin/.idx prefix for validation")
     p.add_argument("--tokenizer", default=os.environ.get("EXP112_TOKENIZER", "timodonnell/contacts-v1-tokenizer"))
+    # Checkpointing + resume (real run; batch priority is preemptible). No shared
+    # FS on cw-rno2a -> checkpoint to node-local disk + sync to S3; resume by
+    # downloading the latest from S3 before AutoResume.
+    p.add_argument("--checkpoint-dir", default=os.environ.get("EXP112_CKPT_DIR", "/tmp/exp112/ckpt"))
+    p.add_argument("--checkpoint-s3", default=os.environ.get("EXP112_CKPT_S3", ""),
+                   help="s3://…/checkpoints/<run>  — where to sync sharded checkpoints (empty = no sync)")
+    p.add_argument("--checkpoint-every", type=int, default=int(os.environ.get("EXP112_CKPT_EVERY", "500")))
+    p.add_argument("--keep-top-k", type=int, default=int(os.environ.get("EXP112_KEEP_TOPK", "1")))
+    p.add_argument("--resume", action="store_true", default=bool(os.environ.get("EXP112_RESUME")),
+                   help="download the latest S3 checkpoint (if any) and resume from it")
+    # Validation
+    p.add_argument("--val-check-interval", type=int, default=int(os.environ.get("EXP112_VAL_INTERVAL", "1000")))
+    p.add_argument("--limit-val-batches", type=int, default=int(os.environ.get("EXP112_VAL_BATCHES", "50")))
     # Logging / output
     p.add_argument("--wandb-project", default=os.environ.get("WANDB_PROJECT", "MarinFold"))
     p.add_argument("--wandb-entity", default=os.environ.get("WANDB_ENTITY", "open-athena"))
@@ -137,8 +155,8 @@ class ThroughputState:
     Records median steady-state per-global-step wall time -> tokens/s + MFU.
     """
 
-    def __init__(self, args, tokens_per_step, flops_per_step, world_size, peak_tflops=989.0):
-        self.args = args
+    def __init__(self, measure_warmup, tokens_per_step, flops_per_step, world_size, peak_tflops=989.0):
+        self.measure_warmup = measure_warmup
         self.tokens_per_step = tokens_per_step
         self.flops_per_step = flops_per_step
         self.world_size = world_size
@@ -161,7 +179,7 @@ class ThroughputState:
             torch.cuda.synchronize()
         dt = time.perf_counter() - self._t
         self._step += 1
-        if self._step > self.args.measure_warmup_steps:
+        if self._step > self.measure_warmup:
             self._durations.append(dt)
 
     def summary(self) -> dict:
@@ -179,6 +197,218 @@ class ThroughputState:
             "model_tflops_per_gpu": round(achieved_flops / self.world_size / 1e12, 2),
             "mfu": round(achieved_flops / (self.peak * self.world_size), 4),
         }
+
+
+# --------------------------------------------------------------------------- #
+# S3 checkpoint persistence (no shared/persistent FS on cw-rno2a; batch priority
+# is preemptible). Megatron writes a SHARDED (DCP) checkpoint dir; each node
+# holds its own ranks' shards on local disk. We sync per-node to a shared S3
+# prefix (union = complete checkpoint) and, on resume, mirror the latest back to
+# every node. Coordination uses torchrun's RANK/LOCAL_RANK env (no torch.dist
+# needed for the file I/O) + a torch.distributed.barrier where a group exists.
+# --------------------------------------------------------------------------- #
+def _env_int(name: str, default: int = 0) -> int:
+    try:
+        return int(os.environ.get(name, default))
+    except ValueError:
+        return default
+
+
+def _s3():
+    import boto3
+    from botocore.config import Config
+    return boto3.client(
+        "s3",
+        endpoint_url=os.environ.get("AWS_ENDPOINT_URL"),  # in-cluster: http://cwlota.com
+        config=Config(s3={"addressing_style": "virtual"}, retries={"max_attempts": 10}),
+    )
+
+
+def _split_s3(uri: str) -> tuple[str, str]:
+    assert uri.startswith("s3://"), uri
+    b, _, k = uri[5:].partition("/")
+    return b, k.rstrip("/")
+
+
+def _barrier():
+    import torch
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        torch.distributed.barrier()
+
+
+def _upload_tree(local_dir, s3_uri):
+    """Upload every file under local_dir to s3_uri/<relpath> (this node's shards)."""
+    import concurrent.futures as cf
+    from pathlib import Path
+    s3 = _s3()
+    bucket, prefix = _split_s3(s3_uri)
+    files = [p for p in Path(local_dir).rglob("*") if p.is_file()]
+    def _put(p):
+        rel = p.relative_to(local_dir).as_posix()
+        s3.upload_file(str(p), bucket, f"{prefix}/{rel}")
+    with cf.ThreadPoolExecutor(max_workers=16) as ex:
+        list(ex.map(_put, files))
+    return len(files)
+
+
+def _download_tree(s3_uri, local_dir):
+    """Mirror s3_uri/* down into local_dir (full checkpoint on every node)."""
+    import concurrent.futures as cf
+    from pathlib import Path
+    s3 = _s3()
+    bucket, prefix = _split_s3(s3_uri)
+    keys = []
+    for pg in s3.get_paginator("list_objects_v2").paginate(Bucket=bucket, Prefix=prefix + "/"):
+        keys += [o["Key"] for o in pg.get("Contents", [])]
+    def _get(key):
+        rel = key[len(prefix) + 1:]
+        dst = Path(local_dir) / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        s3.download_file(bucket, key, str(dst))
+    with cf.ThreadPoolExecutor(max_workers=16) as ex:
+        list(ex.map(_get, keys))
+    return len(keys)
+
+
+def _s3_read_text(s3_uri) -> str | None:
+    s3 = _s3()
+    bucket, key = _split_s3(s3_uri)
+    try:
+        return s3.get_object(Bucket=bucket, Key=key)["Body"].read().decode()
+    except Exception:  # noqa: BLE001 — missing = None
+        return None
+
+
+def _s3_write_text(s3_uri, text: str):
+    s3 = _s3()
+    bucket, key = _split_s3(s3_uri)
+    s3.put_object(Bucket=bucket, Key=key, Body=text.encode())
+
+
+def _list_s3_subdirs(s3_uri) -> list[str]:
+    s3 = _s3()
+    bucket, prefix = _split_s3(s3_uri)
+    out = set()
+    for pg in s3.get_paginator("list_objects_v2").paginate(Bucket=bucket, Prefix=prefix + "/", Delimiter="/"):
+        for cp in pg.get("CommonPrefixes", []):
+            out.add(cp["Prefix"][len(prefix) + 1:].rstrip("/"))
+    return sorted(out)
+
+
+def _delete_s3_subdir(s3_uri):
+    s3 = _s3()
+    bucket, prefix = _split_s3(s3_uri)
+    keys = []
+    for pg in s3.get_paginator("list_objects_v2").paginate(Bucket=bucket, Prefix=prefix + "/"):
+        keys += [{"Key": o["Key"]} for o in pg.get("Contents", [])]
+    for i in range(0, len(keys), 1000):
+        s3.delete_objects(Bucket=bucket, Delete={"Objects": keys[i:i + 1000]})
+
+
+def restore_latest_checkpoint_from_s3(ckpt_dir: str, s3_uri: str) -> str | None:
+    """Before training: node-level (LOCAL_RANK 0) mirror the latest S3 checkpoint
+    into ckpt_dir so AutoResume finds it. Peers wait on a local marker. Returns
+    the restored subdir name, or None if there is no checkpoint yet."""
+    import time
+    from pathlib import Path
+    Path(ckpt_dir).mkdir(parents=True, exist_ok=True)
+    marker = Path(ckpt_dir) / ".restore_done"
+    local_rank = _env_int("LOCAL_RANK", 0)
+    latest_uri = f"{s3_uri}/latest.txt"
+    if local_rank == 0:
+        latest = _s3_read_text(latest_uri)
+        if latest:
+            latest = latest.strip()
+            n = _download_tree(f"{s3_uri}/{latest}", str(Path(ckpt_dir) / latest))
+            print(f"[exp112] restored checkpoint '{latest}' from S3 ({n} files) -> {ckpt_dir}", flush=True)
+            marker.write_text(latest)
+        else:
+            marker.write_text("")
+    else:
+        for _ in range(1200):  # up to ~20 min
+            if marker.exists():
+                break
+            time.sleep(1)
+    val = marker.read_text().strip() if marker.exists() else ""
+    return val or None
+
+
+# --------------------------------------------------------------------------- #
+# Callbacks — MODULE LEVEL (not in main()). NeMo's ModelCheckpoint io-dumps the
+# TrainerContext (incl. callbacks) via fiddle, which pyref's each callback CLASS;
+# a class defined inside main() is `main.<locals>.X` and can't be pyref'd (fiddle
+# AttributeError). Module-level classes with PRIMITIVE-only init args serialize
+# cleanly. `_Callback` is imported here (this file only ever runs in-container);
+# fall back to `object` so `--help` works in the launcher env without lightning.
+# --------------------------------------------------------------------------- #
+try:
+    from lightning.pytorch import Callback as _Callback
+except Exception:  # noqa: BLE001
+    try:
+        from pytorch_lightning import Callback as _Callback
+    except Exception:  # noqa: BLE001
+        _Callback = object
+
+
+def _pick_latest(subdirs):
+    """Highest-step checkpoint subdir (deterministic across nodes)."""
+    def step_of(d):
+        m = re.search(r"step=?(\d+)", d.name)
+        return int(m.group(1)) if m else -1
+    return max(subdirs, key=lambda d: (step_of(d), d.stat().st_mtime))
+
+
+class ThroughputCallback(_Callback):
+    """Times steady-state global steps → tokens/s + MFU (via a ThroughputState)."""
+
+    def __init__(self, measure_warmup: int, tokens_per_step: int, flops_per_step: float,
+                 world_size: int, peak_tflops: float = 989.0):
+        super().__init__()
+        self.state = ThroughputState(measure_warmup, tokens_per_step, flops_per_step,
+                                     world_size, peak_tflops)
+
+    def on_train_batch_start(self, *a, **k):
+        self.state.start()
+
+    def on_train_batch_end(self, *a, **k):
+        self.state.stop()
+
+
+class S3CheckpointSync(_Callback):
+    """After each local checkpoint, sync the newest sharded dir to S3 (each node
+    uploads its own shards; union = complete). Prune S3 to just the latest +
+    commit latest.txt. Non-fatal on error (checkpoint still on local disk)."""
+
+    def __init__(self, checkpoint_s3: str, checkpoint_dir: str, checkpoint_every: int):
+        super().__init__()
+        self.checkpoint_s3 = checkpoint_s3
+        self.checkpoint_dir = checkpoint_dir
+        self.checkpoint_every = checkpoint_every
+
+    def on_train_batch_end(self, trainer, *a, **k):
+        if not self.checkpoint_s3:
+            return
+        step = int(trainer.global_step)
+        if step <= 0 or step % self.checkpoint_every != 0:
+            return
+        try:
+            from pathlib import Path
+            _barrier()  # all ranks finished the (sync) save
+            ck = Path(self.checkpoint_dir)
+            subdirs = [d for d in ck.iterdir() if d.is_dir() and not d.name.startswith(".")] if ck.exists() else []
+            if not subdirs:
+                return
+            latest = _pick_latest(subdirs)
+            n = _upload_tree(str(latest), f"{self.checkpoint_s3}/{latest.name}")
+            _barrier()  # all nodes finished uploading their shards
+            if _env_int("RANK", 0) == 0:
+                for name in _list_s3_subdirs(self.checkpoint_s3):
+                    if name != latest.name:
+                        _delete_s3_subdir(f"{self.checkpoint_s3}/{name}")
+                _s3_write_text(f"{self.checkpoint_s3}/latest.txt", latest.name)
+                print(f"[exp112] checkpoint synced to S3: {latest.name} (node shards: {n} files)", flush=True)
+        except Exception as e:  # noqa: BLE001 — never kill training over a sync
+            print(f"[exp112] S3 checkpoint sync error (non-fatal): {e}", flush=True)
 
 
 def main() -> None:
@@ -234,17 +464,32 @@ def main() -> None:
             global_batch_size=args.global_batch_size,
         )
     else:
-        # Deferred real-run path: Megatron .bin/.idx via PreTrainingDataModule.
+        # Real run: Megatron .bin/.idx (local prefixes; bootstrap downloaded them
+        # from S3). Explicit train/validation/test splits. reset_*: pack docs but
+        # DON'T attend/count position across the <eod> boundary (block cross-doc
+        # attention — matches exp108's block_cross_document_attention).
+        from pathlib import Path
+
         from nemo.collections.llm.gpt.data import PreTrainingDataModule
+        # Megatron writes .npy sample-index maps here — MUST be writable (keep it
+        # off the data dir, which may be a read-only mount).
+        idx_dir = os.environ.get("EXP112_INDEX_DIR", "/tmp/exp112/index")
+        Path(idx_dir).mkdir(parents=True, exist_ok=True)
         data = PreTrainingDataModule(
-            paths=[args.data],
+            paths={
+                "train": [args.train_data_prefix],
+                "validation": [args.val_data_prefix],
+                "test": [args.val_data_prefix],
+            },
             seq_length=args.seq_length,
             tokenizer=tokenizer,
             micro_batch_size=args.micro_batch_size,
             global_batch_size=args.global_batch_size,
-            reset_attention_mask=True,     # block cross-document attention
+            reset_attention_mask=True,
             reset_position_ids=True,
             eod_mask_loss=False,
+            index_mapping_dir=idx_dir,
+            num_workers=4,
         )
 
     # --- Optimizer / schedule (tracks #75; irrelevant to MFU) -----------------
@@ -279,24 +524,17 @@ def main() -> None:
     tokens_per_step = args.global_batch_size * args.seq_length
     flops_per_step = model_flops_per_token(args, vocab_size) * tokens_per_step
 
-    # Build the throughput callback as a real PTL Callback subclass that DELEGATES
-    # to the plain state object (no MRO trap). NeMo 2.0 moved to the
-    # `lightning.pytorch` namespace; fall back to `pytorch_lightning`.
-    try:
-        from lightning.pytorch import Callback
-    except ImportError:
-        from pytorch_lightning import Callback
+    is_real = args.data != "mock"
+    # NeMo writes checkpoints under <log_dir>/<name>/checkpoints; align our S3
+    # sync + restore to that exact dir (compute BEFORE building callbacks).
+    log_dir = os.environ.get("EXP112_LOG_DIR", "/tmp/exp112/nemo_logs")
+    ckpt_dir = os.path.join(log_dir, args.wandb_name, "checkpoints")
+    args.checkpoint_dir = ckpt_dir
 
-    tp_state = ThroughputState(args, tokens_per_step, flops_per_step, world_size, peak_tflops=989.0)
-
-    class ThroughputCallback(Callback):
-        def on_train_batch_start(self, *a, **k):
-            tp_state.start()
-
-        def on_train_batch_end(self, *a, **k):
-            tp_state.stop()
-
-    cb = ThroughputCallback()
+    callbacks = [ThroughputCallback(args.measure_warmup_steps, tokens_per_step, flops_per_step, world_size)]
+    tp_state = callbacks[0].state  # for the end-of-run summary
+    if is_real and args.checkpoint_s3:
+        callbacks.append(S3CheckpointSync(args.checkpoint_s3, ckpt_dir, args.checkpoint_every))
 
     trainer = nl.Trainer(
         devices=args.devices,
@@ -304,12 +542,12 @@ def main() -> None:
         accelerator="gpu",
         strategy=strategy,
         max_steps=args.max_steps,
-        limit_val_batches=0,
-        val_check_interval=args.max_steps,  # effectively no mid-run val
+        limit_val_batches=(args.limit_val_batches if is_real else 0),
+        val_check_interval=(args.val_check_interval if is_real else args.max_steps),
         num_sanity_val_steps=0,
-        log_every_n_steps=1,
-        enable_checkpointing=False,
-        callbacks=[cb],
+        log_every_n_steps=10 if is_real else 1,
+        enable_checkpointing=is_real,
+        callbacks=callbacks,
         plugins=nl.MegatronMixedPrecision(precision=args.precision),
     )
 
@@ -328,12 +566,34 @@ def main() -> None:
         except Exception as e:  # noqa: BLE001
             print(f"[exp112] W&B logger unavailable: {e}")
 
-    nemo_logger = nl.NeMoLogger(name=args.wandb_name, wandb=wandb_logger, log_dir="/tmp/exp112_nemo_logs")
+    # log_dir / ckpt_dir were computed above (before the callbacks).
+    ckpt_cb = None
+    resume = None
+    if is_real:
+        from nemo.lightning import AutoResume
+        from nemo.lightning.pytorch.callbacks import ModelCheckpoint
+        ckpt_cb = ModelCheckpoint(
+            dirpath=ckpt_dir,
+            every_n_train_steps=args.checkpoint_every,
+            save_last=True,
+            save_top_k=args.keep_top_k,
+            save_on_train_epoch_end=False,
+            save_optim_on_train_end=True,
+        )
+        # Preemption resume: pull the latest S3 checkpoint into ckpt_dir first
+        # (node-level), then let AutoResume pick it up.
+        if args.resume and args.checkpoint_s3:
+            restored = restore_latest_checkpoint_from_s3(ckpt_dir, args.checkpoint_s3)
+            print(f"[exp112] resume: restored={restored!r}", flush=True)
+        resume = AutoResume(resume_if_exists=True, resume_ignore_no_checkpoint=True)
+
+    nemo_logger = nl.NeMoLogger(name=args.wandb_name, wandb=wandb_logger, log_dir=log_dir, ckpt=ckpt_cb)
 
     print(f"[exp112] Qwen3 {args.num_layers}L h{args.hidden_size} ffn{args.ffn_hidden_size} "
           f"{args.num_attention_heads}h/{args.num_query_groups}kv seq{args.seq_length} vocab{vocab_size} | "
           f"gbs{args.global_batch_size} mbs{args.micro_batch_size} | {world_size} GPU | "
-          f"data={args.data} max_steps={args.max_steps} | est {flops_per_step/1e12:.1f} TFLOP/step")
+          f"data={args.data} max_steps={args.max_steps} | est {flops_per_step/1e12:.1f} TFLOP/step | "
+          f"ckpt_every={args.checkpoint_every} s3={args.checkpoint_s3 or 'none'}")
 
     llm.train(
         model=model,
@@ -342,7 +602,7 @@ def main() -> None:
         log=nemo_logger,
         optim=opt,
         tokenizer="data",
-        resume=None,
+        resume=resume,
     )
 
     # --- Report (rank 0) ------------------------------------------------------

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
@@ -461,6 +461,28 @@ class S3CheckpointSync(_Callback):
         self._sync(trainer)
 
 
+# Weight-decay mask — MODULE LEVEL for the SAME reason as the callbacks above:
+# it is handed to MegatronOptimizerModule(no_weight_decay_cond=...), and NeMo's
+# ModelCheckpoint fiddle-io-dumps the trainer graph (which includes the optimizer)
+# at every save. A `main.<locals>` closure crashes that serialization at the first
+# checkpoint (fiddle walks the qualname `main.<locals>._no_wd_cond` by getattr ->
+# "'function' object has no attribute '<locals>'"), restart-looping the run before
+# any checkpoint banks. A module-level function pyref's cleanly. It reads
+# wd_embeddings from an env var (set in main) instead of closing over `args`.
+# Excludes biases + 1-D (norms) AND embeddings/output (matches Levanter's #75
+# default; Megatron's default decays the 2-D embedding/output at wd 0.2).
+def _no_wd_cond(name, param):
+    base = name.endswith(".bias") or len(param.shape) == 1
+    if os.environ.get("EXP112_WD_EMBEDDINGS") == "1":
+        res = base
+    else:
+        n = name.lower()
+        res = base or ("embedding" in n) or ("output_layer" in n)
+    if os.environ.get("EXP112_DEBUG_WD"):
+        print(f"[wd] {'NO_WD' if res else 'decay'} shape={tuple(param.shape)} {name}", flush=True)
+    return res
+
+
 def main() -> None:
     args = parse_args()
     if args.tiny:
@@ -496,6 +518,29 @@ def main() -> None:
             _dist.get_rank = real
 
     _bb.BlendedMegatronDatasetBuilder.build = _build_local_rank
+
+    # Belt-and-suspenders: NeMo's ModelCheckpoint._save_checkpoint fiddle-io-dumps
+    # the trainer context ("context/" YAML) on every save. If ANY object in that
+    # graph isn't fiddle-serializable, the exception propagates and kills training
+    # at the first checkpoint. We don't use "context/" for resume (AutoResume reads
+    # the Megatron DCP weights/optimizer, and we rebuild the model in-code each
+    # launch), so make the dump non-fatal: a serialization failure logs + skips the
+    # context rather than crashing the run. The module-level _no_wd_cond above fixes
+    # the known offender; this guards any future one.
+    try:
+        import nemo.lightning.io.mixin as _io_mixin
+        _orig_io_dump = _io_mixin.IOMixin.io_dump
+
+        def _safe_io_dump(self, *a, **k):
+            try:
+                return _orig_io_dump(self, *a, **k)
+            except Exception as e:  # noqa: BLE001
+                print(f"[exp112] NeMo io_dump skipped (non-fatal; resume uses DCP "
+                      f"weights, not fiddle context): {type(e).__name__}: {e}", flush=True)
+
+        _io_mixin.IOMixin.io_dump = _safe_io_dump
+    except Exception as e:  # noqa: BLE001
+        print(f"[exp112] could not install io_dump guard: {e}", flush=True)
 
     # Tokenizer (tiny, from HF) -> real vocab size for faithful head FLOPs.
     from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
@@ -590,20 +635,11 @@ def main() -> None:
     from nemo.lightning.pytorch.optim import CosineAnnealingScheduler, MegatronOptimizerModule
 
     # Weight-decay mask matching Levanter's default (#75): exclude biases, norms
-    # (1-D), AND embeddings/output. Megatron's default only excludes biases+1-D, so
-    # it decays the 2-D embedding/output matrices at wd 0.2 -> over-regularizes a
-    # small-vocab model. Passing no_weight_decay_cond OVERRIDES Megatron's default,
-    # so replicate its bias/1-D rule here too. (Set --wd-embeddings 1 to revert.)
-    def _no_wd_cond(name, param):
-        base = name.endswith(".bias") or len(param.shape) == 1
-        if args.wd_embeddings:
-            res = base
-        else:
-            n = name.lower()
-            res = base or ("embedding" in n) or ("output_layer" in n)
-        if os.environ.get("EXP112_DEBUG_WD"):
-            print(f"[wd] {'NO_WD' if res else 'decay'} shape={tuple(param.shape)} {name}", flush=True)
-        return res
+    # (1-D), AND embeddings/output (Megatron's default only excludes biases+1-D, so
+    # it decays the 2-D embedding/output at wd 0.2 -> over-regularizes a small-vocab
+    # model). The mask fn is MODULE-LEVEL (_no_wd_cond, above) so it survives NeMo's
+    # fiddle io_dump at checkpoint save; it reads wd_embeddings via this env var.
+    os.environ["EXP112_WD_EMBEDDINGS"] = "1" if args.wd_embeddings else "0"
 
     opt = MegatronOptimizerModule(
         config=OptimizerConfig(

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
@@ -60,6 +60,17 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--num-query-groups", type=int, default=8)
     p.add_argument("--kv-channels", type=int, default=64)
     p.add_argument("--rotary-base", type=float, default=500_000.0)  # #75 Llama3 rope theta
+    # --- #75-faithful knobs (the exp108/Levanter run used these; defaults match #75) ---
+    p.add_argument("--rope-scaling-factor", type=float, default=float(os.environ.get("EXP112_ROPE_SCALING", "8.0")),
+                   help="Llama3 RoPE freq-scaling factor (#75 = 8.0; 0 disables). NeMo GPTConfig lacks the "
+                        "knob, so this is injected into MCoreGPTModel (llama3 low/high/orig = 1/4/8192, = #75).")
+    p.add_argument("--tie-embeddings", type=int, default=int(os.environ.get("EXP112_TIE", "1")),
+                   help="tie input/output embeddings (#75/Qwen3 = 1)")
+    p.add_argument("--layernorm-eps", type=float, default=float(os.environ.get("EXP112_LN_EPS", "1e-6")),
+                   help="RMSNorm epsilon (#75/Qwen3-0.6B = 1e-6; Megatron default 1e-5)")
+    p.add_argument("--wd-embeddings", type=int, default=int(os.environ.get("EXP112_WD_EMB", "0")),
+                   help="apply weight decay to embeddings + output layer (#75 = 0 -> EXCLUDED, like Levanter's "
+                        "default mask; Megatron decays them by default, which over-regularizes at wd 0.2)")
     p.add_argument("--no-grad-ckpt", action="store_true",
                    help="disable activation checkpointing (exp108 needed it ON to fit)")
     # Optim (only meaningful for a real run; harmless for the benchmark)
@@ -485,6 +496,23 @@ def main() -> None:
     tokenizer = AutoTokenizer(pretrained_model_name=args.tokenizer)
     vocab_size = tokenizer.vocab_size
 
+    # Llama3 RoPE freq-scaling to match #75 (Levanter Llama3RotaryEmbeddingsConfig:
+    # theta 500000 + factor 8 / low 1 / high 4 / orig 8192). NeMo's generic
+    # GPTConfig has no rope_scaling field and configure_model doesn't pass it, so
+    # inject it at the MCoreGPTModel constructor (Megatron's llama3 scaling
+    # hardcodes low/high/orig = 1/4/8192, exactly #75).
+    if args.rope_scaling_factor and args.rope_scaling_factor > 0:
+        import megatron.core.models.gpt.gpt_model as _mgpt
+        _orig_gpt_init = _mgpt.GPTModel.__init__
+
+        def _gpt_init_rope(self, *a, **k):
+            k["rope_scaling"] = True
+            k["rope_scaling_factor"] = args.rope_scaling_factor
+            print(f"[exp112] Llama3 RoPE scaling ON (factor={args.rope_scaling_factor}, theta={args.rotary_base})", flush=True)
+            return _orig_gpt_init(self, *a, **k)
+
+        _mgpt.GPTModel.__init__ = _gpt_init_rope
+
     # --- Model: Qwen3 geometry via the generic Megatron-backed GPTConfig ------
     config = llm.GPTConfig(
         num_layers=args.num_layers,
@@ -497,13 +525,14 @@ def main() -> None:
         # Qwen3 specifics
         normalization="RMSNorm",
         qk_layernorm=True,
+        layernorm_epsilon=args.layernorm_eps,     # #75/Qwen3 = 1e-6
         gated_linear_unit=True,
         activation_func=F.silu,
         add_bias_linear=False,
         position_embedding_type="rope",
         rotary_base=args.rotary_base,
         rotary_percent=1.0,
-        share_embeddings_and_output_weights=False,
+        share_embeddings_and_output_weights=bool(args.tie_embeddings),  # #75/Qwen3 = tied
         make_vocab_size_divisible_by=128,
         bf16=True,
         # Activation checkpointing (exp108 needed it ON to fit 48L*seq8192).
@@ -550,16 +579,34 @@ def main() -> None:
             num_workers=4,
         )
 
-    # --- Optimizer / schedule (tracks #75; irrelevant to MFU) -----------------
+    # --- Optimizer / schedule (matches #75) -----------------------------------
     from megatron.core.optimizer import OptimizerConfig
     from nemo.lightning.pytorch.optim import CosineAnnealingScheduler, MegatronOptimizerModule
+
+    # Weight-decay mask matching Levanter's default (#75): exclude biases, norms
+    # (1-D), AND embeddings/output. Megatron's default only excludes biases+1-D, so
+    # it decays the 2-D embedding/output matrices at wd 0.2 -> over-regularizes a
+    # small-vocab model. Passing no_weight_decay_cond OVERRIDES Megatron's default,
+    # so replicate its bias/1-D rule here too. (Set --wd-embeddings 1 to revert.)
+    def _no_wd_cond(name, param):
+        base = name.endswith(".bias") or len(param.shape) == 1
+        if args.wd_embeddings:
+            res = base
+        else:
+            n = name.lower()
+            res = base or ("embedding" in n) or ("output_layer" in n)
+        if os.environ.get("EXP112_DEBUG_WD"):
+            print(f"[wd] {'NO_WD' if res else 'decay'} shape={tuple(param.shape)} {name}", flush=True)
+        return res
+
     opt = MegatronOptimizerModule(
         config=OptimizerConfig(
             optimizer="adam",
             lr=args.lr,
             weight_decay=args.weight_decay,
             adam_beta1=0.9,
-            adam_beta2=0.95,
+            adam_beta2=0.95,       # = Levanter's default beta2 (verified)
+            adam_eps=1e-8,
             bf16=True,
             use_distributed_optimizer=True,
             clip_grad=1.0,
@@ -567,8 +614,9 @@ def main() -> None:
         lr_scheduler=CosineAnnealingScheduler(
             warmup_steps=max(1, int(args.warmup_fraction * args.max_steps)),
             constant_steps=0,
-            min_lr=args.lr * 0.1,
+            min_lr=args.lr * 0.1,  # = Levanter min_lr_ratio 0.1
         ),
+        no_weight_decay_cond=_no_wd_cond,
     )
 
     # --- Trainer --------------------------------------------------------------

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
@@ -220,7 +220,8 @@ def _s3():
     return boto3.client(
         "s3",
         endpoint_url=os.environ.get("AWS_ENDPOINT_URL"),  # in-cluster: http://cwlota.com
-        config=Config(s3={"addressing_style": "virtual"}, retries={"max_attempts": 10}),
+        config=Config(s3={"addressing_style": "virtual"}, retries={"max_attempts": 10},
+                      max_pool_connections=32),  # >= the uploader's ThreadPool (16) to avoid pool-full churn
     )
 
 

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
@@ -434,7 +434,13 @@ class S3CheckpointSync(_Callback):
             return
         try:
             _barrier()  # DCP save is synchronous+collective; all nodes have it now
-            n = _upload_tree(str(latest), f"{self.checkpoint_s3}/{latest.name}")
+            # Per-NODE upload (LOCAL_RANK 0 only): each node's local ckpt dir holds
+            # all 8 of that node's ranks' shards. Without this gate all 32 ranks
+            # re-upload the same node's files 8x -> connection-pool churn + a slow
+            # upload stalls the barrier and can trip the NCCL watchdog.
+            n = 0
+            if _env_int("LOCAL_RANK", 0) == 0:
+                n = _upload_tree(str(latest), f"{self.checkpoint_s3}/{latest.name}")
             _barrier()  # all nodes finished uploading their shards
             if _env_int("RANK", 0) == 0:
                 for name in _list_s3_subdirs(self.checkpoint_s3):

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
@@ -64,13 +64,17 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--rope-scaling-factor", type=float, default=float(os.environ.get("EXP112_ROPE_SCALING", "8.0")),
                    help="Llama3 RoPE freq-scaling factor (#75 = 8.0; 0 disables). NeMo GPTConfig lacks the "
                         "knob, so this is injected into MCoreGPTModel (llama3 low/high/orig = 1/4/8192, = #75).")
-    p.add_argument("--tie-embeddings", type=int, default=int(os.environ.get("EXP112_TIE", "1")),
-                   help="tie input/output embeddings (#75/Qwen3 = 1)")
-    p.add_argument("--layernorm-eps", type=float, default=float(os.environ.get("EXP112_LN_EPS", "1e-6")),
-                   help="RMSNorm epsilon (#75/Qwen3-0.6B = 1e-6; Megatron default 1e-5)")
+    # #75's ACTUAL logged W&B config (eric-czech/marin prot-exp75-cv1-1_5b-e8-lr1e-3-wd0p2-v1)
+    # is the authority here: tie_word_embeddings=False, use_qk_norm=False, eps=1e-5.
+    p.add_argument("--tie-embeddings", type=int, default=int(os.environ.get("EXP112_TIE", "0")),
+                   help="tie input/output embeddings (#75 = 0 -> UNTIED, separate lm_head)")
+    p.add_argument("--qk-layernorm", type=int, default=int(os.environ.get("EXP112_QK_NORM", "0")),
+                   help="Qwen3 QK-LayerNorm (#75 use_qk_norm = 0 -> OFF, despite Qwen3-0.6B reference)")
+    p.add_argument("--layernorm-eps", type=float, default=float(os.environ.get("EXP112_LN_EPS", "1e-5")),
+                   help="RMSNorm epsilon (#75 layer_norm_epsilon = 1e-5)")
     p.add_argument("--wd-embeddings", type=int, default=int(os.environ.get("EXP112_WD_EMB", "0")),
-                   help="apply weight decay to embeddings + output layer (#75 = 0 -> EXCLUDED, like Levanter's "
-                        "default mask; Megatron decays them by default, which over-regularizes at wd 0.2)")
+                   help="apply weight decay to the INPUT embedding too (#75 = 0 -> input embedding EXCLUDED; "
+                        "#75 DOES decay the untied output lm_head, like Levanter's default mask)")
     p.add_argument("--no-grad-ckpt", action="store_true",
                    help="disable activation checkpointing (exp108 needed it ON to fit)")
     # Optim (only meaningful for a real run; harmless for the benchmark)
@@ -469,15 +473,19 @@ class S3CheckpointSync(_Callback):
 # "'function' object has no attribute '<locals>'"), restart-looping the run before
 # any checkpoint banks. A module-level function pyref's cleanly. It reads
 # wd_embeddings from an env var (set in main) instead of closing over `args`.
-# Excludes biases + 1-D (norms) AND embeddings/output (matches Levanter's #75
-# default; Megatron's default decays the 2-D embedding/output at wd 0.2).
+# Excludes biases + 1-D (norms) + the INPUT embedding, but DECAYS the untied
+# output lm_head + attn/mlp matrices — matching #75's logged decayed_weights.
 def _no_wd_cond(name, param):
     base = name.endswith(".bias") or len(param.shape) == 1
     if os.environ.get("EXP112_WD_EMBEDDINGS") == "1":
         res = base
     else:
+        # #75's decayed_weights: DECAYS the untied output lm_head + all attn/mlp
+        # matrices; EXCLUDES only the input embedding (+ 1-D norms/bias). So mask
+        # the input embedding but NOT output_layer. (Megatron: input =
+        # `embedding.word_embeddings.weight`, output = `output_layer.weight`.)
         n = name.lower()
-        res = base or ("embedding" in n) or ("output_layer" in n)
+        res = base or ("word_embeddings" in n) or ("embedding" in n and "output" not in n)
     if os.environ.get("EXP112_DEBUG_WD"):
         print(f"[wd] {'NO_WD' if res else 'decay'} shape={tuple(param.shape)} {name}", flush=True)
     return res
@@ -575,15 +583,15 @@ def main() -> None:
         seq_length=args.seq_length,
         # Qwen3 specifics
         normalization="RMSNorm",
-        qk_layernorm=True,
-        layernorm_epsilon=args.layernorm_eps,     # #75/Qwen3 = 1e-6
+        qk_layernorm=bool(args.qk_layernorm),     # #75 use_qk_norm = False
+        layernorm_epsilon=args.layernorm_eps,     # #75 = 1e-5
         gated_linear_unit=True,
         activation_func=F.silu,
         add_bias_linear=False,
         position_embedding_type="rope",
         rotary_base=args.rotary_base,
         rotary_percent=1.0,
-        share_embeddings_and_output_weights=bool(args.tie_embeddings),  # #75/Qwen3 = tied
+        share_embeddings_and_output_weights=bool(args.tie_embeddings),  # #75 = untied (False)
         make_vocab_size_divisible_by=128,
         bf16=True,
         # Activation checkpointing (exp108 needed it ON to fit 48L*seq8192).

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
@@ -350,12 +350,19 @@ except Exception:  # noqa: BLE001
         _Callback = object
 
 
+def _step_of(d):
+    # NeMo names checkpoints with `consumed_samples=N` (monotonic) and sometimes
+    # `step=N`; use whichever is present as the progress/ordering key.
+    for pat in (r"consumed_samples=?(\d+)", r"step=?(\d+)"):
+        m = re.search(pat, d.name)
+        if m:
+            return int(m.group(1))
+    return -1
+
+
 def _pick_latest(subdirs):
     """Highest-step checkpoint subdir (deterministic across nodes)."""
-    def step_of(d):
-        m = re.search(r"step=?(\d+)", d.name)
-        return int(m.group(1)) if m else -1
-    return max(subdirs, key=lambda d: (step_of(d), d.stat().st_mtime))
+    return max(subdirs, key=lambda d: (_step_of(d), d.stat().st_mtime))
 
 
 class ThroughputCallback(_Callback):
@@ -375,30 +382,37 @@ class ThroughputCallback(_Callback):
 
 
 class S3CheckpointSync(_Callback):
-    """After each local checkpoint, sync the newest sharded dir to S3 (each node
-    uploads its own shards; union = complete). Prune S3 to just the latest +
-    commit latest.txt. Non-fatal on error (checkpoint still on local disk)."""
+    """Sync the newest sharded checkpoint dir to S3 whenever a NEW one appears
+    (detected by its step, not by a step-count trigger — NeMo's ModelCheckpoint
+    writes after our callback and at a step offset, so a `% every == 0` trigger
+    misses it). Each node uploads its OWN shards (union = complete checkpoint; no
+    shared FS); rank-0 prunes S3 to just the latest + commits latest.txt. All
+    ranks see the same latest step (every node writes the DCP checkpoint locally),
+    so the barrier stays collective-safe. Non-fatal on error."""
 
     def __init__(self, checkpoint_s3: str, checkpoint_dir: str, checkpoint_every: int):
         super().__init__()
         self.checkpoint_s3 = checkpoint_s3
         self.checkpoint_dir = checkpoint_dir
-        self.checkpoint_every = checkpoint_every
+        self._last_synced = -1
 
-    def on_train_batch_end(self, trainer, *a, **k):
+    def _sync(self):
         if not self.checkpoint_s3:
             return
-        step = int(trainer.global_step)
-        if step <= 0 or step % self.checkpoint_every != 0:
+        from pathlib import Path
+        ck = Path(self.checkpoint_dir)
+        if not ck.exists():
             return
+        subdirs = [d for d in ck.iterdir() if d.is_dir() and not d.name.startswith(".")]
+        subdirs = [d for d in subdirs if _step_of(d) >= 0]  # step-named (skip bare -last)
+        if not subdirs:
+            return
+        latest = _pick_latest(subdirs)
+        step = _step_of(latest)
+        if step <= self._last_synced:
+            return  # already uploaded this checkpoint
         try:
-            from pathlib import Path
-            _barrier()  # all ranks finished the (sync) save
-            ck = Path(self.checkpoint_dir)
-            subdirs = [d for d in ck.iterdir() if d.is_dir() and not d.name.startswith(".")] if ck.exists() else []
-            if not subdirs:
-                return
-            latest = _pick_latest(subdirs)
+            _barrier()  # DCP save is synchronous+collective; all nodes have it now
             n = _upload_tree(str(latest), f"{self.checkpoint_s3}/{latest.name}")
             _barrier()  # all nodes finished uploading their shards
             if _env_int("RANK", 0) == 0:
@@ -407,8 +421,15 @@ class S3CheckpointSync(_Callback):
                         _delete_s3_subdir(f"{self.checkpoint_s3}/{name}")
                 _s3_write_text(f"{self.checkpoint_s3}/latest.txt", latest.name)
                 print(f"[exp112] checkpoint synced to S3: {latest.name} (node shards: {n} files)", flush=True)
+            self._last_synced = step
         except Exception as e:  # noqa: BLE001 — never kill training over a sync
             print(f"[exp112] S3 checkpoint sync error (non-fatal): {e}", flush=True)
+
+    def on_train_batch_end(self, trainer, *a, **k):
+        self._sync()
+
+    def on_train_end(self, trainer, *a, **k):
+        self._sync()  # catch the final checkpoint (no batch after it)
 
 
 def main() -> None:
@@ -421,6 +442,31 @@ def main() -> None:
     from nemo import lightning as nl
     from nemo.collections import llm
     from nemo.collections.llm.gpt.data.mock import MockDataModule
+
+    # Multi-node dataset index cache without a shared FS: Megatron builds the
+    # sample/shuffle .npy on GLOBAL rank-0 only, into a NODE-LOCAL dir, then all
+    # ranks read it -> other nodes' ranks FileNotFound. Patch the dataset builder
+    # so that DURING the build, get_rank() reports the LOCAL rank: each node's
+    # local-rank-0 builds its own node-local cache (before the collective barrier),
+    # and that node's other ranks read it (after). The barrier is collective and
+    # doesn't use get_rank, so this stays correct; get_rank is restored after.
+    import torch.distributed as _dist
+    import megatron.core.datasets.blended_megatron_dataset_builder as _bb
+
+    _orig_build = _bb.BlendedMegatronDatasetBuilder.build
+
+    def _build_local_rank(self):
+        if not (_dist.is_available() and _dist.is_initialized()):
+            return _orig_build(self)
+        lr = _env_int("LOCAL_RANK", 0)
+        real = _dist.get_rank
+        _dist.get_rank = lambda *a, **k: lr
+        try:
+            return _orig_build(self)
+        finally:
+            _dist.get_rank = real
+
+    _bb.BlendedMegatronDatasetBuilder.build = _build_local_rank
 
     # Tokenizer (tiny, from HF) -> real vocab size for faithful head FLOPs.
     from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
@@ -471,10 +517,10 @@ def main() -> None:
         from pathlib import Path
 
         from nemo.collections.llm.gpt.data import PreTrainingDataModule
-        # Megatron writes .npy sample-index maps here — MUST be writable (keep it
-        # off the data dir, which may be a read-only mount).
-        idx_dir = os.environ.get("EXP112_INDEX_DIR", "/tmp/exp112/index")
-        Path(idx_dir).mkdir(parents=True, exist_ok=True)
+        # index_mapping_dir=None -> Megatron builds the sample/shuffle indices
+        # IN MEMORY on every rank (a few seconds over ~9M samples). With a path,
+        # only GLOBAL rank-0 writes the .npy to its node-local disk, and other
+        # nodes' ranks can't read it (no shared FS on cw-rno2a) -> FileNotFound.
         data = PreTrainingDataModule(
             paths={
                 "train": [args.train_data_prefix],
@@ -488,7 +534,7 @@ def main() -> None:
             reset_attention_mask=True,
             reset_position_ids=True,
             eod_mask_loss=False,
-            index_mapping_dir=idx_dir,
+            index_mapping_dir=None,
             num_workers=4,
         )
 

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
@@ -394,23 +394,32 @@ class S3CheckpointSync(_Callback):
         super().__init__()
         self.checkpoint_s3 = checkpoint_s3
         self.checkpoint_dir = checkpoint_dir
-        self._last_synced = -1
+        self.checkpoint_every = max(1, checkpoint_every)
+        self._last_sync_step = 0       # global_step of the last upload (throttle)
+        self._last_synced_key = -1     # consumed_samples of the last uploaded ckpt (dedup)
 
-    def _sync(self):
+    def _sync(self, trainer):
         if not self.checkpoint_s3:
+            return
+        # Throttle by global_step (deterministic across ranks -> barrier-safe): at
+        # most one upload per checkpoint_every steps. NeMo bumps the `-last` ckpt's
+        # consumed_samples every step, so an un-throttled sync would upload ~40 GB
+        # every step at the real scale.
+        step = int(trainer.global_step)
+        if step - self._last_sync_step < self.checkpoint_every:
             return
         from pathlib import Path
         ck = Path(self.checkpoint_dir)
         if not ck.exists():
             return
-        subdirs = [d for d in ck.iterdir() if d.is_dir() and not d.name.startswith(".")]
-        subdirs = [d for d in subdirs if _step_of(d) >= 0]  # step-named (skip bare -last)
+        subdirs = [d for d in ck.iterdir() if d.is_dir() and not d.name.startswith(".") and _step_of(d) >= 0]
         if not subdirs:
             return
         latest = _pick_latest(subdirs)
-        step = _step_of(latest)
-        if step <= self._last_synced:
-            return  # already uploaded this checkpoint
+        key = _step_of(latest)
+        if key <= self._last_synced_key:
+            self._last_sync_step = step  # nothing newer; reset the throttle window
+            return
         try:
             _barrier()  # DCP save is synchronous+collective; all nodes have it now
             n = _upload_tree(str(latest), f"{self.checkpoint_s3}/{latest.name}")
@@ -421,15 +430,17 @@ class S3CheckpointSync(_Callback):
                         _delete_s3_subdir(f"{self.checkpoint_s3}/{name}")
                 _s3_write_text(f"{self.checkpoint_s3}/latest.txt", latest.name)
                 print(f"[exp112] checkpoint synced to S3: {latest.name} (node shards: {n} files)", flush=True)
-            self._last_synced = step
+            self._last_synced_key = key
+            self._last_sync_step = step
         except Exception as e:  # noqa: BLE001 — never kill training over a sync
             print(f"[exp112] S3 checkpoint sync error (non-fatal): {e}", flush=True)
 
     def on_train_batch_end(self, trainer, *a, **k):
-        self._sync()
+        self._sync(trainer)
 
     def on_train_end(self, trainer, *a, **k):
-        self._sync()  # catch the final checkpoint (no batch after it)
+        self._last_sync_step = 0  # force the final checkpoint through the throttle
+        self._sync(trainer)
 
 
 def main() -> None:

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/nemo_train_qwen3.py
@@ -52,14 +52,14 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--micro-batch-size", type=int, default=int(os.environ.get("EXP112_MICRO_BATCH", "1")))
     p.add_argument("--global-batch-size", type=int, default=int(os.environ.get("EXP112_GLOBAL_BATCH", "128")))
     p.add_argument("--seq-length", type=int, default=8192)
-    # Model geometry (defaults = exp112/exp108 Qwen3 ~2.9B)
-    p.add_argument("--num-layers", type=int, default=48)
+    # Model geometry (defaults = #75's 1.47B Qwen3: 2048h / 8192ffn / 32h·8kv / 24L)
+    p.add_argument("--num-layers", type=int, default=24)
     p.add_argument("--hidden-size", type=int, default=2048)
     p.add_argument("--ffn-hidden-size", type=int, default=8192)
     p.add_argument("--num-attention-heads", type=int, default=32)
     p.add_argument("--num-query-groups", type=int, default=8)
     p.add_argument("--kv-channels", type=int, default=64)
-    p.add_argument("--rotary-base", type=float, default=1_000_000.0)
+    p.add_argument("--rotary-base", type=float, default=500_000.0)  # #75 Llama3 rope theta
     p.add_argument("--no-grad-ckpt", action="store_true",
                    help="disable activation checkpointing (exp108 needed it ON to fit)")
     # Optim (only meaningful for a real run; harmless for the benchmark)

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/prepare_megatron_data.py
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/prepare_megatron_data.py
@@ -1,0 +1,162 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Convert the contacts-v1 parquet corpus → Megatron `.bin/.idx` for the exp112
+full NeMo training run (issue #112).
+
+Megatron's pretraining dataloader can't read parquet; it needs a mmap
+`IndexedDataset` (`.bin`+`.idx`). This one-off runs **on the workstation** (uses
+this env's boto3/pyarrow to reach the CoreWeave bucket via the external endpoint
+`https://cwobject.com`) and shells out to the **NeMo container** for the actual
+`preprocess_data.py` tokenization (which has Megatron + the HF tokenizer). Output
+is uploaded to `s3://…/exp112_qwen_3b_nemo_mfu/tokenized_megatron/`, from which the
+training pods download it (fast, in-cluster LOTA).
+
+Per split: stream parquet `document` column → one JSONL (download+extract+delete
+per shard to bound disk) → `preprocess_data.py --json-keys document --append-eod
+--tokenizer-type HuggingFaceTokenizer` → upload the `.bin/.idx`.
+
+Docs already carry a semantic `<end>` token; `--append-eod` appends the
+tokenizer's `<eos>` (id 1) as the *packing boundary* that Megatron's
+`reset_attention_mask`/`reset_position_ids` reset on (block cross-doc attention).
+
+Usage::
+
+    uv run python prepare_megatron_data.py --splits val train        # val first (tiny, fast sanity)
+    uv run python prepare_megatron_data.py --splits val --limit-shards 2   # quick e2e test
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import boto3
+import pyarrow.parquet as pq
+from botocore.config import Config
+
+BUCKET = "marin-us-east-02a"
+CORPUS_PREFIX = "MarinFold/data/document_structures/contacts_v1"
+OUT_PREFIX = "MarinFold/exp112_qwen_3b_nemo_mfu/tokenized_megatron"
+TOKENIZER = "timodonnell/contacts-v1-tokenizer"
+NEMO_IMAGE = os.environ.get("EXP112_IMAGE", "nvcr.io/nvidia/nemo:25.04.02")
+EXTERNAL_ENDPOINT = "https://cwobject.com"  # workstation → bucket (pods use http://cwlota.com)
+
+
+def s3_client():
+    return boto3.client(
+        "s3",
+        endpoint_url=EXTERNAL_ENDPOINT,
+        config=Config(s3={"addressing_style": "virtual"}, retries={"max_attempts": 10}),
+        aws_access_key_id=os.environ["CW_KEY_ID"],
+        aws_secret_access_key=os.environ["CW_KEY_SECRET"],
+    )
+
+
+def list_shards(s3, split: str) -> list[str]:
+    keys = []
+    for pg in s3.get_paginator("list_objects_v2").paginate(Bucket=BUCKET, Prefix=f"{CORPUS_PREFIX}/{split}/"):
+        keys += [o["Key"] for o in pg.get("Contents", []) if o["Key"].endswith(".parquet")]
+    return sorted(keys)
+
+
+def build_jsonl(s3, split: str, workdir: Path, limit: int | None) -> tuple[Path, int]:
+    """Stream shards → one JSONL (`{"document": ...}` per line). Download+delete
+    each shard to keep peak disk ~= JSONL + one shard."""
+    shards = list_shards(s3, split)
+    if limit:
+        shards = shards[:limit]
+    jsonl = workdir / f"{split}_document.jsonl"
+    tmp_shard = workdir / f"_{split}_shard.parquet"
+    ndocs = 0
+    with jsonl.open("w") as out:
+        for i, key in enumerate(shards):
+            s3.download_file(BUCKET, key, str(tmp_shard))
+            col = pq.read_table(tmp_shard, columns=["document"]).column("document")
+            for v in col:
+                out.write(json.dumps({"document": v.as_py()}) + "\n")
+                ndocs += 1
+            tmp_shard.unlink(missing_ok=True)
+            if (i + 1) % 100 == 0 or i + 1 == len(shards):
+                print(f"  [{split}] {i + 1}/{len(shards)} shards, {ndocs:,} docs", flush=True)
+    print(f"  [{split}] JSONL: {jsonl} ({ndocs:,} docs, {jsonl.stat().st_size / 1e9:.2f} GB)")
+    return jsonl, ndocs
+
+
+def run_preprocess(jsonl: Path, split: str, workdir: Path, workers: int) -> Path:
+    """Tokenize JSONL → bin/idx via preprocess_data.py inside the NeMo container.
+    Returns the produced path PREFIX (such that prefix+'.bin'/'.idx' exist)."""
+    out_prefix = f"{split}_document"
+    cmd = [
+        "docker", "run", "--rm", "--network", "host", "--shm-size=2g",
+        "-v", f"{workdir}:/work", "-w", "/work",
+        "-e", "HF_HUB_DISABLE_TELEMETRY=1",
+        NEMO_IMAGE,
+        "python", "/opt/megatron-lm/tools/preprocess_data.py",
+        "--input", f"/work/{jsonl.name}",
+        "--json-keys", "document",
+        "--append-eod",
+        "--tokenizer-type", "HuggingFaceTokenizer",
+        "--tokenizer-model", TOKENIZER,
+        "--workers", str(workers),
+        "--output-prefix", f"/work/{out_prefix}",
+    ]
+    print(f"  [{split}] preprocess_data ({workers} workers)…", flush=True)
+    subprocess.run(cmd, check=True)
+    bins = glob.glob(str(workdir / f"{out_prefix}*.bin"))
+    if len(bins) != 1:
+        raise RuntimeError(f"expected exactly one .bin for {split}, got {bins}")
+    prefix = bins[0][: -len(".bin")]
+    assert Path(prefix + ".idx").exists(), f"missing idx for {prefix}"
+    print(f"  [{split}] produced {prefix}.{{bin,idx}} "
+          f"({Path(prefix + '.bin').stat().st_size / 1e9:.2f} GB bin)")
+    return Path(prefix)
+
+
+def upload(s3, prefix: Path, split: str) -> str:
+    """Upload <prefix>.bin/.idx → S3 as {split}_document.{bin,idx}; return the
+    S3 path prefix the training data module points at (no extension)."""
+    dst_stem = f"{OUT_PREFIX}/{split}_document"
+    for ext in (".bin", ".idx"):
+        key = dst_stem + ext
+        print(f"  [{split}] upload → s3://{BUCKET}/{key} …", flush=True)
+        s3.upload_file(str(prefix) + ext, BUCKET, key)
+    return f"s3://{BUCKET}/{dst_stem}"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--splits", nargs="+", default=["val", "train"])
+    ap.add_argument("--workdir", default=os.environ.get("EXP112_DATAPREP_DIR", "/home/bizon/exp112_dataprep_work"))
+    ap.add_argument("--workers", type=int, default=16)
+    ap.add_argument("--limit-shards", type=int, default=None, help="for a quick e2e test")
+    ap.add_argument("--keep-jsonl", action="store_true")
+    args = ap.parse_args()
+
+    workdir = Path(args.workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+    s3 = s3_client()
+
+    results = {}
+    for split in args.splits:
+        print(f"=== split: {split} ===", flush=True)
+        jsonl, ndocs = build_jsonl(s3, split, workdir, args.limit_shards)
+        prefix = run_preprocess(jsonl, split, workdir, args.workers)
+        s3_prefix = upload(s3, prefix, split)
+        results[split] = {"docs": ndocs, "s3_prefix": s3_prefix}
+        if not args.keep_jsonl:
+            jsonl.unlink(missing_ok=True)
+
+    print("\n=== DONE ===")
+    print(json.dumps(results, indent=2))
+    print("\nTraining data paths (bootstrap downloads these, strips s3://…/tokenized_megatron/ → local):")
+    for split, r in results.items():
+        print(f"  {split}: {r['s3_prefix']}.{{bin,idx}}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/pyproject.toml
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "exp112-models-qwen-3b-nemo-mfu"
+version = "0.1.0"
+description = "3B Qwen3 contacts-v1 on CoreWeave H100 via NVIDIA NeMo, MFU comparison vs exp108's Levanter — issue #112."
+# >=3.12 to match the marin-iris/fray 0.2.x.dev line (dropped 3.11).
+requires-python = ">=3.12,<3.13"
+dependencies = [
+    # --- Launcher / dispatch side ONLY. --------------------------------------
+    # Unlike exp108 this env does NOT carry the training stack (no marin-core /
+    # levanter / torch / jax): NeMo lives inside the `nvcr.io/nvidia/nemo`
+    # container and is launched via a torchrun BINARY entrypoint. All we need on
+    # the workstation + the CPU driver pod is:
+    #   * marin-iris[controller] — the `iris` CLI + CloudK8sService to reach the
+    #     CoreWeave k8s controller (same as exp108; without [controller]:
+    #     "Install iris[controller] to use CloudK8sService").
+    #   * marin-fray — the JobRequest/Entrypoint/current_client submit API.
+    # Pin the FIXED 0.2.x.dev line (<0.3): the frozen `0.99.dev` marin-fray build
+    # has NO `JobRequest.priority` field, so batch-band dispatch would silently
+    # fall back to interactive (dispatch_nemo asserts against this at import).
+    "marin-iris[controller]>=0.2.5.dev202606020954,<0.3",
+    "marin-fray>=0.2.5.dev202606020954,<0.3",
+    # S3 (CoreWeave AI Object Storage) staging of code + reading the parquet
+    # corpus manifest from the workstation. boto3 for the S3 client; pyarrow to
+    # peek at the staged parquet; huggingface_hub only to resolve the tokenizer.
+    "boto3",
+    "s3fs",
+    "pyarrow",
+    "numpy",
+    "huggingface_hub",
+]
+
+[dependency-groups]
+dev = []
+
+[tool.uv]
+package = false
+fork-strategy = "fewest"
+prerelease = "allow"
+# Linux only — the workstation launcher and the CoreWeave controller/driver pods
+# are all Linux.
+environments = [
+    "sys_platform == 'linux'",
+]

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/summary_narrative.md
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/summary_narrative.md
@@ -1,0 +1,17 @@
+# Summary slides — exp: train a 3B qwen3 model on coreweave but use nvidia nemo framework for mfu comparison
+
+<!-- Feeds plots/summary.pdf via build_summary.py.
+     One `## ` heading per slide; body text becomes the slide.
+     Keep this current as the experiment progresses. -->
+
+## What we're doing
+
+_(Copy from the issue.)_
+
+## Why
+
+_(Copy from the issue.)_
+
+## Results so far
+
+_(Fill in as results come in.)_

--- a/experiments/exp112_models_qwen_3b_nemo_mfu/uv.lock
+++ b/experiments/exp112_models_qwen_3b_nemo_mfu/uv.lock
@@ -1,0 +1,1358 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+resolution-markers = [
+    "sys_platform == 'linux'",
+]
+supported-markers = [
+    "sys_platform == 'linux'",
+]
+
+[options]
+prerelease-mode = "allow"
+fork-strategy = "fewest"
+
+[[package]]
+name = "aiobotocore"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", marker = "sys_platform == 'linux'" },
+    { name = "aioitertools", marker = "sys_platform == 'linux'" },
+    { name = "botocore", marker = "sys_platform == 'linux'" },
+    { name = "jmespath", marker = "sys_platform == 'linux'" },
+    { name = "multidict", marker = "sys_platform == 'linux'" },
+    { name = "python-dateutil", marker = "sys_platform == 'linux'" },
+    { name = "wrapt", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/75/42cce839c2ec263ff74b10b650fe36b066fbb124cbee6f247eac0983e1ab/aiobotocore-3.7.0.tar.gz", hash = "sha256:c64d871ed5491a6571948dd48eabd185b46c6c23b64e3afd0c059fc7593ada30", size = 127054, upload-time = "2026-05-09T10:02:52.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/5f/85535dfb3cfd6442d66d1df1694062c5d6df02f895329e7e120b2a3d2b8b/aiobotocore-3.7.0-py3-none-any.whl", hash = "sha256:680bde7c64679a821a9312641b759d9497f790ba8b2e88c6959e6273ee765b8e", size = 89539, upload-time = "2026-05-09T10:02:50.389Z" },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/eec0465c2f67b2664688d0240b3212d5196fd89e741df67ddb81f8d35658/aiohappyeyeballs-2.7.1.tar.gz", hash = "sha256:065665c041c42a5938ed220bdcd7230f22527fbec085e1853d2402c8a3615d9d", size = 24757, upload-time = "2026-07-01T17:11:55.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl", hash = "sha256:9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472", size = 15038, upload-time = "2026-07-01T17:11:54.055Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs", marker = "sys_platform == 'linux'" },
+    { name = "aiosignal", marker = "sys_platform == 'linux'" },
+    { name = "attrs", marker = "sys_platform == 'linux'" },
+    { name = "frozenlist", marker = "sys_platform == 'linux'" },
+    { name = "multidict", marker = "sys_platform == 'linux'" },
+    { name = "propcache", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+    { name = "yarl", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/72/a60607cb849faa8af8a356c9329ea2eb6f395d49e82cc82ccba1fd8deb8f/aiohttp-3.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:64c567bf9eaf664280116a8688f63016e6b32db2505908e2bdaca1b6438142f2", size = 1766854, upload-time = "2026-06-07T21:06:45.391Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d3/d9fe1c9ec7557ab4d0d82bebaa728c6418f0b93295ec2f4ab015f7710cc7/aiohttp-3.14.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f5e6ff2bdbb8f4cd3fbe41f99e25bbcd58e3bf9f13d3dd31a11e7917251cc77a", size = 1740884, upload-time = "2026-06-07T21:06:47.413Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/dc/f2cecfaf9337ba3e63f181500814ff502aa3d00d9c7ec93a9d23d10a27b2/aiohttp-3.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f73e01dc37122325caf079982621262f96d74823c179038a82fddfc50359264", size = 1810034, upload-time = "2026-06-07T21:06:50.165Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d7/2ff65c5e65c0d7476daf7e15c032e0805e36811185b9623e3238ad6c763e/aiohttp-3.14.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb2c0c80d431c0d03f2c7dbf125150fedd4f0de17366a7ca33f7ccb822391842", size = 1904054, upload-time = "2026-06-07T21:06:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9c/d445818389df371f56d141d881153ba23183c4735a03f7356ffb43f7757d/aiohttp-3.14.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e6fc1a85fa7194a1a7d19f44e8609180f4a8eb5fa4c7ed8b4355f080fad235c", size = 1790278, upload-time = "2026-06-07T21:06:54.049Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/aa/bf04cb4d865fc6101c2229a294ad744973b72e513fdc5a6b791e6983d72a/aiohttp-3.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:686b6c0d3911ec387b444ddf5dc62fb7f7c0a7d5186a7861626496a5ab4aff95", size = 1591795, upload-time = "2026-06-07T21:06:55.911Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b4/4dac0038960427ba832f6609dfb4ea5437d7fd80c72001b9e48f834f428b/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c6fa4dc7ad6f8109c70bb1499e589f76b0b792baf39f9b017eb92c8a81d0a199", size = 1728397, upload-time = "2026-06-07T21:06:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/7cd4e8ad7aa3b75f17d56bb5498dd604a93d4e6eece822ba0568c413fff0/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:87a5eea1b2a5e21e1ebdbb33ad4165359189327e63fc4e4894693e7f821ac817", size = 1766504, upload-time = "2026-06-07T21:07:00.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/fc01d9fcad0f73fed3f3d361f1f94f975947b50dff82919f6dc2bf4316cc/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c1421eb01d4fd608d88cc8290211d177a58532b55ad94076fb349c5bf467f0a", size = 1777806, upload-time = "2026-06-07T21:07:02.064Z" },
+    { url = "https://files.pythonhosted.org/packages/41/09/47e2d090bddcc8fb4ccb4c314aadc32d7c5d9bb55f50f6ad1c92fc15d501/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:34b257ec41345c1e8f2df68fa908a7952f5de932723871eb633ecbbff396c9a4", size = 1580707, upload-time = "2026-06-07T21:07:03.942Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/36/f1a4ce904ae0b6930cfe9afc96d0896f7ec1a620c400405d63783bb95a9c/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:de538791a80e5d862addbc183f70f0158ac9b9bb872bb147f1fd2a683691e087", size = 1798121, upload-time = "2026-06-07T21:07:05.987Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/e0075ce9ca0279ee1d4f0c0b85f54fea02ebc83c3007651a72bece658fec/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f71173be42d3241d428f760122febb748de0623f44308a6f120d0dd9ec572e3", size = 1767580, upload-time = "2026-06-07T21:07:07.873Z" },
+]
+
+[[package]]
+name = "aioitertools"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore", marker = "sys_platform == 'linux'" },
+    { name = "jmespath", marker = "sys_platform == 'linux'" },
+    { name = "s3transfer", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/65/47670987f2f9e181397872c7ee6415b7b95156d711b7eab6c55f66e575bc/boto3-1.43.0.tar.gz", hash = "sha256:80d44a943ef90aba7958ab31d30c155c198acc8a9581b5846b3878b2c8951086", size = 113143, upload-time = "2026-04-29T22:07:49.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/a0/3e6a0b1c1ea6bec76f71473727ef27abf3cd40e9709b3ebcbfbcfaae6f79/boto3-1.43.0-py3-none-any.whl", hash = "sha256:8ebe03754a4b73a5cb6ec2f14cca03ac33bd4760d0adea53da4724845130258b", size = 140497, upload-time = "2026-04-29T22:07:46.216Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath", marker = "sys_platform == 'linux'" },
+    { name = "python-dateutil", marker = "sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/79/2f4be1896db3db7ccf44504253a175d56b6bd6b669619edc5147d1aa21ea/botocore-1.43.0.tar.gz", hash = "sha256:e933b31a2d644253e1d029d7d39e99ba41b87e29300534f189744cc438cdf928", size = 15286817, upload-time = "2026-04-29T22:07:31.723Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl", hash = "sha256:cc5b15eaec3c6eac05d8012cb5ef17ebe891beb88a16ca13c374bfaece1241e6", size = 14970102, upload-time = "2026-04-29T22:07:27Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "connect-python"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf", marker = "sys_platform == 'linux'" },
+    { name = "pyqwest", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/fc/0e4798c53e2754f5de36ecf4d198706cb23711d603df6c008f6e7b5b21ae/connect_python-0.9.0.tar.gz", hash = "sha256:a188ec843b0f5953b7e1b88061af50ad91c9aaa2e982d7a89a63ae5c1fff932e", size = 46094, upload-time = "2026-03-19T02:40:42.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/15/5b42df2d9d34e5103f2b69e4f6a4aeb47c52589eaac8d53eb5b0a40eabaa/connect_python-0.9.0-py3-none-any.whl", hash = "sha256:896171fa7236d4e1557e3f7eee76daa8c9dd762f2c21662515f2060f1b542574", size = 63381, upload-time = "2026-03-19T02:40:40.743Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
+]
+
+[[package]]
+name = "duckdb"
+version = "1.6.0.dev280"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c4/e9fa9ffc9acf9b25a543d43bc2b820720d24c7f08d1d285c91dd0e8d6cdd/duckdb-1.6.0.dev280.tar.gz", hash = "sha256:b3112023b9ef6adc30fd31654a420f08d0d3631cbecaa3feb6ae37ea29388493", size = 17557220, upload-time = "2026-07-05T07:18:33.729Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/23/be0ca34e09fbd0156eaa5943d1e67ec80d77bd37ad2b1f277794590e462f/duckdb-1.6.0.dev280-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbd95fcae3922fe3098000033fdf11fdbd942572e2895aa6e02c2c4207953131", size = 21480836, upload-time = "2026-07-05T07:17:31.75Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c1/ed753516cb16a5bf65b3d8470a47bd185f751d8aba57574aa114f96798cb/duckdb-1.6.0.dev280-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4cf16c24a3cdbbbfd78170c7991529676554e55e4c732b2b9add5f90a0e7fc02", size = 23746661, upload-time = "2026-07-05T07:17:35.616Z" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
+name = "exp112-models-qwen-3b-nemo-mfu"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "boto3", marker = "sys_platform == 'linux'" },
+    { name = "huggingface-hub", marker = "sys_platform == 'linux'" },
+    { name = "marin-fray", marker = "sys_platform == 'linux'" },
+    { name = "marin-iris", extra = ["controller"], marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "pyarrow", marker = "sys_platform == 'linux'" },
+    { name = "s3fs", marker = "sys_platform == 'linux'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3" },
+    { name = "huggingface-hub" },
+    { name = "marin-fray", specifier = ">=0.2.5.dev202606020954,<0.3" },
+    { name = "marin-iris", extras = ["controller"], specifier = ">=0.2.5.dev202606020954,<0.3" },
+    { name = "numpy" },
+    { name = "pyarrow" },
+    { name = "s3fs" },
+]
+
+[package.metadata.requires-dev]
+dev = []
+
+[[package]]
+name = "filelock"
+version = "3.29.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/c8/35bdf04fb30755e2ed758f877edf3eb4a243c2463d3a258cc28b18b7a6e2/filelock-3.29.6.tar.gz", hash = "sha256:895c532ef3f4ef04972b9446a8c4e2931a5c399ff3c4be4c9369f2639b80f793", size = 70301, upload-time = "2026-07-06T23:08:08.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/49/7467c2946ccd9617f7da38187071bdc45bb9a95df51f4d63d6622432ce4e/filelock-3.29.6-py3-none-any.whl", hash = "sha256:14d5f5597d2e0c4dbd774cfb6d8132da1db44da83732aab679d54f7dcf97ab65", size = 45478, upload-time = "2026-07-06T23:08:07.197Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "gcsfs"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", marker = "sys_platform == 'linux'" },
+    { name = "decorator", marker = "sys_platform == 'linux'" },
+    { name = "fsspec", marker = "sys_platform == 'linux'" },
+    { name = "google-auth", marker = "sys_platform == 'linux'" },
+    { name = "google-auth-oauthlib", marker = "sys_platform == 'linux'" },
+    { name = "google-cloud-storage", marker = "sys_platform == 'linux'" },
+    { name = "google-cloud-storage-control", marker = "sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/33/58e23c6f492e091c2f01ae1bffe331aa97e18a0b3d24ff90ef648335ddc8/gcsfs-2026.7.0.tar.gz", hash = "sha256:2df36ce1e9010e76dc4295774030495a97496838483c619e9f63bc0ab7bdc770", size = 1265874, upload-time = "2026-07-06T15:02:30.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/eb/a5c4b39903928e6be7735cc7aa31b6c3bbf3d887419e1e7ac751dba02233/gcsfs-2026.7.0-py3-none-any.whl", hash = "sha256:8ce6c08ea64302d8fd4bc23a615ccd9e7752541cde1a88ec8362109bd79cde78", size = 91131, upload-time = "2026-07-06T15:02:29.208Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth", marker = "sys_platform == 'linux'" },
+    { name = "googleapis-common-protos", marker = "sys_platform == 'linux'" },
+    { name = "proto-plus", marker = "sys_platform == 'linux'" },
+    { name = "protobuf", marker = "sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio", marker = "sys_platform == 'linux'" },
+    { name = "grpcio-status", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.55.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", marker = "sys_platform == 'linux'" },
+    { name = "pyasn1-modules", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/1d/f6d3ca1ad0725f2e08a1c6915640748a52de2e66596160a4d53b010cccf0/google_auth-2.55.1-py3-none-any.whl", hash = "sha256:eada68dfd52b3b81191827601e2a0c3fa12540c818534b630ddc5355769c3995", size = 252349, upload-time = "2026-06-25T23:38:52.946Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth", marker = "sys_platform == 'linux'" },
+    { name = "requests-oauthlib", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/18/90c7fac516e63cf2058166fce0c88c353647c677b51cc036c09c49bb5cbb/google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2", size = 21675, upload-time = "2026-05-07T08:03:47.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070", size = 19261, upload-time = "2026-05-07T08:02:13.798Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", marker = "sys_platform == 'linux'" },
+    { name = "google-auth", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-secret-manager"
+version = "2.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"], marker = "sys_platform == 'linux'" },
+    { name = "google-auth", marker = "sys_platform == 'linux'" },
+    { name = "grpc-google-iam-v1", marker = "sys_platform == 'linux'" },
+    { name = "grpcio", marker = "sys_platform == 'linux'" },
+    { name = "proto-plus", marker = "sys_platform == 'linux'" },
+    { name = "protobuf", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/7c/5c88cdde9664f6c75fb68aa11e0af4309a92bef38dd38df0456ffb0f469b/google_cloud_secret_manager-2.29.0.tar.gz", hash = "sha256:ee64133af8fdb3780affb65ec6ccf10ab15a0113d8edeba388665f4be87ce1be", size = 278437, upload-time = "2026-06-03T16:13:43.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/c2/fc3275bc42a522757cb5141d7dae51f048b93d2f5fe4574fcee5392cef03/google_cloud_secret_manager-2.29.0-py3-none-any.whl", hash = "sha256:21bac2d0adb0bb3c13c346d7223832f197c2266534528a1bf1402774e06395a3", size = 225042, upload-time = "2026-06-03T16:12:20.162Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", marker = "sys_platform == 'linux'" },
+    { name = "google-auth", marker = "sys_platform == 'linux'" },
+    { name = "google-cloud-core", marker = "sys_platform == 'linux'" },
+    { name = "google-crc32c", marker = "sys_platform == 'linux'" },
+    { name = "google-resumable-media", marker = "sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/72/86f94e1639a8bcd9d33e8e01b49afcaa1c3a13bda7683c681717e0901e15/google_cloud_storage-3.12.0.tar.gz", hash = "sha256:03ae9847c6babb368f35f054126b8a08cbc0e3266efb990eb17b9926a45cf3be", size = 17338620, upload-time = "2026-06-12T18:03:29.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bd/a89eaebd2f9db5f92ddcc8e4f23c266be1dbd11058bb83451d8dd029f34c/google_cloud_storage-3.12.0-py3-none-any.whl", hash = "sha256:3880773754ddf7c27567b04e2a4d193950b6b99429f37b9097d873686e95b09c", size = 340605, upload-time = "2026-06-12T18:03:12.677Z" },
+]
+
+[[package]]
+name = "google-cloud-storage-control"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"], marker = "sys_platform == 'linux'" },
+    { name = "google-auth", marker = "sys_platform == 'linux'" },
+    { name = "grpc-google-iam-v1", marker = "sys_platform == 'linux'" },
+    { name = "grpcio", marker = "sys_platform == 'linux'" },
+    { name = "proto-plus", marker = "sys_platform == 'linux'" },
+    { name = "protobuf", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/ae/707995271f77e3c1da715c740160f98f87a79a5c601b28d17c4d2500c037/google_cloud_storage_control-1.12.0.tar.gz", hash = "sha256:49090d03532c0c84c6246a5fd490c31fd4bbffb4c7771c0a6744ec23a194a5f6", size = 137036, upload-time = "2026-06-03T16:14:00.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/ba/f187f30fb2c8bb5dbb0de0fcb0dec2f8fab0b782ab42facc83ea02628f1b/google_cloud_storage_control-1.12.0-py3-none-any.whl", hash = "sha256:20f7f1252fa5635d47e12f746aa69d719e31eb9405cbbd14cdfba317db27d421", size = 102205, upload-time = "2026-06-03T16:12:43.266Z" },
+]
+
+[[package]]
+name = "google-cloud-tpu"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"], marker = "sys_platform == 'linux'" },
+    { name = "google-auth", marker = "sys_platform == 'linux'" },
+    { name = "grpcio", marker = "sys_platform == 'linux'" },
+    { name = "proto-plus", marker = "sys_platform == 'linux'" },
+    { name = "protobuf", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/4a/1cd9c4afa464df17dd1ba231e099ea7e5ddd7460af325f5954de87f0ab3f/google_cloud_tpu-1.27.0.tar.gz", hash = "sha256:9c7abbf299f4fa6d421cf094268b795ad6fb99ec02b31af152160469db383c4e", size = 252848, upload-time = "2026-06-22T23:22:38.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/1b/d8924e71aa85b03f00b8ded0ed002ee59b93559e215146775b4378a6a3a2/google_cloud_tpu-1.27.0-py3-none-any.whl", hash = "sha256:5940c9f6aa11ab23160225afdba8d7f7d9a057ce69caed2ab29997eab0b13324", size = 199673, upload-time = "2026-06-22T23:20:38.734Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", extra = ["grpc"], marker = "sys_platform == 'linux'" },
+    { name = "grpcio", marker = "sys_platform == 'linux'" },
+    { name = "protobuf", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/4f/d098419ad0bfc06c9ce440575f05aa22d8973b6c276e86ac7890093d3c37/grpc_google_iam_v1-0.14.4.tar.gz", hash = "sha256:392b3796947ed6334e61171d9ab06bf7eb357f554e5fc7556ad7aab6d0e17038", size = 23706, upload-time = "2026-04-01T01:57:49.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/22/c2dd50c09bf679bd38173656cd4402d2511e563b33bc88f90009cf50613c/grpc_google_iam_v1-0.14.4-py3-none-any.whl", hash = "sha256:412facc320fcbd94034b4df3d557662051d4d8adfa86e0ddb4dca70a3f739964", size = 32675, upload-time = "2026-04-01T01:57:47.69Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.82.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/19/e29d3979b420b92d516ee97f0bff4fb88cbb3d724791318f50beb55db549/grpcio-1.82.0.tar.gz", hash = "sha256:bfe3247e0bb598585ce26565730970d21bccf3c9dc547dc6703a1a3c7888e8e1", size = 13184479, upload-time = "2026-07-06T04:22:54.421Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/e6/9ce68bc431224177b6f506cfb4896a742119c51255143069970955b6510b/grpcio-1.82.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:03cce11532da292215cd8e5f444de91982e39dfb41a916e0e0f91a5c128588ea", size = 6144680, upload-time = "2026-07-06T04:21:29.808Z" },
+    { url = "https://files.pythonhosted.org/packages/38/05/9be6bf4cddb5b5f39c0748cdf5639525cd4116a157c8f3802c9217e54882/grpcio-1.82.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe56f1bea709ddb2531fbd510a2dd6040e993985507c3b2bf3404507aee989b1", size = 6710770, upload-time = "2026-07-06T04:21:35.382Z" },
+    { url = "https://files.pythonhosted.org/packages/00/97/62c0969e993673ebef16d526db2504f38bc4c73cf2593c28746791ab7956/grpcio-1.82.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:77a5d8fe331376c7aaa4e06e903a43bd144de4f98c6e414e13cbc5d64e5aa61e", size = 7450671, upload-time = "2026-07-06T04:21:37.923Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1f/d83d9fbaaef2b6ebbf70a6e467000f13f92b4cf0b84c561c162b43128439/grpcio-1.82.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9ce80ea66c803398fde9c5b1fd925920c9742da7f10f8b85acac0adac3e4d7e0", size = 6886855, upload-time = "2026-07-06T04:21:40.527Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/36/5ed2e28b8c5f00599c7d5e94d5f82c32cf73a6fa42d13c2900cb37c861ec/grpcio-1.82.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4665dc8c9ec30acff455e2b15c47b825f18647c555483aa1ccf670adead8adcc", size = 7501322, upload-time = "2026-07-06T04:21:43.78Z" },
+    { url = "https://files.pythonhosted.org/packages/89/4e/69113709e14e24289940d6aef067b797c73c8c96f580683af7d5f09b22b0/grpcio-1.82.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4405d19ecfc7a8caa9043ff5a651e1871b54fc620f917de5dede7e6fb78e9e14", size = 8536896, upload-time = "2026-07-06T04:21:46.387Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f6/08bd6eb89a558f0f59dacaef747afda7c21e2c2ecf138ae2ec533dea8aeb/grpcio-1.82.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:30e580c19178609799660f52b1e1eb09248969be20dc44caaa4dcaa3e8450dd9", size = 7913890, upload-time = "2026-07-06T04:21:49.733Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.82.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", marker = "sys_platform == 'linux'" },
+    { name = "grpcio", marker = "sys_platform == 'linux'" },
+    { name = "protobuf", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/c3/42148fdb28747b6c12df1351dece3fd574262fa14b180eca9821428626df/grpcio_status-1.82.0.tar.gz", hash = "sha256:ea0cbc12c52a902cb33ba56fb3233dcfad53ffead08f4a659b1752d473a6a0ac", size = 13902, upload-time = "2026-07-06T04:26:47.864Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/f3/fe7e1f57f170ed6cae20eecc0dea62e9de862e68adede80a6cd54a9b4dfa/grpcio_status-1.82.0-py3-none-any.whl", hash = "sha256:d41e45164ae2c265b268aebd9d86defa292a1ba91d86a548bad1f059c4645676", size = 14634, upload-time = "2026-07-06T04:26:38.672Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi", marker = "sys_platform == 'linux'" },
+    { name = "h11", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2", size = 523851, upload-time = "2026-05-25T22:17:10.106Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09", size = 518842, upload-time = "2026-05-25T22:17:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0c9ac76dd2c893841fbf6498d6acec4f2442e1b7067f6e3e316a80e494e8/httptools-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7c3c97f4311c7be57e2986629df89d49cb434dbff78eafcd48c2bff986b15a", size = 501238, upload-time = "2026-05-25T22:17:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745", size = 509567, upload-time = "2026-05-25T22:17:13.842Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform == 'linux'" },
+    { name = "certifi", marker = "sys_platform == 'linux'" },
+    { name = "httpcore", marker = "sys_platform == 'linux'" },
+    { name = "idna", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform == 'linux'" },
+    { name = "filelock", marker = "sys_platform == 'linux'" },
+    { name = "fsspec", marker = "sys_platform == 'linux'" },
+    { name = "hf-xet", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'amd64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "sys_platform == 'linux'" },
+    { name = "packaging", marker = "sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+    { name = "tqdm", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/ea/dc54b4dda5841cb3a7812a178695be776e7c15c597887c2ed892f17d015a/huggingface_hub-1.22.0.tar.gz", hash = "sha256:e2dfe5fe1ec3b87ba2709aa34555b23e3f3f6ad4d7255238e13ddb8348e6bbfa", size = 914232, upload-time = "2026-07-03T09:46:44.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/9c/a1a377265abd8b823a2c661c665028ccb6b9fba1ca9d08e52ff679c20ecd/huggingface_hub-1.22.0-py3-none-any.whl", hash = "sha256:b09e19309ae09ee0a71892701c4fe70af39ab4e00817321dc62f2289a977249b", size = 765085, upload-time = "2026-07-03T09:46:42.832Z" },
+]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "kubernetes"
+version = "35.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi", marker = "sys_platform == 'linux'" },
+    { name = "durationpy", marker = "sys_platform == 'linux'" },
+    { name = "python-dateutil", marker = "sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'linux'" },
+    { name = "requests-oauthlib", marker = "sys_platform == 'linux'" },
+    { name = "six", marker = "sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'linux'" },
+    { name = "websocket-client", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
+]
+
+[[package]]
+name = "marin-finelog"
+version = "0.2.12.dev202607070936"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform == 'linux'" },
+    { name = "connect-python", marker = "sys_platform == 'linux'" },
+    { name = "duckdb", marker = "sys_platform == 'linux'" },
+    { name = "fsspec", marker = "sys_platform == 'linux'" },
+    { name = "gcsfs", marker = "sys_platform == 'linux'" },
+    { name = "marin-rigging", marker = "sys_platform == 'linux'" },
+    { name = "protobuf", marker = "sys_platform == 'linux'" },
+    { name = "pyarrow", marker = "sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+    { name = "zstandard", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/c4/18aebef02604adc967ea148837ff2d25a3c1960abe6c8555ce31932c3181/marin_finelog-0.2.12.dev202607070936.tar.gz", hash = "sha256:db4d7726e5e1c3c990795137351ff1f98ac9795caadcb3ef5e9b794a3d2d27ad", size = 67407, upload-time = "2026-07-07T10:05:27.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/4c/db6c3ed61fd06628fc88309211c28047779c69f5be95d7def3a69c3ccf44/marin_finelog-0.2.12.dev202607070936-py3-none-any.whl", hash = "sha256:250ad33aef5f17235191f52498a3f3faf701cb2273bceffed73e42b4bfc4e8a1", size = 68033, upload-time = "2026-07-07T10:05:14.398Z" },
+]
+
+[[package]]
+name = "marin-finelog-server"
+version = "0.2.12.dev202607070936"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/27/bc0c8d9b87f710c7114c218d92920598cb30a314db5d6917d6f6ca10d6bb/marin_finelog_server-0.2.12.dev202607070936.tar.gz", hash = "sha256:6018b43e6437c0ef3a188004e16924b0cbd9f952b8fd426af86b16c108b87708", size = 223388, upload-time = "2026-07-07T10:05:28.883Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/3a/5ad37038b0560617294868ce253116022fe790ab29c6857c09fcd70565f8/marin_finelog_server-0.2.12.dev202607070936-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c059bc6ebcea122281d76cb7afbd6881ad4fa1556ea4ac9c03f75a02f7302895", size = 41222043, upload-time = "2026-07-07T10:05:22.374Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0d/8583cc3f35e73ad7d9b5cad23791f7216fca404563a2a90a6ba24a540b10/marin_finelog_server-0.2.12.dev202607070936-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:d961018ba31dce7973c26680afa9c0801baadd817fc336863b5cddbc0e853ee9", size = 43789687, upload-time = "2026-07-07T10:05:25.274Z" },
+]
+
+[[package]]
+name = "marin-fray"
+version = "0.2.39.dev202607070858"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle", marker = "sys_platform == 'linux'" },
+    { name = "marin-iris", marker = "sys_platform == 'linux'" },
+    { name = "marin-rigging", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/2c/e6d5f3784484bca5fd0a73fc09973f64f2d08facadb57e199a5218b36119/marin_fray-0.2.39.dev202607070858.tar.gz", hash = "sha256:48dba0d3ff678ad057364660173222e9223754633c70ba900537efd5e1eb9e5f", size = 31270, upload-time = "2026-07-07T08:59:59.637Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/b1/bb89ee85410f0106fc39f3930bdb12f196a3c1c017c54fd8c0bd12a0673d/marin_fray-0.2.39.dev202607070858-py3-none-any.whl", hash = "sha256:1413a0b8f7845a2e133ba81c49aaff34a3762f27d6ff284cd406d9eb17798bf8", size = 28239, upload-time = "2026-07-07T08:59:47.772Z" },
+]
+
+[[package]]
+name = "marin-iris"
+version = "0.2.39.dev202607070858"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform == 'linux'" },
+    { name = "cloudpickle", marker = "sys_platform == 'linux'" },
+    { name = "connect-python", marker = "sys_platform == 'linux'" },
+    { name = "fsspec", marker = "sys_platform == 'linux'" },
+    { name = "gcsfs", marker = "sys_platform == 'linux'" },
+    { name = "google-auth", marker = "sys_platform == 'linux'" },
+    { name = "google-cloud-tpu", marker = "sys_platform == 'linux'" },
+    { name = "grpcio", marker = "sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'linux'" },
+    { name = "humanfriendly", marker = "sys_platform == 'linux'" },
+    { name = "marin-finelog", marker = "sys_platform == 'linux'" },
+    { name = "marin-finelog-server", marker = "sys_platform == 'linux'" },
+    { name = "marin-rigging", marker = "sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'linux'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+    { name = "s3fs", marker = "sys_platform == 'linux'" },
+    { name = "sqlalchemy", marker = "sys_platform == 'linux'" },
+    { name = "starlette", marker = "sys_platform == 'linux'" },
+    { name = "tabulate", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+    { name = "uvicorn", extra = ["standard"], marker = "sys_platform == 'linux'" },
+    { name = "zstandard", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/6ede2cfb4eee0c5e8f4040ca362672720379b4d25df61815781710d6bd7e/marin_iris-0.2.39.dev202607070858.tar.gz", hash = "sha256:54fc3845474398cadb162dfd93eeaaaa8f00dae908816e54240c4805ab7acfcf", size = 782558, upload-time = "2026-07-07T09:00:02.431Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/7b/e8f7b8ddfc6618fddef473751186dda5834e4cfc50d25b83e4fdeadec1a5/marin_iris-0.2.39.dev202607070858-py3-none-any.whl", hash = "sha256:df92ee1dd1d1615c13154bdf40f1475624ecd6fecc3a815cf1bc6905f7b2c3ec", size = 934791, upload-time = "2026-07-07T08:59:51.976Z" },
+]
+
+[package.optional-dependencies]
+controller = [
+    { name = "kubernetes", marker = "sys_platform == 'linux'" },
+    { name = "marin-rigging", extra = ["secrets"], marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "marin-rigging"
+version = "0.2.39.dev202607070858"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform == 'linux'" },
+    { name = "connect-python", marker = "sys_platform == 'linux'" },
+    { name = "fsspec", marker = "sys_platform == 'linux'" },
+    { name = "gcsfs", marker = "sys_platform == 'linux'" },
+    { name = "google-auth", marker = "sys_platform == 'linux'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'linux'" },
+    { name = "s3fs", marker = "sys_platform == 'linux'" },
+    { name = "starlette", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/dd/972d2a6c4d219a8b8e9169c990afc32e777a64a6e48bde30254c2b00e65a/marin_rigging-0.2.39.dev202607070858.tar.gz", hash = "sha256:ca95a1fb87471bbf66cae7594ed17662525692246781728df1d4959a95e3f3d3", size = 112364, upload-time = "2026-07-07T09:00:05.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/27/d2d9b3485a618fa70d4b98d3f899c9db796d88c4cc9f1677fe6d58324391/marin_rigging-0.2.39.dev202607070858-py3-none-any.whl", hash = "sha256:b821052ddf657011923ac4c182e776c9e312fc095014443b02493797175e3a44", size = 88648, upload-time = "2026-07-07T08:59:55.355Z" },
+]
+
+[package.optional-dependencies]
+secrets = [
+    { name = "google-cloud-secret-manager", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/c7/085d0cd63062e84044e3f05797749c3f8e3938ff3aeb0eb2f69d43fafc91/propcache-0.5.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbc581d2814337da56222fab8dc5f161cd798a434e49bac27930aaef798e144", size = 59995, upload-time = "2026-05-08T21:00:15.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/42/32cf8e3009e92b2645cf1e944f701e8ea4e924dffde1ee26db860bcbf7e4/propcache-0.5.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:857187f381f88c8e2fa2fe56ab94879d011b883d5a2ee5a1b60a8cd2a06846d9", size = 63422, upload-time = "2026-05-08T21:00:16.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/f112433f99fc979431b87a39ef169e3f8df070d99a72792c56d6937ac48b/propcache-0.5.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:178b4a2cdaac1818e2bf1c5a99b94383fa73ea5382e032a48dec07dc5668dc42", size = 64342, upload-time = "2026-05-08T21:00:18.362Z" },
+    { url = "https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f328175a2cde1f0ff2c4ed8ce968b9dcfb55f3a7153f39e2957ed994da13476", size = 61639, upload-time = "2026-05-08T21:00:19.692Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/da/4d775080b1490c0ae604acda868bd71aabe3a89ed16f2aa4339eb8a283e7/propcache-0.5.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5671d09a36b06d0fd4a3da0fccbcae360e9b1570924171a15e9e0997f0249fba", size = 61588, upload-time = "2026-05-08T21:00:21.155Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ac/f076982cbe2195ee9cf32de5a1e46951d9fb399fc207f390562dd0fd8fb2/propcache-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a", size = 60029, upload-time = "2026-05-08T21:00:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/189be62e0dd898dce3b331e1b8c7a543cd3a405ac0c81fe8ee8a9d5d77e1/propcache-0.5.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:45f11346f884bc47444f6e6647131055844134c3175b629f84952e2b5cd62b64", size = 56774, upload-time = "2026-05-08T21:00:24.001Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/9e/93377b9c7939c1ffae98f878dee955efadfd638078bc86dbc21f9d52f651/propcache-0.5.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e778ebd44ef4f66ed60a0416b06b489687db264a9c0b3620362f26489492913", size = 63532, upload-time = "2026-05-08T21:00:25.545Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f9/590ef6cfb9b8028d516d287812ece32bb0bc5f11fbb9c8bf6b2e6313fec8/propcache-0.5.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c0cb9ed24c8964e172768d455a38254c2dd8a552905729ce006cad3d3dda59b1", size = 61592, upload-time = "2026-05-08T21:00:27.186Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5e/70958b3034c297a630bba2f17ca7abc2d5f39a803ad7e370ab79d1ecd022/propcache-0.5.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1d1ad32d9d4355e2be65574fd0bfd3677e7066b009cd5b9b2dee8aa6a6393b33", size = 64788, upload-time = "2026-05-08T21:00:28.8Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fd/77fe5936d8c3086ca9048f7f415f122ed82e53884a9ec193646b42deef06/propcache-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a", size = 62514, upload-time = "2026-05-08T21:00:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.14.0a1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types", marker = "sys_platform == 'linux'" },
+    { name = "pydantic-core", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+    { name = "typing-inspection", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/71/0ae6d4e0a84faf0cd050033416509c44a19dc6dbec5bfdd3e1318cb1feb4/pydantic-2.14.0a1.tar.gz", hash = "sha256:2c3a5627d48f59725564c41b582328a29fa8d9b1108128ef6710463a0136d4fd", size = 844232, upload-time = "2026-05-22T13:23:43.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4e/15d81754895da3f256273432da60fcb7c885177fefaf495c5b4364fadca5/pydantic-2.14.0a1-py3-none-any.whl", hash = "sha256:61a1ea8d65df95b681c1fab9cd7d01b2472837f798df53dc6d0f41f0c217b061", size = 470439, upload-time = "2026-05-22T13:23:40.57Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/74/319859f70c733f341df03823c8ca27ce9003faaac3ffa3110f3af1c8641a/pydantic_core-2.47.0.tar.gz", hash = "sha256:422c1797a7864b2a9a996435aba92fe571fb80190f67a31edbc1ac040c7b51fe", size = 476601, upload-time = "2026-05-22T13:19:00.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/a6/2417d8b1856cf7579a21e2679f02417b910e4f29120303e2c45137525072/pydantic_core-2.47.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:faf83e50714837af72f13e9369c50377552a4a74049d4477bed51c7e5822d94b", size = 1975590, upload-time = "2026-05-22T13:17:26.586Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/71/0cd0813355b385bef8fa9a719982e0b44847afedc043b988c9f7c5d02ca9/pydantic_core-2.47.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f50abe60347bf8afe2b2f58db86cf3ac6e418eec7ffa01d9dc90ba29fc64f243", size = 2055885, upload-time = "2026-05-22T13:20:42.378Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/33/5687c6dcf8ecca106c95b2a49f04a633320ab49961da6e57682db37b4482/pydantic_core-2.47.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f13b18e7dec056336f29ee77dea3cc5db0271d6215cac7249cc5c61b0a49d293", size = 2235292, upload-time = "2026-05-22T13:19:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/36/98/08e81f1a0f0aa82cfa1a4d07b66eb116740fd6c82ba4baa8f96d4b377132/pydantic_core-2.47.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3aaabbdbbbb8dff33fa053ffb2c980f39dec745fc03592f50e1e010449129841", size = 2308945, upload-time = "2026-05-22T13:18:38.113Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f1/6e35bdbdb79f96e630265297452d709b2ebd5facfbd83d3eb702eee24939/pydantic_core-2.47.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d2907ee6d15cf26787bfbeb4c42e18e52f358086eab91baea961a0d909248d6", size = 2093861, upload-time = "2026-05-22T13:20:26.271Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/c4/6a48e5da6a567bcf6d3ab113d2d476e1b93e3be941b4c486918f1c9d6714/pydantic_core-2.47.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:c413761260967f4dbb51135e1b49f30a1c29e15bf371fbb39754ed6475739545", size = 2124948, upload-time = "2026-05-22T13:18:15.728Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a1/e356c98dfc6bd5e6e166f2c832865a62941370b17a7199d35bc5999fecc8/pydantic_core-2.47.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2bb527ac6e5a9721023b24615e1a55c01f47c60007f08b7d2afb89ff9c7a0e22", size = 2182065, upload-time = "2026-05-22T13:19:07.986Z" },
+    { url = "https://files.pythonhosted.org/packages/63/aa/6e99aac0a891b05cc522cc464aebeec2bb877fa4744be641a013ebc1785a/pydantic_core-2.47.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b3abf7fd5e6abe483a63413f9cd26b7c93c20780e19c8556434c7279f6b2f10c", size = 2185830, upload-time = "2026-05-22T13:18:34.551Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/c6c5c1ad40b4d58f11d6e754e9c3990a2a3cfff20a9cf5c1f0a855a791b2/pydantic_core-2.47.0-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:9cefe43d17a5a273d71697c084d3787defa7f578cd5fab4cef4c66d13c9e44b2", size = 2327330, upload-time = "2026-05-22T13:19:48.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f8/064747538297e385a1f197f35551d1bf6093e88c5ce9b4e15c035f0a1cfe/pydantic_core-2.47.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:38a8b5371b7938e4f6c31060dbd51d3b3229aef7c43eaac2eb8b153e43c3f189", size = 2366505, upload-time = "2026-05-22T13:20:11.895Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/65/ce0d773f4b51dc332764ba1bd585c81f62d5c92231a66d152aff16be8dfa/pydantic_core-2.47.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf3cfcea028f41a9b42a47f4a53d72ca4274d04e3ee525bd58ca89ea8c5e1910", size = 1995356, upload-time = "2026-05-22T13:19:44.143Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2c/6e63683a77d342c93bad67bb0762ca8fe1d8418acc8617d70ccdcc5ec5ff/pydantic_core-2.47.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52afdd8640d59890539060e91c8a494cf96b463e63b2ba499cc5c23abcb5e96b", size = 2144893, upload-time = "2026-05-22T13:17:59.008Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "pyqwest"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/52/90938b0620768dd97a0d82929afc62870037d904e608cac4e5ef6278e4d3/pyqwest-0.6.2.tar.gz", hash = "sha256:17c41121b9dc400133aae282ce8b00bc8d59e75e095b18ca1d9fb5bd1a3ee33a", size = 452447, upload-time = "2026-06-15T07:53:02.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/11/5295652f43a998dda9bf572c7489ddcdd99e0c9f5ddbd1039d73446d4cb2/pyqwest-0.6.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:31885a69499a23f85ed6970c7e8b227f284ea8427ec695026aa69d4ad17ca94a", size = 5497128, upload-time = "2026-06-15T07:51:54.307Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/52/c3e35be12fd5503376a64ec91711e1ed0d614a09a119b2d938d01d6a7973/pyqwest-0.6.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bccae7bc1fa195d81d439dfdcba6d213b4c234ab645c902b9da209001facb70d", size = 5528596, upload-time = "2026-06-15T07:51:56.423Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ac/32e05ac720cbc64014295b01f82229c012379393701ebb73c5a0274086d6/pyqwest-0.6.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:674841db9d441aa6ab693f52f73df62baa21648888ebf9a8d576dc9f61e4d904", size = 5663292, upload-time = "2026-06-15T07:51:58.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8d/57d760ac9fbf826f6576d66ee53f2419dabd97437148f6ed0f9eb3c38177/pyqwest-0.6.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c72e470599e37db8e5b9d58f1d944d9d2f3e60280a62dba0453019f3c856b34d", size = 5842408, upload-time = "2026-06-15T07:52:00.484Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/7b/078011e618214e2d980669eb1ca3ba1c69b30fabcb2102915a92b6e4c777/pyqwest-0.6.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34e423746911a21945f069ef5900a38a17eebd2f07f3c3071870e44034a85402", size = 5490823, upload-time = "2026-06-15T07:52:06.075Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1a/f80f5417b4b4d1057dc46edff23c753171ba095743ec510ca130b4c0e197/pyqwest-0.6.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:526f5f2724ec7148fd0d7bdc53a25fcc961c8288fb271ace12af5db7e77d1644", size = 5520681, upload-time = "2026-06-15T07:52:07.963Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e4/3fb6a3cb5e75855e11c70133fda27fb0f71d816d17c6847b4cff5334636b/pyqwest-0.6.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f47bffb117d42ce835c8f1a84d2b2e92e698907e1fbe796a17c038a8e72ea225", size = 5657487, upload-time = "2026-06-15T07:52:09.875Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/0c/cbc68a6dbdf06d479afb07edcc33a201f55030817edbe05d16db34635e1a/pyqwest-0.6.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3628ad3d5a851b69b64b2c510bb8f233be829eb0c653fbe2b14dd6edbca2aeab", size = 5833432, upload-time = "2026-06-15T07:52:11.681Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi", marker = "sys_platform == 'linux'" },
+    { name = "charset-normalizer", marker = "sys_platform == 'linux'" },
+    { name = "idna", marker = "sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib", marker = "sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "s3fs"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiobotocore", marker = "sys_platform == 'linux'" },
+    { name = "aiohttp", marker = "sys_platform == 'linux'" },
+    { name = "fsspec", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/00/6677343dc919d6c072bb04d80210afdd22c16838a8d16b3315c122dc728f/s3fs-2026.6.0.tar.gz", hash = "sha256:b28de7082d0a4f72392884bdc497e34a4a1582f675d214c7da0acf6e950a0083", size = 87358, upload-time = "2026-06-16T02:05:48.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/0b/f68a968b49876eae0f2a515387093cebb2eb9451380a96741cc20efac0d0/s3fs-2026.6.0-py3-none-any.whl", hash = "sha256:60576e31bb31193c1f643f32b4c6439548720ea6918ac702e21cd757c80b5db8", size = 32573, upload-time = "2026-06-16T02:05:47.608Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/b3/bcdc2f58fa92592db511beda154c2c08d28f21f6c4637f06a42a24b10c21/s3transfer-0.17.1.tar.gz", hash = "sha256:042dd5e3b1b512355e35a23f0223e426b7042e80b97830ea2680ddce327fc45e", size = 159439, upload-time = "2026-05-26T19:45:01.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/dd/904873250a6554fbae40cddbf9198e3cc37a2f1319d5e1a5ce82fe269c17/s3transfer-0.17.1-py3-none-any.whl", hash = "sha256:5b9827d1044159bbb01b86ef8902760ea39281927f5de31de75e1d657177bf4c", size = 88264, upload-time = "2026-05-26T19:45:00.452Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.1.0b3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b4/3eae7859c5a749016162e0d1ff09810e1221b731f2d28d422b9f2324d9df/sqlalchemy-2.1.0b3.tar.gz", hash = "sha256:68e9cd28deb1ea91c57c63bc16410f654e0c6c06942b3447d4af9f9feb633da5", size = 10284525, upload-time = "2026-06-27T18:52:29.689Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/80/24d235b758c147a314ae4ebae04cd27ea32dc12770669073c99403678d2e/sqlalchemy-2.1.0b3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4f78fccc17b46639bf583e299b0250de67098be33d101081c4dc6bd42c299188", size = 4120752, upload-time = "2026-06-27T20:45:50.643Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5e/b1c638437eb137b0db225a5c6713384a78284e2a34997ee4fd027233ef39/sqlalchemy-2.1.0b3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14c037cb95d6661fedd0da539dcf34e9a9cf52f6760de8d5081a2b944eb7957a", size = 4161755, upload-time = "2026-06-27T20:50:11.484Z" },
+    { url = "https://files.pythonhosted.org/packages/79/a7/0edd0080d0145bbce8bf69e276674d67c7972846c13a8f0c4514001e6782/sqlalchemy-2.1.0b3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d4f4691071684eeab915d854abba174d4569508d23f9780b42cba81d9b1a6fba", size = 3877495, upload-time = "2026-06-28T02:09:26.734Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8a/a7aeb2775038fe8fc1e979a7fd1da438225f437a1f8da3f7fe56746ecf17/sqlalchemy-2.1.0b3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4d17b5c21c24a5b7b6609e007bb2a8df1c144264be488dfe1ab1fb144c608897", size = 4057927, upload-time = "2026-06-27T20:45:52.477Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9e/f4a0a015c0a7e9683231f0c83e11e2efc934390238e78f5dbe9be3532d00/sqlalchemy-2.1.0b3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d250f9713c0af7dfe7f68fa802a3eb106b05da4e3c6a08d2b31dd49e2a76e5f2", size = 3873820, upload-time = "2026-06-28T02:09:29.187Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/ddbb94ebdb008708a3dcc46dcb4a7bc54e88a259327862e617cc266fee1c/sqlalchemy-2.1.0b3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f4c1419fd1ec33d26caad80c70fe2c17e84a0702a41226c0b77ea089ee38e925", size = 4122263, upload-time = "2026-06-27T20:50:13.477Z" },
+    { url = "https://files.pythonhosted.org/packages/02/21/341897a151b5d17d069b855cdda4da5d616e12a9456a80909cd775c74d11/sqlalchemy-2.1.0b3-py3-none-any.whl", hash = "sha256:53266e619324e252dd517d2b061316cf01e4376857d8e5b65fd74dc92fd0c326", size = 1995669, upload-time = "2026-06-27T19:35:57.589Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/57ff8b434839e70dab45601284ea413e947a63799891b7553e5960a793a8/tqdm-4.68.4.tar.gz", hash = "sha256:19829c9673638f2a0b8617da4cdcb927e831cd88bcfcb6e78d42a4d1af131520", size = 792418, upload-time = "2026-07-07T09:58:18.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/2a/5e5e750890ada51017d18d0d4c30da696e5b5bd3180947729927628fc3cb/tqdm-4.68.4-py3-none-any.whl", hash = "sha256:5168118b2368f48c561afda8020fd79195b1bdb0bdf8086b88442c267a315dc2", size = 676612, upload-time = "2026-07-07T09:58:16.256Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.50.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform == 'linux'" },
+    { name = "h11", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/f6/cc9aadc0e481344a42095d222bfa764122fb8cfba708d1922917bd8bfb01/uvicorn-0.50.2.tar.gz", hash = "sha256:b92bf03509b82bcb9d49e7335b4fd364518ad021c2dc18b4e6a2fec8c955a0bb", size = 93716, upload-time = "2026-07-06T10:38:31.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/f0/7c228ee10c7ab8fd3a21d06579a6f7c6075c6ce72594a20fb5d2f206ff24/uvicorn-0.50.2-py3-none-any.whl", hash = "sha256:4ae72a385630bcc17a0adb8290f26c993865e0b43a2114c2aab96420172c056a", size = 72846, upload-time = "2026-07-06T10:38:30.543Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "httptools", marker = "sys_platform == 'linux'" },
+    { name = "python-dotenv", marker = "sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'linux'" },
+    { name = "watchfiles", marker = "sys_platform == 'linux'" },
+    { name = "websockets", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna", marker = "sys_platform == 'linux'" },
+    { name = "multidict", marker = "sys_platform == 'linux'" },
+    { name = "propcache", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/a5/c9f655d5553ea0b99fdac9d6a99ad3f9b3e73b8e5758bb46f58c9831f74c/yarl-1.24.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:507cc19f0b45454e2d6dcd62ff7d062b9f77a2812404e62dbdaec05b50faa035", size = 102902, upload-time = "2026-05-19T21:28:56.963Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/bc/6b9664d815d79af4ee553337f9d606c56bbf269186ada9172de45f1b5f60/yarl-1.24.2-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c4c17bad5a530912d2111825d3f05e89bab2dd376aaa8cbc77e449e6db63e576", size = 97931, upload-time = "2026-05-19T21:28:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ec/32ba48acae30fecd60928f5791188b80a9d6ee3840507ffda29fecd37b71/yarl-1.24.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f5f0cbb112838a4a293985b6ed73948a547dadcc1ba6d2089938e7abdedceef8", size = 111030, upload-time = "2026-05-19T21:29:00.148Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5a/6f4cd081e5f4934d2ae3a8ef4abe3afacc010d26f0035ee91b35cd7d7c37/yarl-1.24.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ec8356b8a6afcf81fc7aeeef13b1ff7a49dec00f313394bbb9e83830d32ccd7", size = 110392, upload-time = "2026-05-19T21:29:02.155Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/da/323a01c349bd5fb01bb6652e314d9bb218cee630a736bdb810ad50e4013f/yarl-1.24.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e7ebcdef69dec6c6451e616f32b622a6d4a2e92b445c992f7c8e5274a6bbc4c", size = 105612, upload-time = "2026-05-19T21:29:04.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/80/264ab684f181e1a876389374519ff05d10248725535ae2ac4e8ac4e563d6/yarl-1.24.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:47a55d6cf6db2f401017a9e96e5288844e5051911fb4e0c8311a3980f5e59a7d", size = 104487, upload-time = "2026-05-19T21:29:06.491Z" },
+    { url = "https://files.pythonhosted.org/packages/41/07/efabe5df87e96d7ad5959760b888344be48cd6884db127b407c6b5503adc/yarl-1.24.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3065657c80a2321225e804048597ad55658a7e76b32d6f5ee4074d04c50401db", size = 102333, upload-time = "2026-05-19T21:29:08.267Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0c/bcf7c42603e1009295f586d8890f2ba032c8b53310e815adf0a202c73d9f/yarl-1.24.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:cb84b80d88e19ede158619b80813968713d8d008b0e2497a576e6a0557d50712", size = 99025, upload-time = "2026-05-19T21:29:10.682Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/82/84482ab1a57a0f21a08afe6a7004c61d741f8f2ecc3b05c321577c612164/yarl-1.24.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:990de4f680b1c217e77ff0d6aa0029f9eb79889c11fb3e9a3942c7eba29c1996", size = 110507, upload-time = "2026-05-19T21:29:12.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8d/a546ba1dfe1b0f290e05fef145cd07614c0f15df1a707195e512d1e39d1d/yarl-1.24.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:abb8ec0323b80161e3802da3150ef660b41d0e9be2048b76a363d93eee992c2b", size = 103719, upload-time = "2026-05-19T21:29:14.893Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b6/267f2a09213138473adfce6b8a6e17791d7fee70bd4d9003218e4dec58b0/yarl-1.24.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e7977781f83638a4c73e0f88425563d70173e0dfd90ac006a45c65036293ee3c", size = 110438, upload-time = "2026-05-19T21:29:16.485Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2d/1c8d89c7c5f9cad9fb2902445d94e2ab1d7aa35de029afbb8ae95c42d00f/yarl-1.24.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e30dd55825dc554ec5b66a94953b8eda8745926514c5089dfcacecb9c99b5bd1", size = 105719, upload-time = "2026-05-19T21:29:18.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+]


### PR DESCRIPTION
Answers **issue #112**: same 3B Qwen3 contacts-v1 model as exp108, but on **NVIDIA NeMo / Megatron-Core** instead of JAX/Levanter, to see whether we beat exp108's poor **~15% MFU**.

## Result — yes, ~1.75×

Single **8×H100**, batch **128 × seq 8192**, bf16, grad-ckpt on, mock data (MFU is compute-bound → mock is faithful; it's how NVIDIA publishes its perf tables). NeMo 2.3.2 / `nvcr.io/nvidia/nemo:25.04.02`.

| run | micro-batch | s/step | tokens/s | MFU |
|---|:-:|:-:|:-:|:-:|
| NeMo | 1 | 11.69 | 89,737 | 25.4% |
| NeMo | 2 | 11.34 | 92,465 | 26.2% |
| **NeMo** | **4** | **11.29** | **92,861** | **26.3%** |
| exp108 Levanter | — | ~20 | ~52,000 | ~15% |

**~26% MFU vs ~15%, ~93k vs ~52k tok/s, ~11.3 vs ~20 s/step** on identical model/shape/hardware, out of the box. Micro-batch barely matters (memory-bound with grad checkpointing).

## What this is / how it works

The novelty vs exp108 is the **payload**, not the submission: exp108 dispatched a levanter *callable* into marin's iris-task image; exp112 dispatches a **`torchrun` binary** into the foreign **NeMo container** at **batch** priority.

- **iris feasibility (verified):** a job can override its image (`ResourceConfig.image`) and run a binary entrypoint (`Entrypoint.from_binary`). The only iris gap — no torchrun rendezvous API — bites *multi-node only*; single-node `torchrun --standalone` sidesteps it. Batch band via `JobRequest.priority=3` (as exp108).
- **Code delivery:** the NeMo image has no repo checkout, so `dispatch_nemo.py` **base64-inlines** the training script into the bootstrap bash; `create_environment(docker_image=…)` (not `workspace`) so the launcher env is *not* synced into the container.
- **Model:** exact exp108 geometry as a Megatron `llm.GPTConfig` — 2048h/48L/32h·8kv GQA / QK-norm / RMSNorm / SwiGLU / RoPE, vocab 2845.
- **Metric:** *throughput* (tokens/s, s/step) leads (formula-free, directly comparable to exp108); MFU (÷989 H100 bf16 peak) is the cross-check.

Validated locally in the NeMo container (`--tiny`) before any cluster time, then the full path ran first-try on `cw-rno2a`.

## Files
`common.py` (constants), `nemo_train_qwen3.py` (in-container, base64-inlined), `dispatch_nemo.py` (batch-priority Fray dispatch), launcher-only `pyproject.toml`/`uv.lock`. Everything under one removable `s3://…/MarinFold/exp112_qwen_3b_nemo_mfu/` prefix.

## Deferred (documented in README)
Remaining MFU headroom (→ ~35–40%) = grad-ckpt recompute + bf16 (no fp8) + DP-replicated params — all known levers. A full run would need the real `.bin/.idx` data path + multi-node torchrun rendezvous.

Does **not** close #112 — experiments are closed by humans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SH6m5LcVoDRKsDYVD89Fwf