### PR TITLE
Fix nine bugs found in a codebase review

### DIFF
--- a/marinfold/marinfold/document_structures/contacts_and_coordinates_v1/generate.py
+++ b/marinfold/marinfold/document_structures/contacts_and_coordinates_v1/generate.py
@@ -278,8 +278,13 @@ def _coordinate_digits(value: float, max_depth: int) -> tuple[int, ...]:
     scale = _coord_scale(max_depth)
     clamped = min(_max_coord(max_depth), max(0.0, value))
     n = round(clamped * scale)
-    coarsest = 100 * scale  # divisor for the hundreds place in scaled space
-    return tuple((n // (coarsest // 10 ** i)) % 10 for i in range(max_depth))
+    # Read the ``max_depth`` decimal digits of ``n`` (a max_depth-digit int in
+    # [0, 10**max_depth - 1]), most-significant first. Use an integer power-of-10
+    # divisor directly: ``100 * scale`` is a float for max_depth < 3 (scale is a
+    # negative power of ten there), which would make every extracted digit a
+    # float and crash token formatting for the depths the config validator
+    # advertises. This form is byte-identical for max_depth 3 and 4.
+    return tuple((n // 10 ** (max_depth - 1 - i)) % 10 for i in range(max_depth))
 
 
 def _xyz_tokens(x: float, y: float, z: float, depth: int, max_depth: int) -> list[str]:

--- a/marinfold/marinfold/document_structures/contacts_v1/generate.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/generate.py
@@ -269,9 +269,13 @@ def _geometric(rng: random.Random, p: float) -> int:
         raise ValueError(f"p must be in (0, 1]; got {p!r}")
     if p == 1.0:
         return 1
-    # rng.random() in [0, 1); 1 - U in (0, 1] avoids log(0).
+    # rng.random() in [0, 1); 1 - U in (0, 1] avoids log(0). The upper
+    # endpoint is inclusive, though: when rng.random() == 0.0, u == 1.0 and
+    # ceil(log(1)/log(1-p)) == 0, which would violate the documented support
+    # {1, 2, 3, ...}. Clamp to 1 so that boundary draw stays in support (the
+    # RNG stream is untouched, so determinism is preserved).
     u = 1.0 - rng.random()
-    return int(math.ceil(math.log(u) / math.log(1.0 - p)))
+    return max(1, int(math.ceil(math.log(u) / math.log(1.0 - p))))
 
 
 def _sample_think_overhead(
@@ -479,9 +483,14 @@ def build_document(
     if not emitted and k1 > 0:
         # No contacts but the initial run still fired: emit it so the document
         # records the sampled overhead (rare — only for proteins with no
-        # above-threshold, seq-sep-respecting contacts).
-        tokens += [THINK_TOKEN] * k1
-        think_emitted += k1
+        # above-threshold, seq-sep-respecting contacts). Clamp to the budget
+        # headroom so the "never overflow context_length" invariant holds even
+        # for a tiny custom context_length: with no contacts, ``fixed`` already
+        # equals the full non-think document length, so ``context_length -
+        # fixed`` is exactly the remaining think budget.
+        k_emit = min(k1, max(0, context_length - fixed))
+        tokens += [THINK_TOKEN] * k_emit
+        think_emitted += k_emit
     tokens.append(END_TOKEN)
 
     return GenerationResult(

--- a/marinfold/marinfold/document_structures/contacts_v1/inference.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/inference.py
@@ -299,7 +299,10 @@ def _pcontact_from_fwd(fwd: np.ndarray) -> np.ndarray:
 def _sym_from_fwd(fwd: np.ndarray) -> np.ndarray:
     """Symmetrized geo-mean log-score ``0.5·(fwd + fwd.T)``.
 
-    The pairwise *ranking* score, and the key that breaks rollout's vote ties.
+    Used only as the key that breaks rollout's large zero-vote mass. The
+    pairwise readout ranks by ``P(contact)`` (:func:`_pcontact_from_fwd`)
+    instead; the two orderings differ for orientation-asymmetric pairs but
+    agree with the exp82/exp89 sym-ranked numbers within backend noise.
     """
     return 0.5 * (fwd + fwd.T)
 

--- a/marinfold/marinfold/registry.py
+++ b/marinfold/marinfold/registry.py
@@ -31,6 +31,7 @@ produced which eval number.
 
 import os
 import re
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import quote
@@ -369,6 +370,7 @@ def _download_bucket_prefix(location: _HFLocation) -> Path:
     match the bucket's metadata.
     """
     from huggingface_hub.constants import HF_HUB_CACHE
+    from huggingface_hub.utils import WeakFileLock
 
     files = _list_bucket_files(location.repo_id, location.subfolder)
     if not files:
@@ -382,7 +384,17 @@ def _download_bucket_prefix(location: _HFLocation) -> Path:
         local_path = local_root / file_entry.path
         if local_path.is_file() and local_path.stat().st_size == file_entry.size:
             continue
-        _download_bucket_file(location.repo_id, file_entry, local_path)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        # Serialize concurrent downloaders of the SAME file so they don't
+        # interleave writes (e.g. a parallel eval sweep sharing one
+        # HF_HUB_CACHE, or the default bucket model pulled by several
+        # processes at once). This mirrors ``snapshot_download``'s own
+        # per-file locking, which the hand-rolled bucket path otherwise
+        # lacks. Re-check under the lock so only the first process downloads.
+        with WeakFileLock(f"{local_path}.lock"):
+            if local_path.is_file() and local_path.stat().st_size == file_entry.size:
+                continue
+            _download_bucket_file(location.repo_id, file_entry, local_path)
 
     result = (
         local_root
@@ -446,7 +458,14 @@ def _download_bucket_file(
     from huggingface_hub.utils import build_hf_headers
 
     local_path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = local_path.with_name(f"{local_path.name}.incomplete")
+    # Unique per-process temp name so two concurrent downloaders of the same
+    # file never share (and corrupt) one ``.incomplete`` scratch file; the
+    # final ``replace`` is atomic, so any observer sees either no file or a
+    # complete one. Defense in depth alongside the per-file lock in
+    # ``_download_bucket_prefix``.
+    temp_path = local_path.with_name(
+        f"{local_path.name}.{os.getpid()}.{uuid.uuid4().hex}.incomplete"
+    )
     try:
         with temp_path.open("wb") as fh:
             http_get(

--- a/marinfold/tests/document_structures/contacts_and_coordinates_v1/test_digits_and_frame.py
+++ b/marinfold/tests/document_structures/contacts_and_coordinates_v1/test_digits_and_frame.py
@@ -5,12 +5,14 @@
 
 import math
 import random
+import re
 
 import numpy as np
 import pytest
 
 from marinfold.document_structures.contacts_and_coordinates_v1.generate import (
     GenerationConfig,
+    _MAX_SUPPORTED_DEPTH,
     _apply_frame,
     _coordinate_digits,
     _random_rotation_matrix,
@@ -45,6 +47,27 @@ def test_max_depth_4_knob_reintroduces_tenths_float_safe():
     assert _xyz_tokens(205.3, 180.2, 5.7, 4, 4) == [
         "<xyz-210>", "<xyz-080>", "<xyz-505>", "<xyz-327>",
     ]
+
+
+def test_coarse_max_depth_1_and_2_yield_integer_digits():
+    # Regression: GenerationConfig validation accepts max_depth in
+    # [1, _MAX_SUPPORTED_DEPTH], but the old extraction used a float divisor
+    # (100 * 10**(max_depth - 3), a float for max_depth < 3), so every "digit"
+    # came out a float and token formatting crashed with
+    # "Unknown format code 'd' for object of type 'float'". Digits must be ints
+    # at every advertised depth, and compose into valid <xyz-NNN> tokens.
+    for value in (0.0, 5.7, 123.4, 999.0, 1e4):
+        for max_depth in (1, 2):
+            digits = _coordinate_digits(value, max_depth)
+            assert len(digits) == max_depth
+            assert all(isinstance(d, int) for d in digits), (value, max_depth, digits)
+    for depth in (1, 2):
+        toks = _xyz_tokens(205.3, 180.2, 5.7, depth, depth)
+        assert len(toks) == depth
+        assert all(re.fullmatch(r"<xyz-\d{3}>", t) for t in toks), toks
+    # The whole advertised range constructs without raising.
+    for d in range(1, _MAX_SUPPORTED_DEPTH + 1):
+        GenerationConfig(max_depth=d)
 
 
 def test_digit_extraction_clamps():

--- a/marinfold/tests/document_structures/contacts_v1/test_think.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_think.py
@@ -104,6 +104,18 @@ def test_geometric_p_one_returns_one():
     assert all(_geometric(rng, 1.0) == 1 for _ in range(10))
 
 
+def test_geometric_boundary_random_zero_stays_in_support():
+    # Regression: rng.random() == 0.0 -> u = 1 - 0 = 1.0, and
+    # ceil(log(1)/log(1-p)) == 0, which would return 0 and violate the
+    # documented support {1, 2, 3, ...}. The clamp keeps it >= 1.
+    class _ZeroRng(random.Random):
+        def random(self):  # noqa: D401 - forces the u == 1.0 boundary
+            return 0.0
+
+    assert _geometric(_ZeroRng(), 0.13) == 1
+    assert _geometric(_ZeroRng(), 0.99) == 1
+
+
 def test_geometric_mean_matches_1_over_p():
     rng = random.Random(42)
     samples = [_geometric(rng, 0.13) for _ in range(20_000)]
@@ -296,6 +308,26 @@ def test_no_contacts_still_emits_initial_run():
     # And it sits right after <begin_statements>.
     bs = toks.index("<begin_statements>")
     assert toks[bs + 1] == "<think>"
+
+
+def test_no_contacts_initial_run_never_overflows_tiny_budget():
+    """Regression: the no-contacts initial-run branch used to emit k1 <think>
+    tokens unconditionally. With a context_length that leaves no think headroom
+    (fixed == context_length), that overflowed the "never exceed context_length"
+    invariant. The clamp caps the run to the remaining budget."""
+    residues = _residues(11)  # fixed == _FRAME_TOKENS(4) + 2*11 + 2*2 == 30
+    cfg = GenerationConfig(min_seq_separation=1, think=True, think_initial_prob=1.0)
+    # No headroom at all: every gate-fired build must still fit in the budget.
+    for i in range(200):
+        res = build_document(f"AF-TINY-{i}", residues, [], context_length=30, config=cfg)
+        if res is None:
+            continue
+        assert res.num_tokens <= 30
+        assert res.document.split().count("<think>") == res.think_tokens
+    # A little headroom (2 tokens) must clamp k1 down to exactly that headroom.
+    res = build_document("AF-TINY-HR", residues, [], context_length=32, config=cfg)
+    assert res is not None and res.num_tokens <= 32
+    assert res.think_tokens <= 2
 
 
 def test_sequence_only_ignores_think():

--- a/scripts/history.py
+++ b/scripts/history.py
@@ -377,7 +377,6 @@ def _experiment_from_wandb_run(run) -> str:
     We look at config + tags + group. If none looks like ``exp<N>_<kind>_<name>``,
     fall back to ``no_experiment``.
     """
-    exp_re = re.compile(r"^exp\d+_[a-z_]+$")
     config = dict(run.config) if hasattr(run, "config") else {}
     candidates = []
     candidates.append(config.get("experiment"))
@@ -385,7 +384,11 @@ def _experiment_from_wandb_run(run) -> str:
     candidates.append(getattr(run, "group", None))
     candidates.extend(getattr(run, "tags", None) or [])
     for c in candidates:
-        if isinstance(c, str) and exp_re.match(c):
+        # Use the canonical parser (not a private regex) so this stays a single
+        # source of truth with _kind_from_wandb_run below: it accepts digits in
+        # the <name> token (e.g. exp67_models_contacts_v1_1_5b) and enforces
+        # that the second token is a real KIND.
+        if isinstance(c, str) and parse_experiment_dir_name(c) is not None:
             return c
     return "no_experiment"
 

--- a/scripts/itemize.py
+++ b/scripts/itemize.py
@@ -59,13 +59,26 @@ def scan_experiment_dirs() -> dict[int, Path]:
     exp_root = REPO_ROOT / "experiments"
     if not exp_root.is_dir():
         return out
-    for p in exp_root.iterdir():
+    # Sort so the winner on a collision is deterministic (not filesystem order).
+    for p in sorted(exp_root.iterdir()):
         if not p.is_dir():
             continue
         parsed = parse_experiment_dir_name(p.name)
         if parsed is None:
             continue
         n, _kind, _name = parsed
+        if n in out:
+            # Two dirs parse to the same issue number. The index renders one
+            # dir per issue and the orphan pass can't see the loser (its issue
+            # IS matched), so a silent overwrite would hide the drift this tool
+            # exists to surface. Warn and keep the first (sorted) dir.
+            print(
+                f"WARNING: multiple experiment dirs for issue #{n}: "
+                f"{out[n].name} and {p.name}; keeping {out[n].name}. "
+                f"Rename or remove the duplicate.",
+                file=sys.stderr,
+            )
+            continue
         out[n] = p
     return out
 

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -100,13 +100,19 @@ def render_readme(*, issue: dict, kind: str, name: str, branch: str) -> str:
     approach = extract_section(body, ["Approach"]) or "_(Outline what the experiment will do.)_"
     success = extract_section(body, ["Success criteria"]) or "_(Concrete metrics + thresholds.)_"
 
-    safe_title = issue["title"].replace('"', '\\"')
+    # Emit the title as a single-quoted YAML scalar (doubling internal single
+    # quotes). A double-quoted scalar processes backslash escapes, so a title
+    # like `Fix C:\path handling` produced an invalid `\p` escape and made the
+    # frontmatter unparseable (yaml.safe_load raised in read_frontmatter /
+    # itemize). Single-quoted scalars don't interpret backslashes, so arbitrary
+    # titles round-trip.
+    safe_title = issue["title"].replace("'", "''")
 
     out: list[str] = []
     out.append("---\n")
     out.append("marinfold_experiment:\n")
     out.append(f"  issue: {issue['number']}\n")
-    out.append(f"  title: \"{safe_title}\"\n")
+    out.append(f"  title: '{safe_title}'\n")
     out.append(f"  kind: {kind}\n")
     out.append(f"  branch: {branch}\n")
     out.append("---\n\n")
@@ -220,8 +226,15 @@ def main(argv: list[str] | None = None) -> int:
         shutil.copyfile(TEMPLATES_DIR / "build_summary.py", build_script)
 
     narrative = exp_dir / "summary_narrative.md"
-    if not narrative.exists() or args.force:
+    if not narrative.exists():
         narrative.write_text(render_narrative(issue=issue))
+    elif args.force:
+        # --force is documented (and its error message scoped) to README.md
+        # only. summary_narrative.md is a living document maintained by hand
+        # throughout the experiment and feeds plots/summary.pdf, so never
+        # clobber an existing one — that would silently destroy real work.
+        print("Kept existing summary_narrative.md (not clobbered by --force).",
+              file=sys.stderr)
 
     rel = readme.relative_to(REPO_ROOT)
     print(f"Scaffolded {rel}")


### PR DESCRIPTION
These defects were found while reviewing the codebase. Fixes are minimal and behavior-preserving on the production paths.

marinfold package:
- contacts_and_coordinates_v1/generate: `_coordinate_digits` used a float divisor (`100 * scale`) for max_depth < 3, so every extracted digit was a float and token formatting crashed with "Unknown format code 'd'" — even though GenerationConfig validation advertises max_depth in [1, 4]. Use an integer power-of-ten divisor; byte-identical for the production depths 3 and 4.
- contacts_v1/generate: `_geometric` returned 0 when `rng.random()` hit exactly 0.0 (u == 1.0 boundary), violating its documented support {1, 2, ...}. Clamp to 1; RNG stream untouched, determinism preserved.
- contacts_v1/generate: the no-contacts `<think>` initial-run branch emitted k1 tokens without a budget check, overflowing context_length for a tiny custom budget. Clamp to the remaining headroom.
- registry: hand-rolled bucket download used a fixed `.incomplete` temp name with no lock, so concurrent downloaders of the same file (e.g. a parallel eval sweep sharing HF_HUB_CACHE — and the default model is a bucket URL) could interleave writes and corrupt it. Add a per-file WeakFileLock with re-check plus a unique per-process temp name.
- contacts_v1/inference: correct `_sym_from_fwd`'s docstring — it is the rollout vote tie-break key, not the pairwise ranking score (which ranks by P(contact)).

scripts:
- history: `_experiment_from_wandb_run` used a regex that rejected any experiment name with a digit in its <name> token (the norm here, e.g. exp67_models_contacts_v1_1_5b). Use the canonical parse_experiment_dir_name so it stays consistent with _kind_from_wandb_run.
- scaffold: issue titles were written into a double-quoted YAML scalar, so a backslash (e.g. `C:\path`) produced an invalid escape and made the README frontmatter unparseable. Emit a single-quoted scalar.
- scaffold: `--force` (documented as README-scoped) also clobbered the hand-maintained summary_narrative.md living document. Never overwrite an existing one.
- itemize: `scan_experiment_dirs` silently dropped a second dir sharing an issue number (filesystem-order dependent). Iterate sorted and warn.

Adds regression tests for the coordinate-digit crash, the geometric boundary, and the think-budget overflow.