### PR TITLE
Rewrite eval-checkpoint skill around invariant evaluation semantics

### DIFF
--- a/.claude/skills/eval-checkpoint/SKILL.md
+++ b/.claude/skills/eval-checkpoint/SKILL.md
@@ -78,17 +78,14 @@ environment when a smaller source/package surface avoids version conflicts.
 
 ## Validate completeness
 
-- Require exactly 554 `(dataset, stem)` score files and zero unreported skips.
-  The 552 unique stems are an expected property, not the evaluation count.
-- Require each score matrix to have shape `[L,L]` for its ground-truth record.
-  Confirm that every required position token is present in each returned
-  next-token log-probability distribution; never replace missing entries with a
-  fallback score without failing the gate.
-- Require 11,080 metric rows per evaluated model: 554 units × four ranges × the
-  five cuts `L`, `L/2`, `L/5`, `R`, and `AUC`, each exactly once.
-- Expect 554 valid values for the three fixed-length precision cuts. For `R`
-  and `AUC`, expect 554 in `all`/`short` and 553 in `medium`/`long`; retain the
-  undefined row rather than silently dropping that protein.
+- Account for every expected `(dataset, stem)` unit and report skips or failures
+  explicitly. Do not deduplicate on `stem` alone.
+- Check that each score matrix matches its protein length and that every
+  required position-token log probability was returned rather than replaced by
+  a fallback value.
+- Check that metric outputs cover the evaluator's expected ranges and cuts for
+  every scored unit, and report valid-value counts where a metric may be
+  undefined.
 
 Stop before reporting if any invariant fails. Name every skipped or invalid
 unit and preserve partial outputs for diagnosis.

--- a/.claude/skills/eval-checkpoint/SKILL.md
+++ b/.claude/skills/eval-checkpoint/SKILL.md
@@ -76,6 +76,24 @@ environment when a smaller source/package surface avoids version conflicts.
   cuts, completeness counts, output paths, and the checkpoint's W&B train/val
   losses when requested. Record the source W&B metric keys.
 
+## Validate against the E8 reference
+
+Before trusting a new execution path, reproduce the
+[exp75](https://github.com/Open-Athena/MarinFold/issues/75) E8 checkpoint
+`prot-exp75-cv1-1_5b-e8-lr1e-3-wd0p2-v1-bc3084` at step 35679. Choose the
+artifact that best fits the runtime and data locality:
+
+- HF format: [HF mirror](https://huggingface.co/open-athena/marinfold-exp75/tree/main/prot-exp75-cv1-1_5b-e8-lr1e-3-wd0p2-v1-bc3084/hf/step-35679)
+  or `gs://marin-us-east5/checkpoints/prot-exp75-cv1-1_5b-e8-lr1e-3-wd0p2-v1-bc3084/hf/step-35679/`.
+- Levanter format: [HF mirror](https://huggingface.co/open-athena/marinfold-exp75/tree/main/prot-exp75-cv1-1_5b-e8-lr1e-3-wd0p2-v1-bc3084/checkpoints/step-35679)
+  or `gs://marin-us-east5/checkpoints/prot-exp75-cv1-1_5b-e8-lr1e-3-wd0p2-v1-bc3084/checkpoints/step-35679/`.
+
+With exp89 semantics, one realization, and no ensembling, the
+[PR #93 E8 row](https://github.com/Open-Athena/MarinFold/pull/93#issue-4738130859)
+reports long-range AUC `0.881` and R-precision `0.339` (all) / `0.269` (long).
+The reproduced metrics should match at the reported precision. Investigate
+discrepancies before evaluating a new checkpoint.
+
 ## Validate completeness
 
 - Account for every expected `(dataset, stem)` unit and report skips or failures

--- a/.claude/skills/eval-checkpoint/SKILL.md
+++ b/.claude/skills/eval-checkpoint/SKILL.md
@@ -9,8 +9,10 @@ description: >-
 
 # Evaluate a contacts-v1 checkpoint
 
-Treat the exp89 evaluator, fixed ground truth, candidate-pair universe, and
-metric implementation as the measurement specification. Infer environment-
+Treat the [exp89 evaluator](https://github.com/Open-Athena/MarinFold/issues/89),
+fixed ground truth, candidate-pair universe, and metric implementation as the
+measurement specification. Its standard pairwise score comes from
+[exp82](https://github.com/Open-Athena/MarinFold/issues/82). Infer environment-
 specific commands from the checked-out revisions and current tooling.
 
 ## Establish identity and locality
@@ -51,9 +53,15 @@ environment when a smaller source/package surface avoids version conflicts.
 3. Gate the full run on one real protein: load the actual weights and tokenizer,
    execute a forward pass, obtain the complete position-token log-probabilities,
    and write a valid score matrix.
-4. On TPU vLLM, verify the TPU-targeted runtime and inspect checkpoint,
-   parameter, and compute dtypes. Normalize floating weights intentionally
-   before sharding; isolate any CPU PyTorch conversion from vLLM engine startup.
+4. On TPU vLLM, derive the expected parameter dtype from the model/runtime
+   configuration and inspect the tensors in every safetensor shard. If they
+   differ—for example, `float32` exported weights with `bfloat16` TPU
+   parameters—rewrite
+   only floating tensors to the expected dtype before vLLM loads and shards
+   them. Preserve integer/bool tensors, names, shapes, shard indexes, config,
+   and tokenizer. Run the conversion in a short-lived CPU process, then start
+   vLLM fresh so it cannot inherit PyTorch/OpenMP state. Record the source and
+   effective dtypes.
 
 ## Expected outputs
 
@@ -68,8 +76,22 @@ environment when a smaller source/package surface avoids version conflicts.
   cuts, completeness counts, output paths, and the checkpoint's W&B train/val
   losses when requested. Record the source W&B metric keys.
 
-Reject silent skips, wrong-shaped matrices, incomplete log-probability vectors,
-or a 552-unit result caused by deduplicating on `stem`.
+## Validate completeness
+
+- Require exactly 554 `(dataset, stem)` score files and zero unreported skips.
+  The 552 unique stems are an expected property, not the evaluation count.
+- Require each score matrix to have shape `[L,L]` for its ground-truth record.
+  Confirm that every required position token is present in each returned
+  next-token log-probability distribution; never replace missing entries with a
+  fallback score without failing the gate.
+- Require 11,080 metric rows per evaluated model: 554 units × four ranges × the
+  five cuts `L`, `L/2`, `L/5`, `R`, and `AUC`, each exactly once.
+- Expect 554 valid values for the three fixed-length precision cuts. For `R`
+  and `AUC`, expect 554 in `all`/`short` and 553 in `medium`/`long`; retain the
+  undefined row rather than silently dropping that protein.
+
+Stop before reporting if any invariant fails. Name every skipped or invalid
+unit and preserve partial outputs for diagnosis.
 
 ## Debugging ladder
 

--- a/.claude/skills/eval-checkpoint/SKILL.md
+++ b/.claude/skills/eval-checkpoint/SKILL.md
@@ -1,111 +1,87 @@
 ---
 name: eval-checkpoint
 description: >-
-  Run the MarinFold contacts-v1 contact-prediction eval set (554 proteins) on a
-  model checkpoint and report R-precision — plus precision@{L,L/2,L/5} and ranking
-  AUC — per sequence-separation range (all / short / medium / long), next to the
-  Protenix-v2 / ESMFold / ESMFold2 baselines. Use this whenever someone wants to
-  evaluate, score, or benchmark a contacts-v1 checkpoint on contact prediction:
-  "eval this checkpoint", "what's the R-precision of <run>", "how does the new
-  model do on the eval set", "score step-N on contacts", "benchmark it vs ESMFold",
-  including brand-new checkpoints straight out of a training run (exp108, exp120,
-  and successors). It handles the Levanter→HF export, pulling the prebuilt ground
-  truth from the bucket, scoring, and the exact metric code. Reach for it before
-  hand-rolling contact metrics or rebuilding ground truth — getting either wrong
-  silently corrupts the numbers.
+  Evaluate a MarinFold contacts-v1 checkpoint with the fixed exp89 contact
+  benchmark. Use for checkpoint scoring, R-precision/AUC requests, comparisons
+  with structure baselines, or reproducing contact metrics on local, CUDA, or
+  Iris TPU execution.
 ---
 
-# eval-checkpoint — contacts-v1 checkpoint → R-precision
+# Evaluate a contacts-v1 checkpoint
 
-The canonical way to answer "how good is this checkpoint at predicting contacts?"
-is the **exp89 harness** (`experiments/exp89_evals_contacts_v1_model_on_eval_set/`).
-It scores a model on a fixed 554-protein eval set and reports the same metrics for
-MarinFold and every structure-predictor baseline, over one shared candidate-pair
-universe, so numbers are directly comparable.
+Treat the exp89 evaluator, fixed ground truth, candidate-pair universe, and
+metric implementation as the measurement specification. Infer environment-
+specific commands from the checked-out revisions and current tooling.
 
-**The exp89 README is the source of truth for exact commands and paths — read it
-first (`experiments/exp89_evals_contacts_v1_model_on_eval_set/README.md`, the
-"Running" section).** This skill is the orchestration and the guardrails; it does
-not restate the full command block, because the README is maintained and this file
-would drift. Your job is to run the harness correctly and not fall into the traps
-below.
+## Establish identity and locality
 
-## What you're producing
+1. Resolve the W&B run, exact step, checkpoint format, tokenizer/vocabulary,
+   storage location, and region. Reuse a complete sibling HF export when one
+   exists; otherwise convert Levanter weights and co-locate the tokenizer.
+2. Match compute and output storage to checkpoint locality. Alternatively,
+   propose a one-time mirror/export to durable HF storage when repeated access
+   justifies the egress.
+3. **Stop before transfer or submission.** Present the locality-matched and
+   one-time-mirror options, including material transfer/cost implications, and
+   require the user to choose. Follow repository approval rules for large
+   cross-region copies.
 
-For each sequence-separation range — `all` (sep ≥ 6), `short` (6–11),
-`medium` (12–23), `long` (≥ 24) — the mean over the 554 proteins of:
-**R-precision** (precision at the top-`#true-contacts` predicted pairs), plus
-precision@{L, L/2, L/5} and ranking AUC. Report MarinFold next to the Protenix-v2
-(single-seq + MSA) / ESMFold / ESMFold2 baselines, like the exp89 headline table.
+## Choose an execution host
 
-The headline people usually want is **long-range R-precision** and **aggregate
-(`all`) R-precision** — lead with those, but produce the full per-range table.
+Use either approach without changing evaluation semantics:
 
-## The workflow
+- **MarinFold-native:** run the evaluator here with pinned published Marin/Iris
+  packages and only the compatible MarinFold import surface.
+- **Marin-native:** use Marin's workspace runtime, cluster configuration, and
+  extras; include the MarinFold evaluator and inputs at a pinned revision.
 
-Run the three-step harness. Steps (1) and the baselines are checkpoint-independent
-and already exist; only export + scoring are per-checkpoint.
+Prefer the approach with checkpoint-local compute and fewer unpinned
+dependencies. Do not install the full MarinFold dependency set into a TPU vLLM
+environment when a smaller source/package surface avoids version conflicts.
 
-1. **Get the checkpoint into HF safetensors.** If you were handed a Levanter
-   checkpoint (a `gs://…/checkpoints/<run>/checkpoints/step-N/` path), export it
-   first with the `export_contacts_v1_best_to_hf.py` pattern — levanter's
-   `export_lm_to_hf` on CPU, with the exp75 Qwen3 config and the contacts-v1
-   tokenizer co-located (vocab 2845). If you already have an HF export
-   (`…/hf/step-N/`, a `Qwen3ForCausalLM` with the tokenizer alongside), skip this.
-   *Co-locate the tokenizer with the weights — the scorer builds the sequence
-   prefix from it, and a mismatched/absent tokenizer produces silently wrong
-   prompts.*
+## Evaluate
 
-2. **Pull the ground-truth universe — do not rebuild it.** It's checkpoint-
-   independent (same 554 proteins every time) and lives on the bucket:
-   ```
-   hf buckets cp hf://buckets/open-athena/MarinFold/data/contacts-v1-model-eval-exp89/gt_universe.jsonl data/gt_universe.jsonl
-   ```
-   Rebuilding it from scratch needs the exp78 pyconfind venv + the staged GT
-   structures and reproduces the same bytes — only do that if the bucket copy is
-   somehow unavailable. The README keeps the rebuild command as a fallback.
+1. Fetch the published exp89 ground-truth universe; do not rebuild it during a
+   normal checkpoint evaluation. Verify 554 `(dataset, stem)` units and 552
+   unique stems. Require canonical baseline inputs when baseline comparison is
+   requested.
+2. Use exp89's pairwise scorer and `compute_metrics.py`; do not substitute
+   another candidate universe or metric implementation. Make scoring resumable
+   by `(dataset, stem)`.
+3. Gate the full run on one real protein: load the actual weights and tokenizer,
+   execute a forward pass, obtain the complete position-token log-probabilities,
+   and write a valid score matrix.
+4. On TPU vLLM, verify the TPU-targeted runtime and inspect checkpoint,
+   parameter, and compute dtypes. Normalize floating weights intentionally
+   before sharding; isolate any CPU PyTorch conversion from vLLM engine startup.
 
-3. **Score, then compute metrics.** Scoring is exp82 **pairwise** — the symmetrized
-   geometric-mean log-prob of `<contact> <pi> <pj>` over every candidate pair,
-   which exp82 found extracts the most LM-only signal. Local CUDA transformers
-   (`score_eval_set.py`) is the canonical, fastest path; the vLLM/iris-TPU variant
-   (`score_eval_set_vllm.py`) is the same scoring definition if you need it.
-   Feed the score matrices to **exp89's `compute_metrics.py`** with its committed
-   `--exp78-*`/`--exp74-*` baseline-splice args (they're in the README). Then
-   `plot.py` if you want the boxplots.
+## Expected outputs
 
-## Guardrails — the ways this goes silently wrong
+- `scores/<dataset>__<stem>.npz`: 554 `[L,L]` score matrices.
+- Timing and provenance records: evaluated run/step, source and evaluated
+  checkpoint paths, revisions, tokenizer, regions, runtime, topology, and job.
+- `marinfold_precision.csv` and the unified `contact_precision_all.csv` (or
+  equivalent wrapper outputs): per-protein precision at `L`, `L/2`, `L/5`, and
+  `R`, plus AUC, for `all`, `short`, `medium`, and `long` ranges—20 rows per
+  evaluation unit.
+- A concise aggregate table led by all/long R-precision, with AUC and precision
+  cuts, completeness counts, output paths, and the checkpoint's W&B train/val
+  losses when requested. Record the source W&B metric keys.
 
-- **Use exp89's `compute_metrics.py`. Never hand-roll the metric, and don't reuse
-  exp82's `metrics()`.** exp82's own implementation disagrees with exp89's by up to
-  0.4/protein (float16 tie-breaking + small-protein edge cases). Cross-predictor
-  comparison is only valid under one metric implementation, and exp89's is it.
-- **The eval unit is (dataset, stem), not stem.** Two stems (`7ur7_A`, `8ah9_A`)
-  appear in two datasets each, so it's **554 evaluated proteins over 552 unique
-  stems**. If your counts say 552, you deduplicated on the wrong key.
-- **Score the whole resolved universe over the shared candidate pairs** the GT
-  universe defines — that's what makes MarinFold and the structure baselines
-  comparable. Don't invent a different candidate set.
-- **Ground truth is fixed**: pyconfind side-chain contacts on the experimental
-  structure, `native_only`, degree ≥ 0.001, sequence-separation ≥ 6 — identical to
-  the contacts-v1 training documents. Don't redefine it per run.
+Reject silent skips, wrong-shaped matrices, incomplete log-probability vectors,
+or a 552-unit result caused by deduplicating on `stem`.
 
-## Inputs
+## Debugging ladder
 
-The one thing that varies per invocation is the checkpoint. Accept either:
-- a GCS **Levanter** path: `gs://…/checkpoints/<wandb-run-name>/checkpoints/step-N/`
-  (needs export, step 1), or
-- an **HF export**: `…/hf/step-N/` (skip export).
+Escalate only as far as needed:
 
-If the user names a W&B run but not a path, the checkpoint layout convention is
-`checkpoints/<wandb-run-name>/step-<N>/` on the bucket — find it there or ask.
+1. Submit the normal Iris job and inspect controller/worker logs.
+2. Submit directly to a TPU slice with Iris `--tpu <slice>` when controller
+   placement or orchestration obscures the failure.
+3. Use `iris task exec` to inspect the live worker without relying on SSH.
+4. Use Marin's `scripts/iris/dev_tpu.py` for an interactive slice and SSH when
+   worker-level inspection is still necessary; treat SSH/OS Login failures as
+   separate from the evaluation runtime.
 
-## Going further (optional)
-
-- **Stronger inference than pairwise:** exp82's **rollout+resample** (rank pairs by
-  sampled-completion vote frequency, optionally with a pairwise tiebreak) edges out
-  pairwise on this eval but costs many rollouts per protein. Use exp82's
-  `score_rollout_resample_eval.py` + `build_comparison_table.py` if the ask is
-  "best possible LM-only number" rather than "standard eval of this checkpoint".
-- **Single-panel high-res plot:** exp82's `plot_all_only.py` renders one range of
-  the comparison boxplot at publication resolution (PNG + vector PDF).
+If no clear supported TPU/Iris path remains—or checkpoint identity, evaluation
+inputs, transfer scope, or metric validity is ambiguous—stop and ask the user.


### PR DESCRIPTION
## Summary

Rewrites the `eval-checkpoint` skill introduced in #135 as a concise, environment-agnostic guide to the invariant parts of contacts-v1 evaluation.

## Why

Exact execution environments change. The durable requirements are checkpoint identity, data locality, the fixed #89 evaluation universe and metrics, complete outputs, and explicit failure boundaries.

## Changes

- Requires user choice between checkpoint-local execution and one-time HF mirroring before transfer or submission.
- Supports either MarinFold with published Marin/Iris packages or a Marin workspace with pinned MarinFold evaluation code.
- Preserves the #89 evaluator and #82 pairwise scoring semantics.
- Defines expected score, metric, timing, provenance, and W&B outputs.
- Adds concise completeness checks without coupling them to the current implementation.
- Documents TPU vLLM dtype handling, including safe `float32`→`bfloat16` conversion.
- Provides a debugging ladder: normal Iris job → direct TPU → `iris task exec` → interactive TPU/SSH.
- Stops for unresolved checkpoint, transfer, runtime, or metric ambiguity.

## Validation

- `quick_validate.py` passes.
- `git diff --check` passes.
