### PR TITLE
Add minimal CoreWeave inference server

### DIFF
--- a/experiments/server/README.md
+++ b/experiments/server/README.md
@@ -1,0 +1,51 @@
+# MarinFold CoreWeave inference server
+
+Minimal control-plane API for running MarinFold inference on CoreWeave. The
+notebook/client remains the control plane: it writes run configs and targets to
+GCS, calls this service to start/check runs, and reads chunked outputs from GCS.
+The service owns the data-plane work inside the deployed pod.
+
+This first increment only provides health/readiness endpoints plus bearer-token
+auth plumbing for future run endpoints.
+
+## Local development
+
+```bash
+cd experiments/server
+uv sync --extra test
+MARINFOLD_SERVER_TOKEN=test-token uv run uvicorn marinfold_server.app:app \
+  --host 127.0.0.1 --port 8080
+```
+
+Smoke test:
+
+```bash
+curl http://127.0.0.1:8080/healthz
+curl http://127.0.0.1:8080/readyz
+curl -H 'Authorization: Bearer test-token' http://127.0.0.1:8080/v1/auth-check
+```
+
+Run tests:
+
+```bash
+uv run pytest
+```
+
+## Planned API
+
+```text
+POST /v1/runs
+GET  /v1/runs/{run_id}
+POST /v1/runs/{run_id}/cancel
+```
+
+Run payloads should carry GCS paths, not protein data:
+
+```json
+{
+  "run_id": "...",
+  "config_gcs": "gs://.../config.json",
+  "targets_gcs": "gs://.../targets.parquet",
+  "output_gcs": "gs://.../runs/<run_id>/"
+}
+```

--- a/experiments/server/marinfold_server/__init__.py
+++ b/experiments/server/marinfold_server/__init__.py
@@ -1,0 +1,5 @@
+"""CoreWeave inference service for MarinFold."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/experiments/server/marinfold_server/app.py
+++ b/experiments/server/marinfold_server/app.py
@@ -1,0 +1,59 @@
+"""FastAPI entry point for the MarinFold CoreWeave inference service."""
+
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+from pydantic import BaseModel
+
+from marinfold_server.auth import require_bearer_token
+from marinfold_server.config import Settings, get_settings
+
+
+class HealthResponse(BaseModel):
+    """Health/readiness response payload."""
+
+    ok: bool
+    service: str
+    environment: str
+
+
+class AuthResponse(BaseModel):
+    """Response for the protected auth smoke-test endpoint."""
+
+    ok: bool
+    authenticated: bool
+
+
+def create_app() -> FastAPI:
+    """Create the ASGI application."""
+
+    app = FastAPI(
+        title="MarinFold inference server",
+        version="0.1.0",
+        summary="Thin control-plane API for CoreWeave-hosted MarinFold inference runs.",
+    )
+
+    @app.get("/healthz", response_model=HealthResponse)
+    def healthz(settings: Annotated[Settings, Depends(get_settings)]) -> HealthResponse:
+        return HealthResponse(
+            ok=True,
+            service=settings.service_name,
+            environment=settings.environment,
+        )
+
+    @app.get("/readyz", response_model=HealthResponse)
+    def readyz(settings: Annotated[Settings, Depends(get_settings)]) -> HealthResponse:
+        return HealthResponse(
+            ok=True,
+            service=settings.service_name,
+            environment=settings.environment,
+        )
+
+    @app.get("/v1/auth-check", response_model=AuthResponse)
+    def auth_check(_auth: Annotated[None, Depends(require_bearer_token)]) -> AuthResponse:
+        return AuthResponse(ok=True, authenticated=True)
+
+    return app
+
+
+app = create_app()

--- a/experiments/server/marinfold_server/auth.py
+++ b/experiments/server/marinfold_server/auth.py
@@ -1,0 +1,38 @@
+"""Bearer-token authentication helpers."""
+
+import secrets
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, status
+
+from marinfold_server.config import Settings, get_settings
+
+
+def _extract_bearer_token(authorization: str | None) -> str | None:
+    if authorization is None:
+        return None
+    scheme, sep, token = authorization.partition(" ")
+    if not sep or scheme.lower() != "bearer" or not token:
+        return None
+    return token
+
+
+def require_bearer_token(
+    authorization: Annotated[str | None, Header()] = None,
+    settings: Annotated[Settings, Depends(get_settings)] = None,
+) -> None:
+    """Require ``Authorization: Bearer <token>`` when a server token is set."""
+
+    expected = settings.token if settings is not None else None
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="MARINFOLD_SERVER_TOKEN is not configured",
+        )
+    supplied = _extract_bearer_token(authorization)
+    if supplied is None or not secrets.compare_digest(supplied, expected):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid bearer token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )

--- a/experiments/server/marinfold_server/config.py
+++ b/experiments/server/marinfold_server/config.py
@@ -1,0 +1,19 @@
+"""Runtime configuration for the MarinFold inference service."""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Settings populated from environment variables."""
+
+    model_config = SettingsConfigDict(env_prefix="MARINFOLD_SERVER_")
+
+    token: str | None = None
+    environment: str = "local"
+    service_name: str = "marinfold-inference-server"
+
+
+def get_settings() -> Settings:
+    """Return service settings from the current process environment."""
+
+    return Settings()

--- a/experiments/server/pod_config/README.md
+++ b/experiments/server/pod_config/README.md
@@ -1,0 +1,32 @@
+# CoreWeave pod config
+
+These manifests deploy the minimal MarinFold inference API to the CoreWeave
+cluster. The current deployment clones this public repo at startup and runs the
+server from `experiments/server`; replace the image/command with a built image
+once the service grows beyond health checks.
+
+## Deploy
+
+```bash
+export KUBECONFIG=~/.kube/CWKubeconfig_marin-gpu_US-EAST-02A
+kubectl config use-context marin-gpu_US-EAST-02A
+
+kubectl create secret generic marinfold-inference-server-token \
+  --from-literal=token="$(openssl rand -hex 32)" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl apply -f experiments/server/pod_config/deployment.yaml
+kubectl apply -f experiments/server/pod_config/service.yaml
+kubectl rollout status deployment/marinfold-inference-server
+
+kubectl port-forward svc/marinfold-inference-server 8080:8080
+curl http://127.0.0.1:8080/healthz
+curl -H "Authorization: Bearer <token>" http://127.0.0.1:8080/v1/auth-check
+```
+
+## Cleanup
+
+```bash
+kubectl delete -f experiments/server/pod_config/service.yaml
+kubectl delete -f experiments/server/pod_config/deployment.yaml
+```

--- a/experiments/server/pod_config/deployment.yaml
+++ b/experiments/server/pod_config/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marinfold-inference-server
+  labels:
+    app: marinfold-inference-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: marinfold-inference-server
+  template:
+    metadata:
+      labels:
+        app: marinfold-inference-server
+    spec:
+      containers:
+        - name: api
+          image: python:3.11-slim
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: MARINFOLD_SERVER_ENVIRONMENT
+              value: coreweave
+            - name: MARINFOLD_SERVER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: marinfold-inference-server-token
+                  key: token
+            - name: MARINFOLD_SERVER_REPO
+              value: https://github.com/Open-Athena/MarinFold.git
+            - name: MARINFOLD_SERVER_REF
+              value: main
+          command: ["/bin/sh", "-lc"]
+          args:
+            - |
+              set -eu
+              apt-get update
+              apt-get install -y --no-install-recommends git ca-certificates curl
+              rm -rf /var/lib/apt/lists/*
+              python -m pip install --no-cache-dir uv
+              git clone --depth 1 --branch "${MARINFOLD_SERVER_REF}" "${MARINFOLD_SERVER_REPO}" /workspace/MarinFold
+              cd /workspace/MarinFold/experiments/server
+              uv sync --no-dev
+              exec uv run uvicorn marinfold_server.app:app --host 0.0.0.0 --port 8080
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "500m"
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          volumeMounts:
+            - name: workspace
+              mountPath: /mnt/marinfold-workspace
+      volumes:
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: marinfold-workspace

--- a/experiments/server/pod_config/service.yaml
+++ b/experiments/server/pod_config/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: marinfold-inference-server
+  labels:
+    app: marinfold-inference-server
+spec:
+  type: ClusterIP
+  selector:
+    app: marinfold-inference-server
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/experiments/server/pyproject.toml
+++ b/experiments/server/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "marinfold-server"
+version = "0.1.0"
+description = "Minimal CoreWeave control-plane API for MarinFold inference runs"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "pydantic-settings>=2.0",
+    "uvicorn[standard]>=0.30",
+]
+
+[project.optional-dependencies]
+test = [
+    "httpx>=0.27",
+    "pytest>=8.0",
+]
+
+[tool.uv]
+package = true
+
+[tool.setuptools.packages.find]
+include = ["marinfold_server*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/experiments/server/tests/test_app.py
+++ b/experiments/server/tests/test_app.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+
+from marinfold_server.app import create_app
+
+
+def test_healthz(monkeypatch):
+    monkeypatch.setenv("MARINFOLD_SERVER_ENVIRONMENT", "test")
+    client = TestClient(create_app())
+
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert response.json()["environment"] == "test"
+
+
+def test_auth_check_requires_configured_token(monkeypatch):
+    monkeypatch.delenv("MARINFOLD_SERVER_TOKEN", raising=False)
+    client = TestClient(create_app())
+
+    response = client.get("/v1/auth-check")
+
+    assert response.status_code == 503
+
+
+def test_auth_check_accepts_bearer_token(monkeypatch):
+    monkeypatch.setenv("MARINFOLD_SERVER_TOKEN", "secret")
+    client = TestClient(create_app())
+
+    response = client.get("/v1/auth-check", headers={"Authorization": "Bearer secret"})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "authenticated": True}
+
+
+def test_auth_check_rejects_bad_token(monkeypatch):
+    monkeypatch.setenv("MARINFOLD_SERVER_TOKEN", "secret")
+    client = TestClient(create_app())
+
+    response = client.get("/v1/auth-check", headers={"Authorization": "Bearer wrong"})
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary\n- add a minimal FastAPI control-plane service under experiments/server\n- add bearer-token auth plumbing and health/readiness endpoints\n- add CoreWeave Kubernetes deployment/service manifests and usage docs\n\n## Validation\n- experiments/server/.venv/bin/python -m pytest\n- local uvicorn smoke test for /healthz and /v1/auth-check\n- deployed to CoreWeave marin-gpu_US-EAST-02A, port-forwarded service, verified /healthz, /readyz, auth success, auth failure; then cleaned up deployment/service/secret\n