### PR TITLE
Remove the experiment-graduation concept; refresh marinfold/README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ infrastructure. Concerns at the repo root:
 - `scripts/` — repo-management scripts (`scaffold.py`, `itemize.py`,
   `history.py`). Run with plain `python scripts/<name>.py`.
 - `marinfold/` — the top-level Python package. Backends, model
-  registry, document-structure shared toolkit, graduated
+  registry, document-structure shared toolkit, the
   document-structure impls (as subpackages of
   `marinfold.document_structures.<name>`), and the user-facing
   `marinfold infer` / `marinfold evaluate` CLI.
@@ -41,7 +41,12 @@ direction is forbidden. If two experiments need the same helper,
 promote it to the kind library once a second use case actually exists
 (not before).
 
-See `experiments/README.md` for the workflow and graduation flow,
+Experiment dirs are never copied into a kind dir — there is no
+graduation step. Reusable code lands in the kind library from the
+start and the experiment imports it; the experiment dir keeps only
+its own driver code and results.
+
+See `experiments/README.md` for the workflow,
 and `marinfold/README.md` for the inference/CLI surface. For any
 data-generation pipeline that runs on the marin Iris cluster via
 Zephyr, read the [`zephyr-pipeline-performance`](.agents/skills/zephyr-pipeline-performance/SKILL.md)

--- a/README.md
+++ b/README.md
@@ -162,10 +162,11 @@ uv run contacts-v1 generate --input tests/data/1QYS.cif \
 
 ## More details (mostly written by robots)
 
-Trained models are listed in `[MODELS.yaml](MODELS.yaml)` by
+Trained models are listed in
+[`MODELS.yaml`](marinfold/marinfold/MODELS.yaml) by
 nickname. The `marinfold` CLI looks up the model, picks the first
-document structure it supports, and dispatches to the graduated
-impl. Two subcommands:
+document structure it supports, and dispatches to that impl. Two
+subcommands:
 
 ```bash
 cd marinfold
@@ -190,7 +191,7 @@ uv run marinfold evaluate \
 | `transformers` | Anywhere torch installs (Apple MPS, CPU, CUDA) | `--extra transformers` |
 
 
-`--model` accepts a `[MODELS.yaml](MODELS.yaml)` nickname or a
+`--model` accepts a [`MODELS.yaml`](marinfold/marinfold/MODELS.yaml) nickname or a
 local checkpoint directory. Omit it to use the entry marked
 `default: true`. `--document-structure` overrides the impl
 selection; without it the first supported impl wins. See
@@ -199,8 +200,10 @@ matrix and `marinfold infer --help` / `marinfold evaluate --help`
 for the full flag set.
 
 For impl-specific flags (seed-N sweeps, distance cap, batch size,
-etc.) each graduated impl ships its own lower-level CLI as a
-console script:
+etc.) each impl has its own lower-level CLI. `contacts-v1` and
+`contacts-and-distances-v1` install theirs as console scripts
+(`contacts-and-coordinates-v1` has none — run it with `python -m`;
+see [`marinfold/README.md`](marinfold/README.md)):
 
 ```bash
 cd marinfold
@@ -220,7 +223,6 @@ uv run contacts-and-distances-v1 evaluate \
 
 ```
 MarinFold/
-├── MODELS.yaml             # registry of trained models (nickname → HF URL)
 ├── RESOURCES.md            # datasets, tokenizers, W&B projects, prior repos
 ├── AGENTS.md               # shared agent rules
 ├── .github/ISSUE_TEMPLATE/experiment.md
@@ -230,18 +232,17 @@ MarinFold/
 │   ├── AGENTS.md
 │   ├── TEMPLATE.md
 │   └── exp<N>_<kind>_<name>/       # individual experiments
-├── marinfold/              # top-level package: backends, doc-structure toolkit, graduated impls, `marinfold` CLI
+├── marinfold/              # top-level package: MODELS.yaml, backends, doc-structure toolkit + impls, `marinfold` CLI
 ├── models/                 # library for model-training experiments
 └── history/                # one file per W&B-logged run + summary RUNS.md
 ```
 
 Each top-level dir under the repo root is a **small library** for one
 kind of work. Concrete experimental work begins as an issue and a
-sub-directory under `experiments/` and may pull in helpers from the
-relevant library. Important / high-quality experiments get
-**graduated** — copied into the kind dir, where the copy keeps
-evolving while the original `experiments/exp<N>_*/` stays frozen as
-the historical record.
+sub-directory under `experiments/` and pulls in helpers from the
+relevant library. An experiment dir is never copied into a kind dir —
+code meant to be reused lands in the library from the start and the
+experiment imports it.
 
 ## Experiment workflow
 
@@ -296,44 +297,14 @@ with a sibling creates the kind dir at that point.
 A **document structure** is a recipe with two responsibilities: turn
 input data (e.g. a PDB) into a training document string, and score a
 trained model against ground-truth structures using the same format.
-Each format is a self-contained experiment dir with its own `cli.py`
-driver (`generate` / `infer` / `evaluate` / `tokenizer` subcommands)
-on top of the shared toolkit in
-`[marinfold.document_structures](marinfold/marinfold/document_structures/)`
-(`EvalResult`, `build_tokenizer`, parquet/jsonl writers). The
-reference impl is
-`[experiments/exp1_document_structures_contacts_and_distances_v1/](experiments/exp1_document_structures_contacts_and_distances_v1/)`;
-graduated impls live as subpackages of `marinfold.document_structures`.
-
-
-
-## Graduating an experiment
-
-When an experiment's results are validated and the code should keep
-evolving as a first-class object, **copy** the directory into the
-matching kind dir, dropping the `exp<N>_<kind>_` prefix:
-
-```bash
-# models / evals / data: peer kind directory
-cp -r experiments/exp<N>_<kind>_<name>/ <kind>/<name>/
-# e.g. cp -r experiments/exp42_models_protein_1b/ models/protein_1b/
-
-# document_structures: subpackage of marinfold
-cp -r experiments/exp<N>_document_structures_<name>/ \
-      marinfold/marinfold/document_structures/<name>/
-```
-
-The original `experiments/exp<N>_*/` directory stays **frozen** as
-the historical record — the README, data, plots, and conclusion
-remain as they were at the time of the experiment. The graduated
-copy is the working version going forward; edits land there.
-
-After the copy: convert sibling imports to intra-package relative
-imports (`from .vocab import …`), add an `__init__.py` re-export
-of the public surface, and — for document_structures impls — add
-an optional-deps extra to `marinfold/pyproject.toml` for any
-heavy parser deps (e.g. `gemmi`). Tests move next to similar
-tests under each kind dir's `tests/`.
+Every format is implemented as a subpackage of
+[`marinfold.document_structures`](marinfold/marinfold/document_structures/)
+from its first commit, with its own `cli.py` driver (`generate` /
+`view` / `infer` / `evaluate` / `tokenizer`, depending on the impl) on
+top of the shared toolkit there (`EvalResult`, `build_tokenizer`,
+parquet/jsonl writers). `contacts-v1` is the current format; see
+[`marinfold/README.md`](marinfold/README.md) for all three and what
+each supports.
 
 ## Run history
 
@@ -411,9 +382,10 @@ with plain `python`:
 
 
 For impl-specific CLI surfaces (e.g. `generate` and `tokenizer`
-subcommands), see the per-impl console script — graduated impls
-expose one as `<structure-name>` (e.g. `contacts-and-distances-v1 {generate,infer,evaluate,tokenizer} ...`) installed alongside the
-top-level `marinfold` command.
+subcommands), see the per-impl CLI — `contacts-v1` and
+`contacts-and-distances-v1` install one as `<structure-name>` (e.g.
+`contacts-and-distances-v1 {generate,infer,evaluate,tokenizer} ...`)
+alongside the top-level `marinfold` command.
 
 To set up the scripts venv: `cd scripts && uv venv --python 3.11 && uv sync`
 (add `--extra wandb` for `history sync` / `history check`).
@@ -425,10 +397,11 @@ Initial port (commit-level) from the
 branch. All training/export scripts live under
 `[experiments/exp0_models_protein_docs_initial_port/](experiments/exp0_models_protein_docs_initial_port/)`;
 shared marin glue is in `[models/marinfold_models/](models/marinfold_models/)`.
-The `contacts-and-distances-v1` document structure is graduated at
+The `contacts-and-distances-v1` document structure lives at
 `[marinfold/marinfold/document_structures/contacts_and_distances_v1/](marinfold/marinfold/document_structures/contacts_and_distances_v1/)`;
-its in-flight history lives at
-`[experiments/exp1_document_structures_contacts_and_distances_v1/](experiments/exp1_document_structures_contacts_and_distances_v1/)`.
+the experiment that first built it is
+`[experiments/exp1_document_structures_contacts_and_distances_v1/](experiments/exp1_document_structures_contacts_and_distances_v1/)`,
+kept as a historical record.
 Eval experiments (e.g. `experiments/exp9_evals_`*) have started
 landing; a shared `evals` kind library will be created when a second
 eval experiment needs the same helper.

--- a/experiments/AGENTS.md
+++ b/experiments/AGENTS.md
@@ -246,36 +246,20 @@ Pure-analysis experiments (no marin imports) don't need a pyproject
 at all — they can just sit as `.py` files in a dir and run with the
 user's system python.
 
-## Graduating an experiment
+## An experiment dir is never copied into a kind dir
 
-Once an experiment's results are validated and the code should keep
-evolving as a first-class object, **copy** the directory into the
-matching kind dir, dropping the `exp<N>_<kind>_` prefix:
+There is no graduation step. An experiment lives under
+`experiments/exp<N>_<kind>_<name>/` for its whole life, and nothing
+gets copied or symlinked out of it into `models/` or `marinfold/`.
 
-```bash
-cp -r experiments/exp<N>_<kind>_<name>/ <kind>/<name>/
-# e.g. cp -r experiments/exp42_models_protein_1b/ models/protein_1b/
-```
-
-**Leave the original `experiments/exp<N>_*/` directory untouched.**
-It's the frozen historical record of what was tried at the time of
-the experiment — the README, the data, the plots, the conclusion.
-The kind-dir copy is the working version going forward; edits land
-there, not in the experiment dir.
-
-After the copy, you'll typically want to:
-
-- Trim or rewrite the experiment-style README if the kind dir has a
-  different docs convention (kind-dir code isn't always
-  question/hypothesis/result-shaped).
-- Decide whether to keep the experiment's `pyproject.toml` and venv
-  or consolidate with the kind library's setup.
-- Update any internal links / commit references that pointed at the
-  experiment dir.
-
-The kind dir and the experiment dir then diverge: the experiment
-stays frozen as the historical snapshot, the kind dir evolves
-freely.
+Code that should be reusable goes into the kind library **from the
+start**, and the experiment imports it — a document structure is
+always implemented in `marinfold.document_structures.<name>`, and
+shared training glue always lives in `marinfold_models`. If a second
+experiment turns out to need a helper an earlier one wrote, move that
+helper into the kind library then (the bar is "≥ 2 experiments would
+import it, and the abstraction is stable"), and leave the rest of the
+experiment where it is.
 
 ## When a researcher replies with a variant
 

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -23,12 +23,19 @@ an issue first.
 
 ## What each kind means
 
-| Kind | Purpose | Where the code lives once it graduates |
+| Kind | Purpose | Shared library it imports from |
 |---|---|---|
 | `models` | Train models | [`../models/`](../models/) |
 | `evals` | Run evals on trained models | — (no shared library yet) |
 | `data` | Generate training/eval datasets | — (no shared library yet) |
 | `document_structures` | Define an interface for both generating documents from input data and evaluating models | [`../marinfold/marinfold/document_structures/`](../marinfold/marinfold/document_structures/) |
+
+An experiment dir stays under `experiments/` for its whole life — it
+is never copied or promoted into a kind dir. Reusable code goes in the
+kind library from the start and the experiment imports it. A document
+structure in particular is always implemented in
+[`marinfold.document_structures`](../marinfold/marinfold/document_structures/);
+see [`../marinfold/README.md`](../marinfold/README.md).
 
 ## Tooling
 
@@ -90,27 +97,6 @@ comes from its dir; a dir-less issue's kind comes from its
    python scripts/itemize.py
    ```
 7. **Close** the issue once the conclusion lands.
-8. **(Optional) Graduate** by *copying* into the kind dir. If the
-   experiment's code should keep evolving as a first-class object,
-   copy the directory:
-   ```bash
-   cp -r experiments/exp<N>_<kind>_<name>/ <kind>/<name>/
-   # e.g. cp -r experiments/exp42_models_protein_1b/ models/protein_1b/
-   ```
-   Drop the `exp<N>_<kind>_` prefix in the destination name.
-   **Leave the original `experiments/exp<N>_*/` directory alone** —
-   it's the historical record of what was tried at the time of the
-   experiment, including the README that captures the question /
-   hypothesis / results. Going forward, edits land in the kind-dir
-   copy; the experiment dir is frozen.
-
-   Things to consider in the copy after the move:
-   - Trim or rewrite the experiment-style README if the kind dir has
-     a different docs convention.
-   - Decide whether to keep the experiment's `pyproject.toml` or
-     consolidate it with the kind library's setup.
-   - Update internal links / commit references that pointed at the
-     experiment dir.
 
 ## Main vs. branch
 

--- a/marinfold/AGENTS.md
+++ b/marinfold/AGENTS.md
@@ -15,10 +15,13 @@ responsibilities, nothing more:
    `core` + `writers`) — `EvalResult`, `build_tokenizer`, output
    writers (`write_docs` / `write_predictions` / `write_eval`).
    Protein-unaware.
-3. **Graduated document-structure impls**
+3. **Document-structure impls**
    (`marinfold.document_structures.<name>`) — each impl is a
-   subpackage. The impl is the only place that knows about residues,
-   distances, and one specific protein-document format.
+   subpackage, and every format is implemented here from its first
+   commit (there's no in-flight location and no graduation step;
+   experiments import the impl from this package). The impl is the
+   only place that knows about residues, distances, and one specific
+   protein-document format.
 4. **Top-level CLI** (`marinfold.cli`) + model registry
    (`marinfold.registry`) — `marinfold infer` / `marinfold evaluate`
    that look up a model in `MODELS.yaml`, pick a supported document
@@ -62,5 +65,5 @@ residues or distances, it's in the wrong place.
    `marinfold infer` and `marinfold evaluate` cover the common
    "run a trained model" cases. Lower-level operations (e.g.
    `generate`, `tokenizer`) stay on the per-impl `cli.py` inside
-   each graduated impl. Don't grow the top-level CLI into a
+   each impl. Don't grow the top-level CLI into a
    centralized dispatcher for impl-specific tooling.

--- a/marinfold/README.md
+++ b/marinfold/README.md
@@ -1,8 +1,8 @@
 # marinfold/
 
-The top-level MarinFold Python package: backend abstraction, shared
-document-structure toolkit, graduated document-structure impls, and
-the `marinfold` CLI.
+The top-level MarinFold Python package: backend abstraction, the shared
+document-structure toolkit, every document-structure impl, and the
+`marinfold` CLI.
 
 ```
 marinfold/
@@ -12,23 +12,21 @@ marinfold/
 ├── marinfold/
 │   ├── __init__.py                       # public API re-exports
 │   ├── cli.py                            # `marinfold infer / evaluate`
-│   ├── registry.py                       # MODELS.yaml: nickname → local path, default model
-│   ├── MODELS.yaml                       # model registry: nickname -> model path
+│   ├── registry.py                       # MODELS.yaml → a local model dir
+│   ├── MODELS.yaml                       # model registry: nickname → HF URL
 │   ├── inference/                        # Backend protocol + three backends
 │   │   ├── core.py
 │   │   ├── _vllm.py
 │   │   ├── _transformers.py
 │   │   └── _mlx.py
-│   └── document_structures/              # shared toolkit + graduated impl subpackages
+│   └── document_structures/              # shared toolkit + one subpackage per impl
 │       ├── core.py                       # EvalResult, build_tokenizer
 │       ├── writers.py                    # write_docs / write_predictions / write_eval
-│       └── contacts_and_distances_v1/    # graduated impl (subpackage)
-│           ├── cli.py
-│           ├── vocab.py / parse.py / generate.py / inference.py
-│           └── ...
-└── tests/
-    ├── test_registry.py / test_cli.py / test_transformers.py
-    └── document_structures/contacts_and_distances_v1/test_structure.py
+│       ├── io.py                         # read_object_bytes / thread_per_row_in_shard
+│       ├── contacts_v1/                  # current format (README.md + SPEC.md)
+│       ├── contacts_and_coordinates_v1/  # contacts-v1 + a 3D coordinate section
+│       └── contacts_and_distances_v1/    # previous generation: CB-CB distances
+└── tests/                                # mirrors the package layout
 ```
 
 ## Public API
@@ -37,16 +35,24 @@ marinfold/
 # Run a trained model:
 from marinfold import Backend, load_backend, resolve_model
 
-backend = load_backend("mlx", model="1B")          # MODELS.yaml nickname
+backend = load_backend("mlx", model=None)   # None → the MODELS.yaml default
 probs = backend.next_token_probs(prompts, target_token_ids)
+
+# Inspect the model registry:
+from marinfold import (
+    ModelEntry, default_model_nickname, list_model_entries, resolve_model_entry,
+)
 
 # Build a doc-structure impl:
 from marinfold import EvalResult, build_tokenizer
 from marinfold import write_docs, write_predictions, write_eval
 
-# Use a graduated impl directly:
-from marinfold.document_structures.contacts_and_distances_v1 import (
-    predict, evaluate, InferenceConfig,
+# Per-row I/O for data-generation pipelines (not re-exported at the top level):
+from marinfold.document_structures import read_object_bytes, thread_per_row_in_shard
+
+# Use an impl directly:
+from marinfold.document_structures.contacts_v1 import (
+    predict, evaluate, InferenceConfig, generate_document,
 )
 ```
 
@@ -63,28 +69,63 @@ step is required.
 
 ## Document-structure impls
 
-Graduated impls live as subpackages of `marinfold.document_structures`.
-The current impl (`contacts-and-distances-v1`) and its parser /
-plotting deps (`gemmi`, `matplotlib`) are pulled in by the base
-install.
+Every document structure is implemented **here**, as a subpackage of
+`marinfold.document_structures`, from its first commit. There is no
+separate in-flight location and no graduation step: an experiment that
+needs a new format adds the subpackage in this package and imports it,
+so an experiment dir under `../experiments/` holds only that
+experiment's own driver code and results. (Two early dirs —
+`exp1_document_structures_contacts_and_distances_v1` and
+`exp34_document_structures_contacts_and_distances_v2` — predate this and
+still carry their own copies of an impl. They are frozen historical
+records, not the working code.)
 
-The high-level `marinfold infer` / `marinfold evaluate` CLI picks
-the impl automatically based on the model's `document_structures`
-list in `MODELS.yaml`. Each impl also ships its own lower-level
-console script (e.g. `contacts-and-distances-v1`) for power-user
-flag access.
+| Impl | Format | `generate` | `infer` / `evaluate` |
+|---|---|---|---|
+| `contacts-v1` | Sequence section + the strongest pyconfind side-chain contacts. The current format — the default model speaks it. | yes | yes |
+| `contacts-and-coordinates-v1` | contacts-v1 plus a coordinate section revealing 3D atom positions coarse-to-fine. | yes | no — generation-only, no trained model yet |
+| `contacts-and-distances-v1` | Previous generation: `<d_X.X>` CB-CB distance bins over residue pairs. | yes | yes |
+
+An impl owns everything format-specific: vocabulary, parsing, document
+generation, and — where it has one — the inference readout. `contacts_v1`
+and `contacts_and_coordinates_v1` each carry a `README.md` (orientation)
+and a `SPEC.md` (the authoritative format definition, plus a maintained
+"Implementation notes & discrepancies" section).
+
+The high-level `marinfold infer` / `marinfold evaluate` CLI picks the
+impl automatically from the model's `document_structures` list in
+`MODELS.yaml`. Each impl also has its own lower-level CLI for power-user
+flag access (`generate`, `view`, `tokenizer`, seed-N sweeps, …). The two
+older impls expose theirs as console scripts (`contacts-v1`,
+`contacts-and-distances-v1`); `contacts-and-coordinates-v1` has no
+console script — run it with
+`python -m marinfold.document_structures.contacts_and_coordinates_v1.cli`.
+
+Dependencies: `gemmi` and `matplotlib` come with the base install, and
+are imported lazily. Generating documents for `contacts-v1` or
+`contacts-and-coordinates-v1` additionally needs `pyconfind` — install
+`marinfold[contacts-v1]`. (Their `tokenizer` subcommands work without
+it.)
 
 ## Model resolution
 
 `--model` (or the `model=` arg to `load_backend`) accepts:
 
 1. A local directory (path that exists on disk). Used as-is.
-2. A nickname listed in `marinfold/MODELS.yaml`. The matching HF
-   subfolder is downloaded via `huggingface_hub.snapshot_download`.
+2. A nickname listed in `marinfold/MODELS.yaml`.
+3. `None` / omitted — the entry marked `default: true` is used.
 
 Bare HF repo ids are not accepted — register the model in
 `MODELS.yaml` to use it. This is deliberate: it keeps the set of
 known models small, named, and discoverable.
+
+A nickname's `url` is fetched according to its shape:
+
+- A regular repo (`.../<org>/<repo>/tree/<rev>/<subfolder>`) — the
+  matching subfolder is downloaded via `huggingface_hub.snapshot_download`.
+- A storage bucket (`.../buckets/<org>/<bucket>/tree/<prefix>`) — buckets
+  are flat and have no revisions, so the prefix is mirrored into the HF
+  cache via the bucket HTTP API instead.
 
 `MODELS.yaml` is located in this order:
 
@@ -95,6 +136,8 @@ known models small, named, and discoverable.
 
 ## See also
 
-- [`../experiments/`](../experiments/) — in-flight experiments,
-  including pre-graduation document-structure impls.
 - [`marinfold/MODELS.yaml`](./marinfold/MODELS.yaml) — registered trained models.
+- [`contacts_v1/`](./marinfold/document_structures/contacts_v1/) — the current
+  document structure: `README.md` + `SPEC.md`.
+- [`../experiments/`](../experiments/) — in-flight experiments, which
+  import the impls from this package.

--- a/marinfold/marinfold/cli.py
+++ b/marinfold/marinfold/cli.py
@@ -66,7 +66,7 @@ def _load_impl(structure_name: str) -> ModuleType:
 
     Two failure modes:
 
-    - The impl subpackage doesn't exist (typo / not yet graduated).
+    - The impl subpackage doesn't exist (typo / not implemented yet).
     - The impl exists but a transitive import fails (missing dep).
     """
     module_name = _impl_module_name(structure_name)
@@ -80,8 +80,8 @@ def _load_impl(structure_name: str) -> ModuleType:
         if impl_missing:
             raise SystemExit(
                 f"Document structure {structure_name!r} is not available. "
-                f"Expected subpackage {module_name!r}. Graduate the impl "
-                f"into marinfold/marinfold/document_structures/ first."
+                f"Expected subpackage {module_name!r}. Add the impl under "
+                f"marinfold/marinfold/document_structures/ first."
             ) from exc
         raise SystemExit(
             f"Document structure {structure_name!r} is installed but a "

--- a/marinfold/marinfold/document_structures/__init__.py
+++ b/marinfold/marinfold/document_structures/__init__.py
@@ -4,12 +4,11 @@
 """Shared toolkit for MarinFold document-structure implementations.
 
 A document structure is a protein-document format. Each format lives
-as its own proper package under ``document_structures/<name>/`` once
-graduated (and as a flat experiment dir under
-``experiments/exp<N>_document_structures_<name>/`` while in
-flight).
+as its own proper package under ``document_structures/<name>/``, from
+its first commit — experiments import the impl from here rather than
+carrying their own copy.
 
-This subpackage holds the three pieces every impl shares:
+This subpackage holds the pieces every impl shares:
 
 - :class:`EvalResult` — return shape of ``evaluate``.
 - :func:`build_tokenizer` — build a ``PreTrainedTokenizerFast`` from

--- a/marinfold/marinfold/inference/__init__.py
+++ b/marinfold/marinfold/inference/__init__.py
@@ -15,8 +15,8 @@ importing :mod:`marinfold.inference` itself requires only the base
 deps and works with zero backends installed.
 
 The library is protein-unaware. Document-structure impls
-(``marinfold.document_structures`` and graduated impl packages
-under ``document_structures/``) build prompts as opaque token-id
+(``marinfold.document_structures`` and the impl packages under
+``document_structures/``) build prompts as opaque token-id
 lists and pass them in.
 """
 

--- a/models/AGENTS.md
+++ b/models/AGENTS.md
@@ -10,11 +10,10 @@ collection of training scripts. Specific training pipelines live as
 experiments under `experiments/exp<N>_models_<name>/` and import
 `marinfold_models.*` from here.
 
-Graduated experiments may also appear as symlinks under this
-directory (e.g. `models/contacts_and_distances_v1_baseline/` →
-`../experiments/exp<N>_models_contacts_and_distances_v1_baseline/`).
-Those are not part of the library; the library is `marinfold_models/`
-only.
+The library is `marinfold_models/`, and that's all `models/` holds.
+Experiment dirs are never copied or symlinked in — an experiment
+stays under `experiments/` for its whole life and imports what it
+needs from here.
 
 ## Hard rules
 
@@ -83,13 +82,3 @@ the top-level `experiments/` tree.
 
 If marin's `default_train` signature evolves, refresh both vendored
 files in one PR — no compatibility shims.
-
-## Graduated experiments
-
-When an experiment is graduated (see
-[`experiments/AGENTS.md`](../experiments/AGENTS.md)), its directory
-is **copied** here under a name that drops the `exp<N>_models_`
-prefix. The copy is the working version going forward; the original
-`experiments/exp<N>_models_<name>/` stays frozen as the historical
-record. Don't reach back to the experiment dir to edit code — make
-changes here.

--- a/models/README.md
+++ b/models/README.md
@@ -4,9 +4,7 @@ Shared library for MarinFold model-training experiments.
 
 The actual training pipelines (per-size, per-loss-mask variant, etc.) live
 under `experiments/exp<N>_models_<name>/` as standalone marin executor
-graphs. This directory holds code those experiments import — plus
-copies of experiments that have been **graduated** (see
-[`../experiments/README.md`](../experiments/README.md#graduating-an-experiment)).
+graphs. This directory holds only the code those experiments import.
 
 ## Layout
 
@@ -15,13 +13,16 @@ models/
 ├── pyproject.toml                # subproject pyproject (uses marin via wheels)
 ├── README.md                     # this file
 ├── AGENTS.md                     # rules for working under models/
-├── marinfold_models/             # importable library
-│   ├── __init__.py
-│   ├── defaults.py               # vendored marin default_train / default_tokenize
-│   └── simple_train_config.py    # vendored marin SimpleTrainConfig
-└── <graduated subdirs>           # e.g. contacts_and_distances_v1_baseline/,
-                                  # copied (not symlinked) from experiments/
+└── marinfold_models/             # importable library
+    ├── __init__.py
+    ├── defaults.py               # vendored marin default_train / default_tokenize
+    └── simple_train_config.py    # vendored marin SimpleTrainConfig
 ```
+
+`marinfold_models/` is the whole of `models/` — experiment code never
+gets copied in here. If an experiment needs something from this
+library it imports it (see below); if two experiments need the same
+helper, the helper moves here.
 
 ## Setup
 

--- a/models/pyproject.toml
+++ b/models/pyproject.toml
@@ -68,8 +68,4 @@ resiliparse = { index = "marin-resiliparse" }
 allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
-# Only the library package goes in the wheel — graduated-experiment
-# subdirs (e.g. models/contacts_and_distances_v1/) are runnable
-# code copied from experiments/, not library code, so they're
-# explicitly excluded.
 packages = ["marinfold_models"]


### PR DESCRIPTION
We no longer graduate experiments — at all, for any kind. This removes the concept from the codebase and refreshes [`marinfold/README.md`](https://github.com/Open-Athena/MarinFold/tree/main/marinfold), which had drifted well past the graduation wording.

Two commits, reviewable independently.

## 1. `marinfold/`: refresh the README

The README described a package with **one** document structure and named the wrong one as current. Verified against the source and fixed:

| Claim | Was | Now |
|---|---|---|
| Impls | only `contacts-and-distances-v1`, called "the current impl" | all three, with `contacts-v1` correctly current (the `default: true` model speaks it) and `contacts-and-distances-v1` the previous generation |
| `contacts-and-coordinates-v1` | absent | generation-only (no `inference.py`/`plots.py`, no trained model), and **not** a console script — runs via `python -m` |
| Per-impl CLI | "each impl ships its own console script" | true for two of three; coordinates has no entry point in `pyproject.toml` |
| `document_structures/io.py` | absent | in the tree + public API |
| Public API | missed the registry re-exports | covers `ModelEntry`, `list_model_entries`, …; example uses the default model, not the legacy `1B` |
| Model resolution | "downloaded via `snapshot_download`" | both URL shapes — repos via `snapshot_download`, buckets mirrored via the bucket HTTP API |
| Deps | gemmi/matplotlib only | adds that generation needs `pyconfind` via `marinfold[contacts-v1]` |

Also fixed a **user-facing** `cli.py` error that told people to "Graduate the impl into marinfold/marinfold/document_structures/ first".

## 2. Remove graduation repo-wide

An experiment dir now lives under `experiments/` for its whole life; nothing is copied or symlinked out of it into a kind dir. Reusable code lands in the kind library from the start and the experiment imports it.

Removed the flow from the root `README.md` ("Graduating an experiment"), `experiments/README.md` (optional step 8 + the kinds-table header *"Where the code lives once it graduates"*), `experiments/AGENTS.md`, `models/README.md`, `models/AGENTS.md`, `models/pyproject.toml`, and root `AGENTS.md`.

**The `models/` docs described something that never existed.** The README's layout showed a `<graduated subdirs>` entry, and `AGENTS.md` claimed graduated experiments appear as *symlinks* while the README — and `AGENTS.md`'s own later section — said *copied*. `models/` has only ever contained `marinfold_models/`.

### Kept deliberately

- **Promoting a shared helper** into a kind library once ≥ 2 experiments need it. Different rule, still live — easy to conflate with graduation, so I left it intact and restated it.
- **Experiment dirs as frozen historical records.** That survives; they just never get copied out.
- **The four "graduated" mentions inside frozen experiment dirs** (`exp1` ×2, `exp65` ×2). They record what happened at the time, and rewriting them would falsify the record. `exp65`'s is a different sense of the word anyway (a file moved from `.dev/`). Say the word if you'd rather they go.

## Drive-by

The root README linked a root `MODELS.yaml` that hasn't existed since `78e3015` moved it into the package, and the layout diagram still showed it there. Both links now point at `marinfold/marinfold/MODELS.yaml`, in the correct `` [`x`](y) `` form — backtick-*wrapped* `` `[x](y)` `` renders as literal text, not a link. ~14 such links remain elsewhere in the root README; left alone as a separate cleanup.

## Verification

- `pytest -m "not network"` → **257 passed, 4 skipped**. No test asserted on the changed error string.
- Exercised every documented CLI: `contacts-v1` (generate/view/infer/evaluate/tokenizer), `contacts-and-distances-v1` (generate/infer/evaluate/tokenizer), and confirmed `contacts-and-coordinates-v1` fails to spawn as a script but works via `python -m` (generate/view/tokenizer).
- `models/pyproject.toml` still parses and still declares `packages = ["marinfold_models"]`.
- All relative links in every touched markdown file resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
