### PR TITLE
inference: load tokenizer.json when tokenizer_class is unresolvable

### DIFF
--- a/marinfold/marinfold/inference/_mlx.py
+++ b/marinfold/marinfold/inference/_mlx.py
@@ -7,10 +7,12 @@ Gated by the ``[mlx]`` extra (Darwin-only wheels). Uses
 ``mlx_lm.load`` to read HF safetensors directly — no conversion step
 is required for unquantized inference.
 
-The HF tokenizer is loaded separately with
-``transformers.AutoTokenizer`` so the surfaced object is exactly the
-same ``PreTrainedTokenizerFast`` the other backends expose, rather
-than mlx-lm's ``TokenizerWrapper``.
+The HF tokenizer is loaded separately via the shared
+:func:`marinfold.inference._tokenizer.load_tokenizer` so the surfaced
+object is exactly the same ``PreTrainedTokenizerFast`` the other
+backends expose, rather than mlx-lm's ``TokenizerWrapper`` — and so
+marinfold-custom ``tokenizer_class`` exports fall back to
+``tokenizer.json`` the same way the transformers backend does.
 
 Prefix-cache strategy (what makes this fast on Apple Silicon):
 
@@ -34,7 +36,8 @@ import mlx.core as mx
 import numpy as np
 from mlx_lm import load as mlx_load
 from mlx_lm.models.cache import KVCache, make_prompt_cache
-from transformers import AutoTokenizer
+
+from marinfold.inference._tokenizer import load_tokenizer
 
 
 class MlxBackend:
@@ -57,7 +60,7 @@ class MlxBackend:
                 f"tail_batch_size must be >= 1; got {tail_batch_size}."
             )
         self._tail_batch_size = tail_batch_size
-        self._tokenizer = AutoTokenizer.from_pretrained(str(model_path))
+        self._tokenizer = load_tokenizer(model_path)
         # mlx_lm.load returns (model, tokenizer); we use mlx_lm's
         # tokenizer only as a sanity check that the path is loadable
         # and rely on the HF tokenizer above for the public surface.

--- a/marinfold/marinfold/inference/_mlx.py
+++ b/marinfold/marinfold/inference/_mlx.py
@@ -37,7 +37,7 @@ import numpy as np
 from mlx_lm import load as mlx_load
 from mlx_lm.models.cache import KVCache, make_prompt_cache
 
-from marinfold.inference._tokenizer import load_tokenizer
+from marinfold.inference._tokenizer import load_tokenizer, model_source_path
 
 
 class MlxBackend:
@@ -60,11 +60,13 @@ class MlxBackend:
                 f"tail_batch_size must be >= 1; got {tail_batch_size}."
             )
         self._tail_batch_size = tail_batch_size
-        self._tokenizer = load_tokenizer(model_path)
-        # mlx_lm.load returns (model, tokenizer); we use mlx_lm's
-        # tokenizer only as a sanity check that the path is loadable
-        # and rely on the HF tokenizer above for the public surface.
-        self._model, _ = mlx_load(str(model_path))
+        source_path = model_source_path(model_path)
+        self._tokenizer = load_tokenizer(Path(source_path))
+        # mlx_lm.load always loads both the model and its tokenizer from one
+        # directory. The source-path helper supplies a symlink overlay when
+        # the original tokenizer config needs repair, so mlx-lm does not
+        # independently hit the same unresolvable tokenizer_class.
+        self._model, _ = mlx_load(source_path)
 
     @property
     def tokenizer(self):

--- a/marinfold/marinfold/inference/_tokenizer.py
+++ b/marinfold/marinfold/inference/_tokenizer.py
@@ -1,0 +1,93 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared tokenizer loading for the inference backends.
+
+Kept torch-free so the MLX / vLLM backends can reuse it without
+pulling in the ``[transformers]`` extra's torch dependency.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from transformers import AutoTokenizer, PreTrainedTokenizerFast
+
+# Special-token / length keys we carry over from a checkpoint's
+# ``tokenizer_config.json`` when falling back to a raw
+# ``PreTrainedTokenizerFast`` (see :func:`load_tokenizer`). The
+# marinfold training export also writes bookkeeping keys — ``backend``,
+# ``is_local``, ``local_files_only``, ``tokenizer_class`` — which are
+# either meaningless to transformers or (in the case of a custom
+# ``tokenizer_class``) the very thing that breaks ``AutoTokenizer``; we
+# deliberately drop those.
+_FALLBACK_TOKENIZER_KEYS = (
+    "bos_token",
+    "eos_token",
+    "unk_token",
+    "pad_token",
+    "cls_token",
+    "sep_token",
+    "mask_token",
+    "model_max_length",
+    "clean_up_tokenization_spaces",
+)
+
+
+def load_tokenizer(model_path: Path):
+    """Load a checkpoint tokenizer, tolerating marinfold-custom exports.
+
+    ``AutoTokenizer.from_pretrained`` is tried first. Training-path
+    checkpoints (e.g. ``contacts-v1-exp120-1.5B``) declare
+    ``"tokenizer_class": "TokenizersBackend"`` in ``tokenizer_config.json``
+    — a levanter export class name ``AutoTokenizer`` can't resolve, so the
+    call raises ``ValueError: Tokenizer class TokenizersBackend does not
+    exist``. Those checkpoints do ship a valid WordLevel ``tokenizer.json``
+    though, so on any load failure we fall back to constructing a
+    ``PreTrainedTokenizerFast`` straight from ``tokenizer.json``, carrying
+    the special tokens over from the config. If there is no
+    ``tokenizer.json`` to fall back to, the original error is re-raised.
+    """
+    try:
+        return AutoTokenizer.from_pretrained(str(model_path))
+    except Exception:
+        tokenizer_file = Path(model_path) / "tokenizer.json"
+        if not tokenizer_file.exists():
+            raise
+        config: dict = {}
+        config_path = Path(model_path) / "tokenizer_config.json"
+        if config_path.exists():
+            with open(config_path) as fh:
+                config = json.load(fh)
+        kwargs = {k: config[k] for k in _FALLBACK_TOKENIZER_KEYS if k in config}
+        return PreTrainedTokenizerFast(
+            tokenizer_file=str(tokenizer_file), **kwargs
+        )
+
+
+def tokenizer_source_path(model_path: Path) -> str:
+    """Return a filesystem path a path-based loader can read the tokenizer from.
+
+    Unlike :func:`load_tokenizer`, this is for consumers that load the
+    tokenizer *themselves* from a path — notably vLLM, whose engine
+    constructs its own tokenizer internally via ``AutoTokenizer`` and so
+    can't be handed a Python tokenizer object.
+
+    If the checkpoint's own directory loads cleanly, it is returned
+    unchanged. If ``AutoTokenizer`` can't resolve it (a marinfold-custom
+    ``tokenizer_class`` such as ``"TokenizersBackend"``), a repaired
+    ``PreTrainedTokenizerFast`` copy — whose ``tokenizer_config.json``
+    declares a class ``AutoTokenizer`` understands — is written to a fresh
+    temp dir and that path is returned instead. Raises if the tokenizer
+    can't be loaded at all (no ``tokenizer.json`` to fall back to).
+    """
+    try:
+        AutoTokenizer.from_pretrained(str(model_path))
+        return str(model_path)
+    except Exception:
+        # load_tokenizer re-raises the original error when there is no
+        # tokenizer.json to fall back to, so we never write a bogus repair.
+        repaired = load_tokenizer(model_path)
+        out_dir = tempfile.mkdtemp(prefix="marinfold-tokenizer-")
+        repaired.save_pretrained(out_dir)
+        return out_dir

--- a/marinfold/marinfold/inference/_tokenizer.py
+++ b/marinfold/marinfold/inference/_tokenizer.py
@@ -91,3 +91,27 @@ def tokenizer_source_path(model_path: Path) -> str:
         out_dir = tempfile.mkdtemp(prefix="marinfold-tokenizer-")
         repaired.save_pretrained(out_dir)
         return out_dir
+
+
+def model_source_path(model_path: Path) -> str:
+    """Return a model path whose tokenizer is loadable by a combined loader.
+
+    Some consumers — notably ``mlx_lm.load`` — insist on loading the model
+    and tokenizer from the same directory. If the checkpoint tokenizer loads
+    normally, return ``model_path`` unchanged. Otherwise, create the repaired
+    tokenizer directory from :func:`tokenizer_source_path` and symlink every
+    missing model artifact into it. This keeps large weights in place while
+    presenting the combined loader with one complete, loadable directory.
+    """
+    source_path = Path(tokenizer_source_path(model_path))
+    if source_path == model_path:
+        return str(model_path)
+
+    for model_entry in model_path.iterdir():
+        destination = source_path / model_entry.name
+        if destination.exists() or destination.is_symlink():
+            continue
+        destination.symlink_to(
+            model_entry.resolve(), target_is_directory=model_entry.is_dir()
+        )
+    return str(source_path)

--- a/marinfold/marinfold/inference/_transformers.py
+++ b/marinfold/marinfold/inference/_transformers.py
@@ -26,8 +26,12 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM
 from transformers.cache_utils import DynamicCache
+
+# Re-exported for backward compatibility: the shared loader used to live
+# here. Tests and callers may still import it from this module.
+from marinfold.inference._tokenizer import load_tokenizer as _load_tokenizer
 
 
 def _best_device() -> str:
@@ -89,7 +93,7 @@ class TransformersBackend:
         self._device = device or _best_device()
         self._tail_batch_size = tail_batch_size
         torch_dtype = _resolve_dtype(dtype)
-        self._tokenizer = AutoTokenizer.from_pretrained(str(model_path))
+        self._tokenizer = _load_tokenizer(model_path)
         self._model = (
             AutoModelForCausalLM.from_pretrained(str(model_path), dtype=torch_dtype)
             .to(self._device)

--- a/marinfold/marinfold/inference/_vllm.py
+++ b/marinfold/marinfold/inference/_vllm.py
@@ -25,6 +25,8 @@ from pathlib import Path
 import numpy as np
 from vllm import LLM, SamplingParams, TokensPrompt
 
+from marinfold.inference._tokenizer import tokenizer_source_path
+
 
 class VllmBackend:
     """vLLM-backed implementation of the :class:`Backend` protocol."""
@@ -44,8 +46,15 @@ class VllmBackend:
             )
         self._tail_batch_size = tail_batch_size
         self._top_k_logprobs = top_k_logprobs
+        # vLLM builds its tokenizer internally from a path via
+        # AutoTokenizer, which chokes on marinfold training-export
+        # checkpoints (tokenizer_class == "TokenizersBackend"). Point it at
+        # a repaired tokenizer dir when the checkpoint's own config is
+        # unresolvable; otherwise this returns model_path unchanged.
+        tokenizer_path = tokenizer_source_path(model_path)
         self._llm = LLM(
             model=str(model_path),
+            tokenizer=tokenizer_path,
             dtype=dtype,
             gpu_memory_utilization=gpu_memory_utilization,
             enforce_eager=True,

--- a/marinfold/tests/test_tokenizer.py
+++ b/marinfold/tests/test_tokenizer.py
@@ -1,0 +1,114 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared, torch-free tokenizer loader used by every backend."""
+
+import json
+
+import pytest
+
+# transformers is a base dependency, but guard so the suite degrades
+# gracefully if it is ever made optional.
+pytest.importorskip("transformers")
+pytest.importorskip("tokenizers")
+
+from transformers import (  # noqa: E402
+    AutoTokenizer,
+    PreTrainedTokenizerFast,
+)
+
+from marinfold.inference._tokenizer import (  # noqa: E402
+    load_tokenizer,
+    tokenizer_source_path,
+)
+
+
+def _write_checkpoint_tokenizer(directory):
+    """Save a minimal WordLevel HF tokenizer the way a checkpoint ships it."""
+    from tokenizers import Tokenizer, models
+
+    inner = Tokenizer(
+        models.WordLevel(
+            vocab={"<pad>": 0, "<eos>": 1, "<UNK>": 2, "a": 3},
+            unk_token="<UNK>",
+        )
+    )
+    PreTrainedTokenizerFast(
+        tokenizer_object=inner,
+        pad_token="<pad>",
+        eos_token="<eos>",
+        unk_token="<UNK>",
+    ).save_pretrained(str(directory))
+    return directory
+
+
+def test_load_tokenizer_uses_autotokenizer_for_standard_config(tmp_path) -> None:
+    tok = load_tokenizer(_write_checkpoint_tokenizer(tmp_path))
+    assert isinstance(tok, PreTrainedTokenizerFast)
+    assert (tok.pad_token, tok.eos_token, tok.unk_token) == (
+        "<pad>",
+        "<eos>",
+        "<UNK>",
+    )
+
+
+def test_load_tokenizer_falls_back_on_marinfold_custom_class(tmp_path) -> None:
+    """Training-export checkpoints label the tokenizer ``TokenizersBackend``,
+    which ``AutoTokenizer`` can't resolve; the loader must fall back to the
+    shipped ``tokenizer.json``."""
+    directory = _write_checkpoint_tokenizer(tmp_path)
+    config_path = directory / "tokenizer_config.json"
+    config = json.loads(config_path.read_text())
+    config["tokenizer_class"] = "TokenizersBackend"
+    config_path.write_text(json.dumps(config))
+
+    # Precondition: vanilla AutoTokenizer really does choke on this checkpoint.
+    with pytest.raises(ValueError):
+        AutoTokenizer.from_pretrained(str(directory))
+
+    tok = load_tokenizer(directory)
+    assert isinstance(tok, PreTrainedTokenizerFast)
+    assert (tok.pad_token, tok.eos_token, tok.unk_token) == (
+        "<pad>",
+        "<eos>",
+        "<UNK>",
+    )
+    ids = tok.encode("<eos>")
+    assert tok.decode(ids) == "<eos>"
+
+
+def test_load_tokenizer_reraises_without_tokenizer_json(tmp_path) -> None:
+    """With no ``tokenizer.json`` to fall back to, the original load error
+    must surface rather than a confusing secondary failure."""
+    (tmp_path / "tokenizer_config.json").write_text(
+        json.dumps({"tokenizer_class": "TokenizersBackend"})
+    )
+    with pytest.raises(Exception):
+        load_tokenizer(tmp_path)
+
+
+def test_tokenizer_source_path_passthrough_for_standard_config(tmp_path) -> None:
+    """A checkpoint AutoTokenizer can load is handed to path-based loaders
+    (e.g. vLLM) unchanged — no temp-dir repair."""
+    directory = _write_checkpoint_tokenizer(tmp_path)
+    assert tokenizer_source_path(directory) == str(directory)
+
+
+def test_tokenizer_source_path_repairs_marinfold_custom_class(tmp_path) -> None:
+    """A checkpoint AutoTokenizer *can't* load is repaired into a fresh dir
+    that AutoTokenizer then loads cleanly (this is what vLLM consumes)."""
+    directory = _write_checkpoint_tokenizer(tmp_path)
+    config_path = directory / "tokenizer_config.json"
+    config = json.loads(config_path.read_text())
+    config["tokenizer_class"] = "TokenizersBackend"
+    config_path.write_text(json.dumps(config))
+
+    repaired = tokenizer_source_path(directory)
+    assert repaired != str(directory)
+    # The repaired dir is loadable by the very API vLLM uses internally.
+    tok = AutoTokenizer.from_pretrained(repaired)
+    assert (tok.pad_token, tok.eos_token, tok.unk_token) == (
+        "<pad>",
+        "<eos>",
+        "<UNK>",
+    )

--- a/marinfold/tests/test_tokenizer.py
+++ b/marinfold/tests/test_tokenizer.py
@@ -4,6 +4,7 @@
 """Tests for the shared, torch-free tokenizer loader used by every backend."""
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -19,6 +20,7 @@ from transformers import (  # noqa: E402
 
 from marinfold.inference._tokenizer import (  # noqa: E402
     load_tokenizer,
+    model_source_path,
     tokenizer_source_path,
 )
 
@@ -42,6 +44,13 @@ def _write_checkpoint_tokenizer(directory):
     return directory
 
 
+def _set_unresolvable_tokenizer_class(directory) -> None:
+    config_path = directory / "tokenizer_config.json"
+    config = json.loads(config_path.read_text())
+    config["tokenizer_class"] = "TokenizersBackend"
+    config_path.write_text(json.dumps(config))
+
+
 def test_load_tokenizer_uses_autotokenizer_for_standard_config(tmp_path) -> None:
     tok = load_tokenizer(_write_checkpoint_tokenizer(tmp_path))
     assert isinstance(tok, PreTrainedTokenizerFast)
@@ -57,10 +66,7 @@ def test_load_tokenizer_falls_back_on_marinfold_custom_class(tmp_path) -> None:
     which ``AutoTokenizer`` can't resolve; the loader must fall back to the
     shipped ``tokenizer.json``."""
     directory = _write_checkpoint_tokenizer(tmp_path)
-    config_path = directory / "tokenizer_config.json"
-    config = json.loads(config_path.read_text())
-    config["tokenizer_class"] = "TokenizersBackend"
-    config_path.write_text(json.dumps(config))
+    _set_unresolvable_tokenizer_class(directory)
 
     # Precondition: vanilla AutoTokenizer really does choke on this checkpoint.
     with pytest.raises(ValueError):
@@ -98,10 +104,7 @@ def test_tokenizer_source_path_repairs_marinfold_custom_class(tmp_path) -> None:
     """A checkpoint AutoTokenizer *can't* load is repaired into a fresh dir
     that AutoTokenizer then loads cleanly (this is what vLLM consumes)."""
     directory = _write_checkpoint_tokenizer(tmp_path)
-    config_path = directory / "tokenizer_config.json"
-    config = json.loads(config_path.read_text())
-    config["tokenizer_class"] = "TokenizersBackend"
-    config_path.write_text(json.dumps(config))
+    _set_unresolvable_tokenizer_class(directory)
 
     repaired = tokenizer_source_path(directory)
     assert repaired != str(directory)
@@ -112,3 +115,39 @@ def test_tokenizer_source_path_repairs_marinfold_custom_class(tmp_path) -> None:
         "<eos>",
         "<UNK>",
     )
+
+
+def test_model_source_path_repairs_tokenizer_and_preserves_model_files(
+    tmp_path,
+) -> None:
+    """Combined loaders get repaired tokenizer files plus original weights."""
+    directory = _write_checkpoint_tokenizer(tmp_path)
+    config_path = directory / "config.json"
+    weights_path = directory / "model.safetensors"
+    config_path.write_text('{"model_type": "llama"}')
+    weights_path.write_bytes(b"model weights stay in place")
+    _set_unresolvable_tokenizer_class(directory)
+
+    repaired = Path(model_source_path(directory))
+
+    assert repaired != directory
+    assert (repaired / "config.json").is_symlink()
+    assert (repaired / "model.safetensors").is_symlink()
+    assert (repaired / "config.json").read_text() == config_path.read_text()
+    assert (repaired / "model.safetensors").read_bytes() == weights_path.read_bytes()
+    assert AutoTokenizer.from_pretrained(repaired).unk_token == "<UNK>"
+    original_config = json.loads((directory / "tokenizer_config.json").read_text())
+    assert original_config["tokenizer_class"] == "TokenizersBackend"
+
+
+def test_mlx_tokenizer_loader_accepts_repaired_model_source(tmp_path) -> None:
+    """mlx-lm's combined-loader tokenizer step accepts the repaired overlay."""
+    mlx_utils = pytest.importorskip("mlx_lm.utils")
+    directory = _write_checkpoint_tokenizer(tmp_path)
+    (directory / "config.json").write_text('{"model_type": "llama"}')
+    _set_unresolvable_tokenizer_class(directory)
+
+    repaired = Path(model_source_path(directory))
+    tok = mlx_utils.load_tokenizer(repaired)
+
+    assert tok.encode("a", add_special_tokens=False) == [3]

--- a/marinfold/tests/test_transformers.py
+++ b/marinfold/tests/test_transformers.py
@@ -20,3 +20,12 @@ def test_shared_backend_default_dtype_stays_safe_for_mps_models() -> None:
         "device": None,
         "tail_batch_size": 64,
     }
+
+
+def test_transformers_reexports_shared_tokenizer_loader() -> None:
+    """The backend still exposes ``_load_tokenizer`` for existing callers,
+    now aliased to the shared implementation."""
+    from marinfold.inference._tokenizer import load_tokenizer
+    from marinfold.inference._transformers import _load_tokenizer
+
+    assert _load_tokenizer is load_tokenizer


### PR DESCRIPTION
## Problem

The three inference backends fail to load training-path checkpoints (e.g. `contacts-v1-exp120-1.5B`). Their `tokenizer_config.json` declares `"tokenizer_class": "TokenizersBackend"` — a **levanter** export class name (written by exp120's `export_lm_to_hf(save_tokenizer=True)`, not defined in this repo) that transformers' `AutoTokenizer` can't resolve:

```
ValueError: Tokenizer class TokenizersBackend does not exist or is not currently imported.
```

The checkpoints do ship a valid WordLevel `tokenizer.json`. exp159's `run_pilot.py` worked around this with an on-disk `_fix_tokenizer_config` relabel after every `resolve_model`; the exp89/eval and #160 training-eval paths would hit the same wall.

Chose **option (a)** (robust for already-published checkpoints) over fixing the export — the bad label is baked into checkpoints already in the bucket, and the class name comes from levanter, not this repo.

## Fix

New shared, **torch-free** module `marinfold/inference/_tokenizer.py`:

- **`load_tokenizer(model_path)`** — tries `AutoTokenizer`, and on any failure falls back to `PreTrainedTokenizerFast(tokenizer_file=.../tokenizer.json, ...)`, carrying the special tokens over from the config (a `_FALLBACK_TOKENIZER_KEYS` whitelist; the levanter bookkeeping keys `backend`/`is_local`/`local_files_only`/`tokenizer_class` are dropped). Re-raises the original error if there's no `tokenizer.json` to fall back to.
- **`tokenizer_source_path(model_path)`** — returns a filesystem path a *path-based* loader (vLLM) can read: the model dir unchanged when it loads cleanly, or a repaired `PreTrainedTokenizerFast` copy in a temp dir when the config is unresolvable.

All three backends wired to it:

| Backend | Loads tokenizer via | Fix |
|---|---|---|
| transformers | `load_tokenizer` (object) | fallback |
| mlx | `load_tokenizer` (object) | fallback |
| vllm | vLLM-internal, from a **path** | `tokenizer=tokenizer_source_path(...)`, `model=` stays on weights |

vLLM needed the separate treatment because it builds its tokenizer internally from a path (not from an object we control), so it hit the same bug during `LLM(...)` construction — `trust_remote_code=True` doesn't help since `TokenizersBackend` has no module/`auto_map` to import.

Supersedes exp159's `_fix_tokenizer_config` on-disk workaround.

## Verification

- **End-to-end on the real `contacts-v1-exp120-1.5B`** (which genuinely ships `tokenizer_class == "TokenizersBackend"`) via the transformers backend on CPU: tokenizer resolves to `PreTrainedTokenizerFast` (vocab 2845, pad/eos/unk = `<pad>`/`<eos>`/`<UNK>`), and a forward pass returns valid probabilities. Confirmed the original bug reproduces first with vanilla `AutoTokenizer`.
- **8 tests pass** — `test_tokenizer.py` (torch-free: fallback paths + vLLM repaired-path helper) and `test_transformers.py`.
- All four inference modules compile.

### Caveats
- The **mlx** and **vllm** engines are not runtime-tested here (mlx is Darwin-only; vllm is TPU/iris-only and not installed; the box's GPU driver is also too old for the env's torch). Their fixes are exercised by the torch-free helper tests + static compile. The vLLM path rests on `LLM(model=..., tokenizer=<dir>)` loading the tokenizer from `tokenizer=` — a documented param, but worth a sanity check on the next iris run.
- The broken-checkpoint vLLM path leaves a `mkdtemp` dir for the process lifetime (one per backend instance — negligible for one-run-per-process usage). Can add explicit cleanup if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)