### PR TITLE
Zack/greedy contact set loss

### DIFF
--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/README.md
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/README.md
@@ -39,6 +39,14 @@ For CoreWeave/Iris runs, defaults are:
 - data globs: `s3://marin-us-east-02a/MarinFold/data/document_structures/contacts_v1/{train,val}/*.parquet`
 - optimizer LR: `EXP156_LEARNING_RATE` if set, otherwise `3.1623e-3`
 - optional durable GPU telemetry: `EXP156_ENABLE_GPU_TELEMETRY=1`
+- tokenized-cache mirror: set both cache roots below to adopt the validated exp67 caches directly, rather than rebuilding from parquet:
+
+```bash
+EXP156_TOKENIZED_TRAIN_CACHE=s3://marin-us-east-02a/marin/protein-structure/MarinFold/exp156_contacts_v1_greedy_set_loss/tokenized/contacts-v1-663ba6
+EXP156_TOKENIZED_VAL_CACHE=s3://marin-us-east-02a/marin/protein-structure/MarinFold/exp156_contacts_v1_greedy_set_loss/tokenized/contacts-v1-val-92827b
+```
+
+The two variables must be set together. `train.py` adopts these as typed `TokenizedCache` artifacts, so no raw-parquet tokenization job is scheduled.
 
 Example smoke launch:
 

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/README.md
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/README.md
@@ -20,16 +20,27 @@ A greedy hard/Viterbi contact-set loss will let the model learn easy contacts fi
 
 ## Approach
 
-Prototype a contacts-v1-specific greedy set loss and a custom Levanter training script that swaps the standard next-token CE for the new objective. Start with a smoke-sized run before any full-scale training.
+This experiment adds a contacts-v1-specific greedy set loss and a custom Levanter training path. The same launcher can run two arms:
 
-For CoreWeave/Iris smoke runs, `train.py` defaults to:
+- `EXP156_LOSS_KIND=next-token`: stock Levanter autoregressive CE baseline.
+- `EXP156_LOSS_KIND=greedy-set`: custom `Trainer` loop that parses the contacts-v1 target block and greedily matches each prediction slot against any remaining true contact pair, including either pair orientation.
+
+The greedy arm now trains inside the jitted Levanter loop; it is no longer just a host-side smoke prototype. It also installs validation hooks for:
+
+- `eval/<val-name>/greedy_set/loss`
+- `eval/<val-name>/next_token/loss`, unless `EXP156_ENABLE_GREEDY_NEXT_TOKEN_EVAL=0`
+
+The next-token validation hook is useful on single-device runs, but currently disabled for greedy multi-GPU runs because Levanter's fused next-token CE path can hit an axis-size mismatch when evaluating a greedy-trained model on an 8-way local mesh.
+
+For CoreWeave/Iris runs, defaults are:
 
 - output prefix: `s3://marin-us-east-02a/marin/protein-structure/MarinFold/exp156_contacts_v1_greedy_set_loss/`
-- resources: `ResourceConfig.with_gpu("H100", count=1, cpu=16, ram="128g", disk="200g")`
 - warm start: `contacts-v1-exp120-1.5B` HF export, staged locally on the worker before Levanter init
 - data globs: `s3://marin-us-east-02a/MarinFold/data/document_structures/contacts_v1/{train,val}/*.parquet`
+- optimizer LR: `EXP156_LEARNING_RATE` if set, otherwise `3.1623e-3`
+- optional durable GPU telemetry: `EXP156_ENABLE_GPU_TELEMETRY=1`
 
-The CoreWeave S3 mirror was verified with a temporary pod in namespace `iris`: train has 2067 shards, val has 22 shards. If using a different mirror, launch with explicit overrides, e.g.:
+Example smoke launch:
 
 ```bash
 EXP156_ACCELERATOR=gpu \
@@ -37,28 +48,50 @@ EXP156_BASE_PREFIX=s3://marin-us-east-02a/marin/protein-structure/MarinFold \
 EXP156_TRAIN_GLOB='s3://.../contacts-v1/train/*.parquet' \
 EXP156_VAL_GLOB='s3://.../contacts-v1/val/*.parquet' \
 EXP156_INITIALIZE_FROM_HF=contacts-v1-exp120-1.5B \
-EXP156_STEPS=1 \
-EXP156_TRAIN_BATCH_SIZE=1 \
+EXP156_LOSS_KIND=greedy-set \
+EXP156_STEPS=75 \
+EXP156_STEPS_PER_EVAL=50 \
+EXP156_MAX_EVAL_BATCHES=16 \
+EXP156_TRAIN_BATCH_SIZE=16 \
 python experiments/exp156_models_contacts_v1_greedy_set_loss/train.py --run
 ```
 
-Loss selection:
+## Results so far
 
-- `EXP156_LOSS_KIND=next-token` runs stock Levanter autoregressive CE with the same data/resources/warm-start. This is the baseline arm.
-- `EXP156_LOSS_KIND=greedy-set` is the target experimental arm, but the full JAX/Haliax `Trainer` loss is still being wired. The smoke/prototype loss works on real logits; the remaining work is to make the hard assignment and selected-token gather run inside Levanter's jitted training step.
+### H100 single-GPU short runs
 
-Current caveat: the baseline config can launch; the greedy training arm is intentionally blocked until the JAX/Haliax loss replaces the current host-side prototype.
+A 75-step greedy-set rerun with both validation hooks succeeded:
+
+- step 50: greedy-set val loss `5.499`; next-token CE val loss `5.545`
+- final step 74: greedy-set val loss `5.393`; next-token CE val loss `5.419`
+
+Earlier 300-step stock next-token H100 run reached final next-token eval loss `4.19192`, so the short greedy run is not yet a fair same-step comparison.
+
+### GB200 4-GPU runs
+
+The stock next-token 4×GB200 run completed 2000 steps and exported `step-1999`:
+
+- final next-token eval loss: `5.516`
+
+The first greedy 4×GB200 run failed during its auxiliary next-token validation hook with a fused CE axis mismatch. The rerun disabled that auxiliary hook and completed 2000 steps:
+
+- final greedy-set validation loss: `5.674`
+
+Both high-LR 4×GB200 runs showed train loss collapsing near zero while validation losses became noisy/worse, consistent with overfitting or an overly aggressive learning rate on this smoke-sized cache. Follow-up 8×H100 runs are using a lower LR (`3e-4`).
+
+## Current caveats
+
+- Multi-GPU greedy runs currently report greedy-set validation only; next-token CE validation is disabled with `EXP156_ENABLE_GREEDY_NEXT_TOKEN_EVAL=0` until the CE eval path avoids the fused-kernel axis mismatch.
+- The runs above used small cached datasets and short schedules; they are signal-gathering runs, not final model-quality comparisons.
+- W&B is intentionally offline unless credentials are available, so logs and telemetry should be read from Iris/S3 artifacts.
 
 ## Success criteria
 
 - Custom loss target-selection logic is unit tested on toy contact sets.
 - Custom training entrypoint can lower/build a Marin/Iris training job.
-- A tiny smoke run starts and reports finite loss.
-
-## Results
-
-_(Fill in after the run completes.)_
+- Greedy and next-token arms both produce finite train losses and validation metrics.
+- Durable GPU telemetry is written for CoreWeave GPU runs.
 
 ## Conclusion
 
-_(Fill in after results are in.)_
+The greedy-set loss is trainable inside Levanter and can be evaluated directly with a greedy-set validation loss. Early results do not show a clear quality win yet; the next useful comparison is a same-hardware, lower-LR, longer 8×H100 run against the stock next-token baseline.

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/README.md
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/README.md
@@ -1,0 +1,64 @@
+---
+marinfold_experiment:
+  issue: 156
+  title: 'exp: train contacts-v1 with greedy latent contact-set loss'
+  kind: models
+  branch: zack/greedy-contact-set-loss
+---
+
+# exp: train contacts-v1 with greedy latent contact-set loss
+
+**Issue:** [#156](https://github.com/Open-Athena/MarinFold/issues/156) · **Kind:** `models` · **Branch:** `zack/greedy-contact-set-loss`
+
+## Question
+
+Can a contacts-v1 model train more data-efficiently if the loss treats contact-list ordering and pair orientation as latent, letting the model emit any remaining contact pair at each slot?
+
+## Hypothesis
+
+A greedy hard/Viterbi contact-set loss will let the model learn easy contacts first and use them as context for harder contacts, reducing wasted loss on arbitrary serialization order.
+
+## Approach
+
+Prototype a contacts-v1-specific greedy set loss and a custom Levanter training script that swaps the standard next-token CE for the new objective. Start with a smoke-sized run before any full-scale training.
+
+For CoreWeave/Iris smoke runs, `train.py` defaults to:
+
+- output prefix: `s3://marin-us-east-02a/marin/protein-structure/MarinFold/exp156_contacts_v1_greedy_set_loss/`
+- resources: `ResourceConfig.with_gpu("H100", count=1, cpu=16, ram="128g", disk="200g")`
+- warm start: `contacts-v1-exp120-1.5B` HF export, staged locally on the worker before Levanter init
+- data globs: `s3://marin-us-east-02a/MarinFold/data/document_structures/contacts_v1/{train,val}/*.parquet`
+
+The CoreWeave S3 mirror was verified with a temporary pod in namespace `iris`: train has 2067 shards, val has 22 shards. If using a different mirror, launch with explicit overrides, e.g.:
+
+```bash
+EXP156_ACCELERATOR=gpu \
+EXP156_BASE_PREFIX=s3://marin-us-east-02a/marin/protein-structure/MarinFold \
+EXP156_TRAIN_GLOB='s3://.../contacts-v1/train/*.parquet' \
+EXP156_VAL_GLOB='s3://.../contacts-v1/val/*.parquet' \
+EXP156_INITIALIZE_FROM_HF=contacts-v1-exp120-1.5B \
+EXP156_STEPS=1 \
+EXP156_TRAIN_BATCH_SIZE=1 \
+python experiments/exp156_models_contacts_v1_greedy_set_loss/train.py --run
+```
+
+Loss selection:
+
+- `EXP156_LOSS_KIND=next-token` runs stock Levanter autoregressive CE with the same data/resources/warm-start. This is the baseline arm.
+- `EXP156_LOSS_KIND=greedy-set` is the target experimental arm, but the full JAX/Haliax `Trainer` loss is still being wired. The smoke/prototype loss works on real logits; the remaining work is to make the hard assignment and selected-token gather run inside Levanter's jitted training step.
+
+Current caveat: the baseline config can launch; the greedy training arm is intentionally blocked until the JAX/Haliax loss replaces the current host-side prototype.
+
+## Success criteria
+
+- Custom loss target-selection logic is unit tested on toy contact sets.
+- Custom training entrypoint can lower/build a Marin/Iris training job.
+- A tiny smoke run starts and reports finite loss.
+
+## Results
+
+_(Fill in after the run completes.)_
+
+## Conclusion
+
+_(Fill in after results are in.)_

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/build_summary.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/build_summary.py
@@ -1,0 +1,258 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build ``plots/summary.pdf`` — this experiment's living presentation.
+
+Run from the experiment dir::
+
+    uv run python build_summary.py    # if the experiment has a pyproject
+    python build_summary.py           # otherwise (pure-analysis dirs)
+
+Contract (see ``experiments/AGENTS.md`` for the full story):
+
+- Narrative section first: sourced from ``summary_narrative.md`` —
+  one ``## `` heading per slide, body text below it. Edit this as
+  the experiment progresses; it reflects what we're doing, why, and
+  the current state of the results.
+- Plot appendix last: auto-discovered from ``plots/*.{png,jpg,jpeg}``.
+  Each plot's caption + generating script + args come from a
+  sidecar ``plots/<plot>.<ext>.meta.json`` written by the plotting
+  script via :func:`save_plot_with_meta` below.
+- Plots without a sidecar still appear, with a placeholder caption
+  nudging you to wire ``save_plot_with_meta`` in.
+
+Regeneration is meant to be fast: no analysis is rerun, only PNGs
+and text are assembled. Build time scales linearly with slide count.
+"""
+
+import json
+import re
+import sys
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+
+# ---------------------------------------------------------------------------
+# Helper for plotting scripts to call when they save a plot.
+# Importable without pulling in matplotlib (those imports are lazy in main()).
+# ---------------------------------------------------------------------------
+
+def save_plot_with_meta(
+    fig,
+    path: str | Path,
+    *,
+    caption: str,
+    script: str | None = None,
+    args: Sequence[str] | None = None,
+    **savefig_kwargs,
+) -> Path:
+    """Save ``fig`` to ``path`` plus a ``<path>.meta.json`` sidecar.
+
+    The sidecar carries the generating script's name, its argv, and a
+    human-readable caption. ``build_summary.py`` reads these when
+    assembling the slide appendix so the PDF can print, in small text
+    on each plot page, exactly how to rerun the script.
+
+    Defaults: ``script`` = ``sys.argv[0]``, ``args`` = ``sys.argv[1:]``.
+    Any extra kwargs (``dpi``, ``transparent``, ...) pass through to
+    ``fig.savefig``. ``bbox_inches="tight"`` is the default unless you
+    override it.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    savefig_kwargs.setdefault("bbox_inches", "tight")
+    fig.savefig(path, **savefig_kwargs)
+
+    script = script if script is not None else Path(sys.argv[0]).name
+    args = list(args) if args is not None else list(sys.argv[1:])
+
+    sidecar = path.with_suffix(path.suffix + ".meta.json")
+    sidecar.write_text(json.dumps(
+        {"script": script, "args": args, "caption": caption},
+        indent=2,
+    ))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Module-level config.
+# ---------------------------------------------------------------------------
+
+HERE = Path(__file__).resolve().parent
+PLOTS_DIR = HERE / "plots"
+NARRATIVE_PATH = HERE / "summary_narrative.md"
+OUTPUT_PATH = PLOTS_DIR / "summary.pdf"
+
+# Letter landscape, in inches.
+SLIDE_W, SLIDE_H = 13.33, 7.5
+
+PLOT_EXTENSIONS = (".png", ".jpg", ".jpeg")
+
+
+# ---------------------------------------------------------------------------
+# Narrative parsing.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Slide:
+    title: str
+    body: str
+
+
+def parse_narrative(path: Path) -> list[Slide]:
+    if not path.exists():
+        return [Slide(
+            title="(narrative missing)",
+            body=(
+                f"Create `{path.name}` in the experiment dir.\n\n"
+                "One `## ` heading per slide. Keep it updated as the experiment progresses."
+            ),
+        )]
+    text = path.read_text()
+    slides: list[Slide] = []
+    current_title: str | None = None
+    buf: list[str] = []
+    for line in text.splitlines():
+        m = re.match(r"^##\s+(.*)$", line)
+        if m:
+            if current_title is not None:
+                slides.append(Slide(title=current_title, body="\n".join(buf).strip()))
+            current_title = m.group(1).strip()
+            buf = []
+        elif current_title is not None:
+            buf.append(line)
+    if current_title is not None:
+        slides.append(Slide(title=current_title, body="\n".join(buf).strip()))
+    if not slides:
+        return [Slide(
+            title="(empty narrative)",
+            body=f"Add `## ` headings to `{path.name}`.",
+        )]
+    return slides
+
+
+# ---------------------------------------------------------------------------
+# Plot discovery.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PlotEntry:
+    path: Path
+    caption: str
+    script: str
+    args: list[str] = field(default_factory=list)
+
+    @property
+    def invocation(self) -> str:
+        if not self.args:
+            return self.script
+        return self.script + " " + " ".join(self.args)
+
+
+def load_plots(plots_dir: Path) -> list[PlotEntry]:
+    if not plots_dir.exists():
+        return []
+    paths: list[Path] = [
+        p for p in plots_dir.iterdir()
+        if p.suffix.lower() in PLOT_EXTENSIONS
+    ]
+    paths.sort(key=lambda p: p.name)
+
+    entries: list[PlotEntry] = []
+    for img in paths:
+        meta_path = img.with_suffix(img.suffix + ".meta.json")
+        if meta_path.exists():
+            meta = json.loads(meta_path.read_text())
+            caption = str(meta.get("caption", ""))
+            script = str(meta.get("script", "?"))
+            args = [str(a) for a in meta.get("args", [])]
+        else:
+            caption = (
+                "(metadata missing — call `save_plot_with_meta(...)` in "
+                "the generating script; see build_summary.py)"
+            )
+            script = "?"
+            args = []
+        entries.append(PlotEntry(path=img, caption=caption, script=script, args=args))
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# PDF rendering. matplotlib is imported lazily inside main() so that
+# importers of `save_plot_with_meta` don't pay the matplotlib startup cost.
+# ---------------------------------------------------------------------------
+
+def _new_slide(plt):
+    fig = plt.figure(figsize=(SLIDE_W, SLIDE_H))
+    fig.patch.set_facecolor("white")
+    return fig
+
+
+def render_text_slide(plt, slide: Slide):
+    fig = _new_slide(plt)
+    fig.text(0.05, 0.92, slide.title, fontsize=26, fontweight="bold", va="top")
+
+    paragraphs = [p.strip() for p in (slide.body or "").split("\n\n") if p.strip()]
+    wrapped = "\n\n".join(textwrap.fill(p, width=90) for p in paragraphs)
+    fig.text(0.05, 0.82, wrapped, fontsize=14, va="top")
+    return fig
+
+
+def render_plot_slide(plt, mpimg, entry: PlotEntry):
+    fig = _new_slide(plt)
+    fig.text(0.05, 0.94, entry.path.name, fontsize=18, fontweight="bold", va="top")
+    if entry.caption:
+        fig.text(
+            0.05, 0.88,
+            textwrap.fill(entry.caption, width=130),
+            fontsize=11, va="top",
+        )
+
+    ax = fig.add_axes([0.06, 0.10, 0.88, 0.74])
+    ax.set_axis_off()
+    img = mpimg.imread(entry.path)
+    ax.imshow(img)
+
+    fig.text(
+        0.05, 0.04,
+        f"$ {entry.invocation}",
+        fontsize=8, family="monospace", color="#555",
+    )
+    return fig
+
+
+def main() -> int:
+    # Lazy imports so `from build_summary import save_plot_with_meta`
+    # stays cheap for plotting scripts.
+    import matplotlib.image as mpimg
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+
+    narrative_slides = parse_narrative(NARRATIVE_PATH)
+    plot_entries = load_plots(PLOTS_DIR)
+
+    PLOTS_DIR.mkdir(exist_ok=True)
+    with PdfPages(OUTPUT_PATH) as pdf:
+        for slide in narrative_slides:
+            fig = render_text_slide(plt, slide)
+            pdf.savefig(fig)
+            plt.close(fig)
+        for entry in plot_entries:
+            fig = render_plot_slide(plt, mpimg, entry)
+            pdf.savefig(fig)
+            plt.close(fig)
+
+    try:
+        rel = OUTPUT_PATH.relative_to(HERE.parent)
+    except ValueError:
+        rel = OUTPUT_PATH
+    print(f"Wrote {rel}")
+    print(f"  Narrative slides: {len(narrative_slides)}")
+    print(f"  Plot slides:      {len(plot_entries)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/copy_token_caches.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/copy_token_caches.py
@@ -1,0 +1,167 @@
+"""Resumable exp156 contacts-v1 token-cache mirror from GCS to CoreWeave S3.
+
+Run inside the dedicated CoreWeave copy Pod. The Pod mounts a short-lived GCS
+reader credential at ``GOOGLE_APPLICATION_CREDENTIALS`` and inherits the
+cluster's existing CoreWeave S3 credentials through ``iris-task-env``. It
+copies cache completion markers last, so a marker at the destination means its
+entire cache root was copied successfully.
+"""
+
+import argparse
+import logging
+import os
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+
+import gcsfs
+import s3fs
+
+logger = logging.getLogger(__name__)
+
+CHUNK_BYTES = 8 * 1024 * 1024
+EXECUTOR_STATUS_FILENAME = ".executor_status"
+
+
+@dataclass(frozen=True)
+class CopyEntry:
+    """One immutable source object and its relative path under a cache root."""
+
+    relative_path: str
+    source_size: int
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse cache-root pairs and copy parallelism."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cache",
+        action="append",
+        nargs=2,
+        metavar=("SOURCE", "DESTINATION"),
+        required=True,
+        help="One source/destination cache-root pair; repeat for train and validation.",
+    )
+    parser.add_argument("--workers", type=int, default=16, help="Concurrent object copies.")
+    return parser.parse_args()
+
+
+def relative_entries(gcs: gcsfs.GCSFileSystem, source_root: str) -> list[CopyEntry]:
+    """List source objects except the completion marker, sorted by path."""
+    source_prefix = gcs._strip_protocol(source_root).rstrip("/")
+    entries: list[CopyEntry] = []
+    for source_path, info in gcs.find(source_root, detail=True).items():
+        if source_path == source_prefix:
+            continue
+        if not source_path.startswith(source_prefix + "/"):
+            raise RuntimeError(f"unexpected GCS listing entry {source_path!r} under {source_root!r}")
+        relative_path = source_path[len(source_prefix) + 1 :]
+        if relative_path == EXECUTOR_STATUS_FILENAME:
+            continue
+        size = info.get("size")
+        if not isinstance(size, int):
+            raise RuntimeError(f"GCS entry {source_path!r} has no integer size: {info!r}")
+        entries.append(CopyEntry(relative_path=relative_path, source_size=size))
+    return sorted(entries, key=lambda entry: entry.relative_path)
+
+
+def destination_has_matching_size(s3: s3fs.S3FileSystem, destination: str, source_size: int) -> bool:
+    """Return whether an existing destination object has the expected byte size."""
+    if not s3.exists(destination):
+        return False
+    size = s3.info(destination).get("size")
+    return size == source_size
+
+
+def copy_entry(
+    gcs: gcsfs.GCSFileSystem,
+    s3: s3fs.S3FileSystem,
+    source_root: str,
+    destination_root: str,
+    entry: CopyEntry,
+) -> int:
+    """Copy one object atomically, skipping a size-matched prior result."""
+    source = f"{source_root.rstrip('/')}/{entry.relative_path}"
+    destination = f"{destination_root.rstrip('/')}/{entry.relative_path}"
+    if destination_has_matching_size(s3, destination, entry.source_size):
+        return 0
+
+    temporary = f"{destination}.tmp.{uuid.uuid4().hex}"
+    copied = 0
+    try:
+        with gcs.open(source, "rb") as source_file, s3.open(temporary, "wb") as destination_file:
+            while chunk := source_file.read(CHUNK_BYTES):
+                destination_file.write(chunk)
+                copied += len(chunk)
+        if copied != entry.source_size:
+            raise RuntimeError(f"copied {copied} bytes, expected {entry.source_size} for {source!r}")
+        s3.mv(temporary, destination)
+    except BaseException:
+        if s3.exists(temporary):
+            s3.rm(temporary)
+        raise
+    return copied
+
+
+def copy_completion_marker(
+    gcs: gcsfs.GCSFileSystem,
+    s3: s3fs.S3FileSystem,
+    source_root: str,
+    destination_root: str,
+) -> None:
+    """Copy the source completion marker after every data object has succeeded."""
+    source = f"{source_root.rstrip('/')}/{EXECUTOR_STATUS_FILENAME}"
+    destination = f"{destination_root.rstrip('/')}/{EXECUTOR_STATUS_FILENAME}"
+    source_size = gcs.info(source).get("size")
+    if not isinstance(source_size, int):
+        raise RuntimeError(f"GCS completion marker {source!r} has no integer size")
+    if destination_has_matching_size(s3, destination, source_size):
+        return
+    temporary = f"{destination}.tmp.{uuid.uuid4().hex}"
+    try:
+        with gcs.open(source, "rb") as source_file, s3.open(temporary, "wb") as destination_file:
+            while chunk := source_file.read(CHUNK_BYTES):
+                destination_file.write(chunk)
+        s3.mv(temporary, destination)
+    except BaseException:
+        if s3.exists(temporary):
+            s3.rm(temporary)
+        raise
+
+
+def copy_cache(gcs: gcsfs.GCSFileSystem, s3: s3fs.S3FileSystem, source_root: str, destination_root: str, workers: int) -> None:
+    """Copy one cache root with bounded parallelism and resumable size checks."""
+    entries = relative_entries(gcs, source_root)
+    if not entries:
+        raise RuntimeError(f"source cache {source_root!r} contains no data objects")
+    logger.info("Copying %d objects: %s -> %s", len(entries), source_root, destination_root)
+    copied_bytes = 0
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [
+            executor.submit(copy_entry, gcs, s3, source_root, destination_root, entry)
+            for entry in entries
+        ]
+        for completed, future in enumerate(as_completed(futures), start=1):
+            copied_bytes += future.result()
+            if completed % 100 == 0 or completed == len(entries):
+                logger.info("Completed %d/%d objects (%.2f GiB copied)", completed, len(entries), copied_bytes / 2**30)
+    copy_completion_marker(gcs, s3, source_root, destination_root)
+    logger.info("Completed cache: %s -> %s", source_root, destination_root)
+
+
+def main() -> None:
+    """Mirror all requested roots using the mounted GCS and inherited S3 credentials."""
+    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+        raise RuntimeError("GOOGLE_APPLICATION_CREDENTIALS must point to the mounted GCS reader credential")
+    args = parse_args()
+    if args.workers < 1:
+        raise ValueError("--workers must be positive")
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    gcs = gcsfs.GCSFileSystem()
+    s3 = s3fs.S3FileSystem(anon=False)
+    for source_root, destination_root in args.cache:
+        copy_cache(gcs, s3, source_root, destination_root, args.workers)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/direct_train.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/direct_train.py
@@ -1,0 +1,141 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run exp156 training directly in the allocated Iris GPU task.
+
+The experiment's normal ``train.py --run`` entrypoint is an artifact coordinator
+that submits a nested accelerator task. This entrypoint instead builds the same
+Levanter configuration in the already-allocated GPU task. It is required for
+multi-node CoreWeave runs and makes the spawn-based telemetry writer safe.
+"""
+
+import dataclasses
+import os
+from datetime import timedelta
+
+import jmp
+from fray.types import ResourceConfig
+from levanter.adaptor import NoAdaptorConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.compat.hf_checkpoints import HFCompatConfig
+from levanter.data.text.datasets import DatasetComponent, LmDataConfig
+from levanter.distributed import DistributedConfig
+from levanter.main.train_lm import TrainLmConfig
+from levanter.optim.config import AdamConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from levanter.utils.mesh import MeshConfig
+from marin.processing.tokenize.tokenize import TokenizedCache
+from marin.training.training import TrainLmOnPodConfig
+
+import train as exp156
+
+
+def _component(cache_path: str) -> DatasetComponent:
+    """Load a legacy mirrored cache without artifact metadata."""
+    return dataclasses.replace(TokenizedCache.raw_load(cache_path).as_component(), pack=False)
+
+
+def main() -> None:
+    """Configure and run one chosen exp156 objective directly on GPUs."""
+    name = os.environ["EXP156_NAME"]
+    loss_kind = os.environ["EXP156_LOSS_KIND"]
+    version = os.environ.get("EXP156_VERSION", "exp156-direct")
+    steps = int(os.environ.get("EXP156_STEPS", "300"))
+    steps_per_eval = int(os.environ.get("EXP156_STEPS_PER_EVAL", "50"))
+    train_batch_size = int(os.environ.get("EXP156_TRAIN_BATCH_SIZE", "16"))
+    per_device_parallelism = int(os.environ.get("EXP156_PER_DEVICE_PARALLELISM", "1"))
+    max_eval_batches = int(os.environ.get("EXP156_MAX_EVAL_BATCHES", "16"))
+
+    train_key = "tokenized/contacts-v1-train"
+    val_key = "tokenized/contacts-v1-val"
+    data = LmDataConfig(
+        components={
+            train_key: _component(os.environ["EXP156_TOKENIZED_TRAIN_CACHE"]),
+            val_key: _component(os.environ["EXP156_TOKENIZED_VAL_CACHE"]),
+        },
+        train_weights={train_key: 1.0, val_key: 0.0},
+        tokenizer=exp156.CONTACTS_TOKENIZER,
+        cache_dir=None,
+        auto_build_caches=False,
+        shuffle=True,
+        mixture_block_size=1,
+        block_cross_document_attention=True,
+    )
+    save_interval = None if os.environ.get("EXP156_DISABLE_TEMP_CHECKPOINTS") == "1" else timedelta(minutes=10)
+    trainer = TrainerConfig(
+        id=name,
+        tracker=WandbConfig(
+            entity="open-athena",
+            project="MarinFold",
+            name=name,
+            tags=list(exp156.TAGS),
+            group="exp156-contacts-v1-greedy-set-loss",
+        ),
+        mp=jmp.get_policy("p=f32,c=bfloat16"),
+        train_batch_size=train_batch_size,
+        per_device_parallelism=per_device_parallelism,
+        num_train_steps=steps,
+        steps_per_eval=steps_per_eval,
+        checkpointer=CheckpointerConfig(save_interval=save_interval, keep=[{"every": steps}]),
+        mesh=MeshConfig(
+            axes={"replica": 1, "data": -1, "model": 1},
+            compute_mapping={"token": exp156.TOKEN_AXES, "token_repeat": exp156.TOKEN_AXES},
+        ),
+        per_device_eval_parallelism=-1,
+        max_eval_batches=max_eval_batches,
+        allow_nondivisible_batch_size=True,
+        distributed=DistributedConfig(initialize_jax_distributed=False),
+    )
+    train_config = TrainLmConfig(
+        data=data,
+        trainer=trainer,
+        model=exp156.MODEL_CONFIG,
+        optimizer=AdamConfig(
+            learning_rate=float(os.environ.get("EXP156_LEARNING_RATE", "3.1623e-3")),
+            weight_decay=0.2,
+            beta1=0.9,
+            beta2=0.95,
+            warmup=0.1,
+            lr_schedule="cosine",
+            min_lr_ratio=0.1,
+        ),
+        z_loss_weight=0.0,
+        train_seq_len=8192,
+        hf_save_steps=steps,
+        data_seed=0,
+        adapter=NoAdaptorConfig(),
+        initialize_from_hf=exp156.INITIALIZE_FROM_HF,
+        pad_tokenizer_to_match_model=True,
+    )
+    if not isinstance(train_config.model, HFCompatConfig):
+        raise TypeError("expected HF-compatible model config")
+
+    resources = ResourceConfig.with_gpu(
+        os.environ.get("EXP156_GPU", "H100"),
+        count=int(os.environ.get("EXP156_GPU_COUNT", "1")),
+        cpu=float(os.environ.get("EXP156_CPU", "16")),
+        ram=os.environ.get("EXP156_RAM", "128g"),
+        disk=os.environ.get("EXP156_DISK", "200g"),
+    )
+    env_vars = {"WANDB_ENTITY": "open-athena", "WANDB_PROJECT": "MarinFold"}
+    for env_name in ("WANDB_API_KEY", "WANDB_MODE"):
+        if env_value := os.environ.get(env_name):
+            env_vars[env_name] = env_value
+    pod_config = TrainLmOnPodConfig(
+        train_config=train_config,
+        resources=resources,
+        output_path=f"{exp156.MARIN_PREFIX}/users/zack/checkpoints/{name}/{version}",
+        env_vars=env_vars,
+        auto_build_caches=False,
+    )
+    if loss_kind == "next-token":
+        exp156._run_stock_next_token_train_with_telemetry(pod_config)
+    elif loss_kind == "greedy-set":
+        exp156._run_greedy_set_train_with_telemetry(pod_config)
+    else:
+        raise ValueError(f"unsupported EXP156_LOSS_KIND={loss_kind!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/exp156_gpu_telemetry.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/exp156_gpu_telemetry.py
@@ -1,0 +1,548 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Temporary exp156 copy of the durable JSONL/GPU telemetry helpers.
+
+Remove this file after marin-community/marin#7641 lands in the published Marin package.
+"""
+
+import dataclasses
+import contextlib
+import csv
+import datetime as dt
+import json
+import logging
+import multiprocessing
+import posixpath
+import queue
+import select
+import shutil
+import subprocess
+import threading
+from collections.abc import Iterator
+from dataclasses import dataclass
+from multiprocessing.synchronize import Event as EventType
+from enum import StrEnum
+from typing import Any
+
+import fsspec
+
+logger = logging.getLogger(__name__)
+
+_DONE = object()
+
+
+class BackpressurePolicy(StrEnum):
+    """Queue behavior when the writer actor is full."""
+
+    BLOCK = "block"
+    DROP = "drop"
+
+
+@dataclass(frozen=True)
+class JsonlChunkWriterConfig:
+    """Configuration for :class:`JsonlChunkWriter`.
+
+    Args:
+        output_uri: Destination directory for ``parts/part-*.jsonl`` and
+            ``manifest.json``.
+        records_per_chunk: Number of records per durable chunk file.
+        max_queue_items: Maximum queued records before backpressure policy is
+            applied.
+        backpressure_policy: Whether ``write`` blocks or drops when the queue is
+            full.
+        log_every: Log writer progress after this many enqueued records.
+    """
+
+    output_uri: str
+    records_per_chunk: int = 120
+    max_queue_items: int = 10_000
+    backpressure_policy: BackpressurePolicy = BackpressurePolicy.BLOCK
+    log_every: int = 1_000
+
+    def __post_init__(self) -> None:
+        if not self.output_uri:
+            raise ValueError("output_uri must be non-empty")
+        if self.records_per_chunk <= 0:
+            raise ValueError("records_per_chunk must be positive")
+        if self.max_queue_items <= 0:
+            raise ValueError("max_queue_items must be positive")
+        if self.log_every <= 0:
+            raise ValueError("log_every must be positive")
+        if isinstance(self.backpressure_policy, str):
+            object.__setattr__(self, "backpressure_policy", BackpressurePolicy(self.backpressure_policy))
+        if not isinstance(self.backpressure_policy, BackpressurePolicy):
+            raise ValueError("backpressure_policy must be a BackpressurePolicy")
+
+
+@dataclass(frozen=True)
+class JsonlChunkWriterStats:
+    """Snapshot of writer counters."""
+
+    records_enqueued: int
+    records_written: int
+    records_dropped: int
+    chunks_written: int
+    bytes_written: int
+    max_queue_size_observed: int
+
+
+class JsonlChunkWriter:
+    """JSONL writer backed by a queue and writer thread.
+
+    ``write`` serializes the object and enqueues one JSON line. Remote I/O is
+    performed only by the writer thread. Queue backpressure is controlled by
+    ``JsonlChunkWriterConfig.backpressure_policy``.
+    """
+
+    def __init__(self, config: JsonlChunkWriterConfig):
+        self.config = config
+        self._queue: queue.Queue[str | object] = queue.Queue(maxsize=config.max_queue_items)
+        self._thread: threading.Thread | None = None
+        self._started_at: str | None = None
+        self._ended_at: str | None = None
+        self._chunks: list[dict[str, Any]] = []
+        self._records_enqueued = 0
+        self._records_written = 0
+        self._records_dropped = 0
+        self._chunks_written = 0
+        self._bytes_written = 0
+        self._max_queue_size_observed = 0
+        self._closed = False
+        self._writer_error: str | None = None
+
+    def __enter__(self) -> "JsonlChunkWriter":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()
+
+    def start(self) -> None:
+        """Start the writer actor thread."""
+        if self._thread is not None:
+            raise RuntimeError("JsonlChunkWriter is already started")
+        self._started_at = dt.datetime.now(dt.UTC).isoformat()
+        self._thread = threading.Thread(target=self._run_writer, name="jsonl-chunk-writer", daemon=False)
+        self._thread.start()
+
+    def write(self, obj: Any) -> bool:
+        """Serialize and enqueue one JSON object.
+
+        Returns ``True`` when the record was accepted. Returns ``False`` when
+        the object is not JSON-serializable, the writer is closed, or the queue
+        is full and ``backpressure_policy`` is ``DROP``.
+        """
+        try:
+            line = json.dumps(obj, default=_json_default, sort_keys=True, separators=(",", ":")) + "\n"
+        except (TypeError, ValueError):
+            self._records_dropped += 1
+            if self._records_dropped == 1 or self._records_dropped % self.config.log_every == 0:
+                logger.warning(
+                    "jsonl-writer dropping non-json record output_uri=%s dropped=%d",
+                    self.config.output_uri,
+                    self._records_dropped,
+                )
+            return False
+        if self._closed:
+            return False
+        self._raise_if_writer_failed()
+        if self.config.backpressure_policy is BackpressurePolicy.BLOCK:
+            self._put_record_with_backpressure(line)
+        else:
+            try:
+                self._queue.put_nowait(line)
+            except queue.Full:
+                self._raise_if_writer_failed()
+                self._records_dropped += 1
+                if self._records_dropped == 1 or self._records_dropped % self.config.log_every == 0:
+                    logger.warning(
+                        "jsonl-writer dropping records output_uri=%s queue_size=%d dropped=%d",
+                        self.config.output_uri,
+                        self._queue.qsize(),
+                        self._records_dropped,
+                    )
+                return False
+
+        self._records_enqueued += 1
+        queue_size = self._queue.qsize()
+        self._max_queue_size_observed = max(self._max_queue_size_observed, queue_size)
+        if self._records_enqueued % self.config.log_every == 0:
+            logger.info(
+                "jsonl-writer queued output_uri=%s enqueued=%d queue_size=%d dropped=%d",
+                self.config.output_uri,
+                self._records_enqueued,
+                queue_size,
+                self._records_dropped,
+            )
+        return True
+
+    def close(self) -> None:
+        """Signal completion, wait for final flush, and write the manifest."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._thread is not None and self._thread.is_alive():
+            self._put_done_signal()
+            self._thread.join()
+        if self._writer_error is not None:
+            raise RuntimeError(f"JSONL writer failed: {self._writer_error}")
+
+    def stats(self) -> JsonlChunkWriterStats:
+        """Return a best-effort counter snapshot."""
+        return JsonlChunkWriterStats(
+            records_enqueued=self._records_enqueued,
+            records_written=self._records_written,
+            records_dropped=self._records_dropped,
+            chunks_written=self._chunks_written,
+            bytes_written=self._bytes_written,
+            max_queue_size_observed=self._max_queue_size_observed,
+        )
+
+    def _put_record_with_backpressure(self, line: str) -> None:
+        while True:
+            self._raise_if_writer_failed()
+            try:
+                self._queue.put(line, timeout=1.0)
+                return
+            except queue.Full:
+                continue
+
+    def _put_done_signal(self) -> None:
+        while self._thread is not None and self._thread.is_alive():
+            try:
+                self._queue.put(_DONE, timeout=1.0)
+                return
+            except queue.Full:
+                continue
+
+    def _raise_if_writer_failed(self) -> None:
+        if self._writer_error is not None:
+            raise RuntimeError(f"JSONL writer failed: {self._writer_error}")
+        if self._thread is not None and not self._thread.is_alive() and not self._closed:
+            raise RuntimeError("JSONL writer thread exited before close")
+
+    def _run_writer(self) -> None:
+        part_index = 0
+        records: list[str] = []
+        try:
+            while True:
+                item = self._queue.get()
+                if item is _DONE:
+                    break
+                assert isinstance(item, str)
+                records.append(item)
+                if len(records) >= self.config.records_per_chunk:
+                    self._flush(records, part_index)
+                    part_index += 1
+                    records = []
+            if records:
+                self._flush(records, part_index)
+            self._ended_at = dt.datetime.now(dt.UTC).isoformat()
+            self._write_manifest(completed=True)
+        except Exception as exc:
+            self._writer_error = f"{type(exc).__name__}: {exc}"
+            self._ended_at = dt.datetime.now(dt.UTC).isoformat()
+            try:
+                self._write_manifest(completed=False)
+            except Exception:
+                logger.exception("jsonl-writer failed to write failure manifest output_uri=%s", self.config.output_uri)
+
+    def _flush(self, records: list[str], part_index: int) -> None:
+        relative_path = f"parts/part-{part_index:06d}.jsonl"
+        uri = f"{self.config.output_uri.rstrip('/')}/{relative_path}"
+        body = "".join(records)
+        self._write_text_file(uri, body)
+        byte_count = len(body.encode("utf-8"))
+        self._records_written += len(records)
+        self._chunks_written += 1
+        self._bytes_written += byte_count
+        self._chunks.append(
+            {
+                "path": relative_path,
+                "records": len(records),
+                "bytes": byte_count,
+                "written_at": dt.datetime.now(dt.UTC).isoformat(),
+            }
+        )
+        logger.info(
+            "jsonl-writer flush output_uri=%s part=%06d records=%d bytes=%d queue_size=%d dropped=%d",
+            self.config.output_uri,
+            part_index,
+            len(records),
+            byte_count,
+            self._queue.qsize(),
+            self._records_dropped,
+        )
+
+    def _write_manifest(self, *, completed: bool) -> None:
+        manifest = {
+            "started_at": self._started_at,
+            "ended_at": self._ended_at,
+            "completed": completed,
+            "error": self._writer_error,
+            "config": dataclasses.asdict(self.config),
+            "records_enqueued": self._records_enqueued,
+            "records_written": self._records_written,
+            "records_dropped": self._records_dropped,
+            "chunks_written": self._chunks_written,
+            "bytes_written": self._bytes_written,
+            "max_queue_size_observed": self._max_queue_size_observed,
+            "chunks": list(self._chunks),
+        }
+        manifest_uri = f"{self.config.output_uri.rstrip('/')}/manifest.json"
+        self._write_text_file(manifest_uri, json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+    @classmethod
+    def _write_text_file(cls, uri: str, body: str) -> None:
+        fs, path = fsspec.core.url_to_fs(uri)
+        parent = posixpath.dirname(path)
+        if parent:
+            fs.mkdirs(parent, exist_ok=True)
+        with fs.open(path, "wt") as f:
+            f.write(body)
+
+
+def _json_default(obj: Any) -> Any:
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
+    if isinstance(obj, dt.datetime):
+        return obj.isoformat()
+    raise TypeError(f"object of type {type(obj).__name__} is not JSON serializable")
+
+
+
+
+
+
+DEFAULT_NVIDIA_SMI_FIELDS = (
+    "timestamp",
+    "index",
+    "name",
+    "uuid",
+    "utilization.gpu",
+    "utilization.memory",
+    "memory.used",
+    "memory.total",
+    "power.draw",
+    "pstate",
+    "clocks.sm",
+    "clocks.mem",
+    "temperature.gpu",
+)
+
+
+@dataclass(frozen=True)
+class NvidiaSmiTelemetryConfig:
+    """Configuration for a durable ``nvidia-smi`` telemetry process.
+
+    Args:
+        output_uri: Destination directory for JSONL chunks and manifest.
+        interval: Seconds between ``nvidia-smi`` samples.
+        records_per_chunk: Number of samples per durable JSONL chunk file.
+        max_queue_items: Maximum JSONL records queued in the writer actor before
+            backpressure policy is applied.
+        backpressure_policy: Whether telemetry writes block or drop when the
+            writer queue is full.
+        log_every: Log writer progress after this many accepted/dropped records.
+        query_fields: ``nvidia-smi --query-gpu`` fields.
+        command: Optional full command. Tests and non-NVIDIA probes can pass a
+            command that emits ``nvidia-smi --format=csv``-style output.
+        start_method: Multiprocessing start method used for the telemetry
+            process.
+        stop_timeout: Seconds to wait for graceful process shutdown before
+            terminating it.
+        require_command: Fail before training starts if the command executable
+            is not present.
+    """
+
+    output_uri: str
+    interval: float = 5.0
+    records_per_chunk: int = 120
+    max_queue_items: int = 10_000
+    backpressure_policy: BackpressurePolicy = BackpressurePolicy.BLOCK
+    log_every: int = 1_000
+    query_fields: tuple[str, ...] = DEFAULT_NVIDIA_SMI_FIELDS
+    command: tuple[str, ...] = ()
+    start_method: str = "spawn"
+    stop_timeout: float = 30.0
+    require_command: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.output_uri:
+            raise ValueError("output_uri must be non-empty")
+        if self.interval <= 0:
+            raise ValueError("interval must be positive")
+        if self.records_per_chunk <= 0:
+            raise ValueError("records_per_chunk must be positive")
+        if self.max_queue_items <= 0:
+            raise ValueError("max_queue_items must be positive")
+        if self.log_every <= 0:
+            raise ValueError("log_every must be positive")
+        if isinstance(self.backpressure_policy, str):
+            object.__setattr__(self, "backpressure_policy", BackpressurePolicy(self.backpressure_policy))
+        if not isinstance(self.backpressure_policy, BackpressurePolicy):
+            raise ValueError("backpressure_policy must be a BackpressurePolicy")
+        if self.stop_timeout <= 0:
+            raise ValueError("stop_timeout must be positive")
+        if self.command and not self.command[0]:
+            raise ValueError("command executable must be non-empty")
+        if not self.command and not self.query_fields:
+            raise ValueError("query_fields must be non-empty when command is not set")
+
+
+def build_nvidia_smi_command(config: NvidiaSmiTelemetryConfig) -> tuple[str, ...]:
+    """Return the command used by the telemetry process."""
+    if config.command:
+        return config.command
+    return (
+        "nvidia-smi",
+        f"--query-gpu={','.join(config.query_fields)}",
+        "--format=csv",
+        "-l",
+        _format_seconds_for_nvidia_smi(config.interval),
+    )
+
+
+@dataclass(frozen=True)
+class NvidiaSmiTelemetryHandle:
+    """Handle for a running telemetry process."""
+
+    process: multiprocessing.Process
+    stop_event: EventType
+    stop_timeout: float
+
+    def stop(self) -> None:
+        """Request shutdown, flush the final chunk, and reap the process."""
+        self.stop_event.set()
+        self.process.join(timeout=self.stop_timeout)
+        if self.process.is_alive():
+            logger.warning("GPU telemetry process did not stop in %.1fs; terminating", self.stop_timeout)
+            self.process.terminate()
+            self.process.join(timeout=5.0)
+        if self.process.exitcode not in (0, None):
+            logger.warning("GPU telemetry process exited with code %s", self.process.exitcode)
+
+
+def start_nvidia_smi_telemetry(config: NvidiaSmiTelemetryConfig) -> NvidiaSmiTelemetryHandle:
+    """Start a background process that writes GPU telemetry JSONL chunks."""
+    command = build_nvidia_smi_command(config)
+    if config.require_command and shutil.which(command[0]) is None:
+        raise FileNotFoundError(f"GPU telemetry command not found: {command[0]}")
+    ctx = multiprocessing.get_context(config.start_method)
+    stop_event = ctx.Event()
+    process = ctx.Process(
+        target=run_nvidia_smi_telemetry,
+        args=(config, stop_event),
+        name="nvidia-smi-telemetry",
+        daemon=False,
+    )
+    process.start()
+    return NvidiaSmiTelemetryHandle(process=process, stop_event=stop_event, stop_timeout=config.stop_timeout)
+
+
+@contextlib.contextmanager
+def nvidia_smi_telemetry(config: NvidiaSmiTelemetryConfig) -> Iterator[NvidiaSmiTelemetryHandle]:
+    """Run durable GPU telemetry while the body executes."""
+    handle = start_nvidia_smi_telemetry(config)
+    try:
+        yield handle
+    finally:
+        handle.stop()
+
+
+def run_nvidia_smi_telemetry(config: NvidiaSmiTelemetryConfig, stop_event: EventType) -> None:
+    """Run ``nvidia-smi`` and write parsed samples as JSONL chunks."""
+    command = build_nvidia_smi_command(config)
+    writer_config = JsonlChunkWriterConfig(
+        output_uri=config.output_uri,
+        records_per_chunk=config.records_per_chunk,
+        max_queue_items=config.max_queue_items,
+        backpressure_policy=config.backpressure_policy,
+        log_every=config.log_every,
+    )
+    process: subprocess.Popen[str] | None = None
+    with JsonlChunkWriter(writer_config) as writer:
+        writer.write(
+            {
+                "record_type": "metadata",
+                "timestamp_utc": dt.datetime.now(dt.UTC).isoformat(),
+                "command": list(command),
+                "query_fields": list(config.query_fields),
+                "interval": config.interval,
+            }
+        )
+        try:
+            process = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+            assert process.stdout is not None
+            header: list[str] | None = None
+            while not stop_event.is_set():
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    if process.poll() is not None:
+                        break
+                    continue
+                line = process.stdout.readline()
+                if line == "":
+                    if process.poll() is not None:
+                        break
+                    continue
+                row = next(csv.reader([line.rstrip("\n")]))
+                if header is None:
+                    header = [_normalize_field_name(field) for field in row]
+                    continue
+                values = {header[index]: value.strip() for index, value in enumerate(row) if index < len(header)}
+                writer.write(
+                    {
+                        "record_type": "gpu_sample",
+                        "timestamp_utc": dt.datetime.now(dt.UTC).isoformat(),
+                        "nvidia_smi": values,
+                    }
+                )
+            if process.poll() is not None and process.returncode not in (0, None):
+                stderr = process.stderr.read() if process.stderr is not None else ""
+                writer.write(
+                    {
+                        "record_type": "error",
+                        "timestamp_utc": dt.datetime.now(dt.UTC).isoformat(),
+                        "message": "telemetry command exited nonzero",
+                        "returncode": process.returncode,
+                        "stderr": stderr.strip(),
+                    }
+                )
+        finally:
+            if process is not None and process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5.0)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5.0)
+            writer.write(
+                {
+                    "record_type": "metadata",
+                    "timestamp_utc": dt.datetime.now(dt.UTC).isoformat(),
+                    "event": "telemetry_stop",
+                }
+            )
+
+
+def _normalize_field_name(field: str) -> str:
+    field = field.strip()
+    if " [" in field:
+        field = field.split(" [", 1)[0]
+    return field.replace(".", "_").replace(" ", "_").replace("-", "_")
+
+
+def _format_seconds_for_nvidia_smi(seconds: float) -> str:
+    if seconds.is_integer():
+        return str(int(seconds))
+    return str(seconds)
+
+

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/list_coreweave_s3.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/list_coreweave_s3.py
@@ -1,0 +1,87 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""List candidate CoreWeave S3 prefixes for exp156 data discovery.
+
+Run this inside a CoreWeave Iris task, where AWS_* / FSSPEC_S3 credentials are
+injected by the cluster. It intentionally lists only shallow prefixes by default.
+"""
+
+import argparse
+import os
+from collections.abc import Iterable
+from urllib.parse import urlparse
+
+
+def _s3_options() -> dict[str, object]:
+    endpoint_url = os.environ.get("AWS_ENDPOINT_URL") or os.environ.get("S3_ENDPOINT_URL")
+    options: dict[str, object] = {}
+    if endpoint_url:
+        options["client_kwargs"] = {"endpoint_url": endpoint_url}
+    return options
+
+
+def _list_with_s3fs(prefixes: Iterable[str]) -> None:
+    import s3fs
+
+    fs = s3fs.S3FileSystem(anon=False, **_s3_options())
+    for prefix in prefixes:
+        print(f"\n## {prefix}")
+        try:
+            entries = fs.ls(prefix, detail=True)
+        except FileNotFoundError:
+            print("missing")
+            continue
+        except Exception as exc:
+            print(f"ERROR: {type(exc).__name__}: {exc}")
+            continue
+        for entry in entries:
+            name = entry.get("name", str(entry)) if isinstance(entry, dict) else str(entry)
+            size = entry.get("size") if isinstance(entry, dict) else None
+            kind = entry.get("type") if isinstance(entry, dict) else None
+            suffix = "/" if kind == "directory" and not name.endswith("/") else ""
+            size_text = "" if size is None else f"\t{size}"
+            print(f"{name}{suffix}{size_text}")
+
+
+def _parents(path: str) -> list[str]:
+    parsed = urlparse(path)
+    parts = [part for part in parsed.path.split("/") if part]
+    out = [f"s3://{parsed.netloc}"]
+    for i in range(1, len(parts) + 1):
+        out.append(f"s3://{parsed.netloc}/{'/'.join(parts[:i])}")
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "prefix",
+        nargs="*",
+        default=[
+            "s3://marin-us-east-02a",
+            "s3://marin-us-east-02a/marin",
+            "s3://marin-us-east-02a/MarinFold",
+            "s3://marin-us-east-02a/MarinFold/data",
+            "s3://marin-us-east-02a/MarinFold/data/document_structures",
+            "s3://marin-us-east-02a/MarinFold/data/document_structures/contacts_v1",
+            "s3://marin-us-east-02a/marin/data",
+            "s3://marin-us-east-02a/marin/checkpoints",
+        ],
+    )
+    parser.add_argument(
+        "--parents-of",
+        help="Also list every parent of this full s3:// path.",
+    )
+    args = parser.parse_args()
+    prefixes = list(args.prefix)
+    if args.parents_of:
+        prefixes.extend(_parents(args.parents_of))
+    print("AWS_ACCESS_KEY_ID", "set" if os.environ.get("AWS_ACCESS_KEY_ID") else "unset")
+    print("AWS_ENDPOINT_URL", os.environ.get("AWS_ENDPOINT_URL", "unset"))
+    print("FSSPEC_S3", os.environ.get("FSSPEC_S3", "unset"))
+    _list_with_s3fs(prefixes)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/pyproject.toml
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/pyproject.toml
@@ -1,0 +1,71 @@
+[project]
+name = "exp156-models-contacts-v1-greedy-set-loss"
+version = "0.1.0"
+description = "Prototype contacts-v1 greedy latent contact-set training loss."
+requires-python = ">=3.12,<3.13"
+dependencies = [
+    "fsspec",
+    "gcsfs",
+    "marin-core>=0.2.5.dev202606020954,<0.3",
+    "marin-iris>=0.2.5.dev202606020954,<0.3",
+    "marin-levanter>=0.2.5.dev202606020954,<0.3",
+    "marin-rigging>=0.2.5.dev202606020954,<0.3",
+    "marin-zephyr>=0.2.5.dev202606020954,<0.3",
+    "marin-dupekit<0.3",
+    "marinfold",
+    "marinfold-models",
+    "numpy",
+    "pyarrow",
+    "tokenizers",
+    "transformers",
+]
+
+[project.optional-dependencies]
+tpu = ["marin-core[tpu]; sys_platform == 'linux'"]
+gpu = ["marin-core[gpu]; sys_platform == 'linux'"]
+cpu = [
+    "marin-core[cpu]",
+    "torch==2.11.0",
+    "torchvision==0.26.0+cpu; sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
+
+[dependency-groups]
+dev = ["pytest"]
+
+[tool.uv]
+package = false
+fork-strategy = "fewest"
+prerelease = "allow"
+environments = [
+    "sys_platform == 'darwin'",
+    "sys_platform == 'linux'",
+]
+override-dependencies = [
+    "antlr4-python3-runtime==4.11",
+    "datasets>=3.1.0,<4.0.0",
+    "equinox>=0.11.10",
+    "omegaconf>=2.4.0.dev4",
+    "python-multipart>=0.0.22",
+    "transformers>=5.5.3,<6",
+    "wheel>=0.46.2",
+]
+
+find-links = [
+    "https://github.com/marin-community/kitoken/releases/expanded_assets/kitoken-0.10.2-a3012f4",
+]
+
+[[tool.uv.index]]
+name = "marin-resiliparse"
+url = "https://marin-community.github.io/chatnoir-resiliparse/simple"
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[tool.uv.sources]
+resiliparse = { index = "marin-resiliparse" }
+torch = [{ index = "pytorch-cpu", extra = "cpu" }]
+torchvision = [{ index = "pytorch-cpu", extra = "cpu" }]
+marinfold = { path = "../../marinfold" }
+marinfold-models = { path = "../../models" }

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/smoke_compare_losses.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/smoke_compare_losses.py
@@ -1,0 +1,426 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare strict CE vs greedy set loss on a trained contacts-v1 model.
+
+This is a Colab/CoreWeave smoke script, not the final Levanter training path. It
+loads a recent MarinFold contacts-v1 HF export, runs a few teacher-forced toy
+contacts-v1 documents, and checks that relaxing contact order/orientation lowers
+(or ties) the contact-block loss on the same logits.
+"""
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import torch
+from transformers import AutoModelForCausalLM, PreTrainedTokenizerFast
+
+from marinfold.document_structures.contacts_v1.greedy_set_loss import (
+    greedy_matched_contact_block_loss,
+)
+from marinfold.registry import resolve_model
+
+
+ONE_TO_THREE = {
+    "A": "ALA",
+    "R": "ARG",
+    "N": "ASN",
+    "D": "ASP",
+    "C": "CYS",
+    "Q": "GLN",
+    "E": "GLU",
+    "G": "GLY",
+    "H": "HIS",
+    "I": "ILE",
+    "L": "LEU",
+    "K": "LYS",
+    "M": "MET",
+    "F": "PHE",
+    "P": "PRO",
+    "S": "SER",
+    "T": "THR",
+    "W": "TRP",
+    "Y": "TYR",
+    "V": "VAL",
+}
+
+
+DOCS = [
+    " ".join(
+        [
+            "<contacts-v1>",
+            "<begin_sequence>",
+            "<p0>", "<ALA>",
+            "<p1>", "<GLY>",
+            "<p2>", "<SER>",
+            "<p3>", "<VAL>",
+            "<p4>", "<THR>",
+            "<p5>", "<LEU>",
+            "<p6>", "<ASP>",
+            "<p7>", "<LYS>",
+            "<begin_statements>",
+            "<contact>", "<p0>", "<p6>",
+            "<contact>", "<p1>", "<p7>",
+            "<end>",
+            "<eos>",
+        ]
+    ),
+    " ".join(
+        [
+            "<contacts-v1>",
+            "<begin_sequence>",
+            "<p10>", "<PHE>",
+            "<p11>", "<ALA>",
+            "<p12>", "<GLU>",
+            "<p13>", "<TYR>",
+            "<p14>", "<ASN>",
+            "<p15>", "<ARG>",
+            "<p16>", "<GLY>",
+            "<begin_statements>",
+            "<contact>", "<p10>", "<p16>",
+            "<contact>", "<p11>", "<p15>",
+            "<end>",
+            "<eos>",
+        ]
+    ),
+]
+
+
+def _doc_from_sequence_and_contacts(
+    sequence: str,
+    contacts: list[list[int]],
+    *,
+    max_contacts: int | None,
+) -> str:
+    tokens = ["<contacts-v1>", "<begin_sequence>"]
+    for index, code in enumerate(sequence.strip().upper()):
+        tokens.extend([f"<p{index}>", f"<{ONE_TO_THREE.get(code, 'UNK')}>"])
+    tokens.append("<begin_statements>")
+    selected_contacts = contacts if max_contacts is None else contacts[:max_contacts]
+    for left, right in selected_contacts:
+        tokens.extend(["<contact>", f"<p{int(left)}>", f"<p{int(right)}>"])
+    tokens.extend(["<end>", "<eos>"])
+    return " ".join(tokens)
+
+
+def _load_foldbench_jsonl(path: Path, *, max_contacts: int | None, limit: int) -> list[str]:
+    docs: list[str] = []
+    with path.open() as f:
+        for line in f:
+            row = json.loads(line)
+            docs.append(
+                _doc_from_sequence_and_contacts(
+                    row["input_seq"],
+                    row["contacts"],
+                    max_contacts=max_contacts,
+                )
+            )
+            if len(docs) >= limit:
+                break
+    if not docs:
+        raise ValueError(f"no docs loaded from {path}")
+    return docs
+
+
+def _token_id(tokenizer, token: str) -> int:
+    token_id = tokenizer.convert_tokens_to_ids(token)
+    if token_id is None or token_id == tokenizer.unk_token_id:
+        raise ValueError(f"token {token!r} is absent from tokenizer")
+    return int(token_id)
+
+
+def _encode_batch(docs: list[str], tokenizer) -> tuple[torch.Tensor, torch.Tensor]:
+    pad_id = _token_id(tokenizer, "<pad>")
+    rows: list[list[int]] = []
+    for doc in docs:
+        row = [_token_id(tokenizer, token) for token in doc.split()]
+        rows.append(row)
+    width = max(len(row) for row in rows)
+    input_ids = np.full((len(rows), width), pad_id, dtype=np.int64)
+    attention_mask = np.zeros((len(rows), width), dtype=np.int64)
+    for row_index, row in enumerate(rows):
+        input_ids[row_index, : len(row)] = row
+        attention_mask[row_index, : len(row)] = 1
+    return torch.as_tensor(input_ids), torch.as_tensor(attention_mask)
+
+
+def _finite_log_softmax(logits: torch.Tensor, *, logit_clip: float | None) -> torch.Tensor:
+    logits = logits.float()
+    if logit_clip is not None:
+        logits = torch.clamp(logits, min=-logit_clip, max=logit_clip)
+    if not torch.isfinite(logits).all():
+        bad = int((~torch.isfinite(logits)).sum().item())
+        raise RuntimeError(f"model produced {bad} non-finite logits before log_softmax")
+    log_probs = torch.log_softmax(logits, dim=-1)
+    if not torch.isfinite(log_probs).all():
+        bad = int((~torch.isfinite(log_probs)).sum().item())
+        raise RuntimeError(f"log_softmax produced {bad} non-finite values")
+    return log_probs
+
+
+def _strict_loss(log_probs: np.ndarray, token_ids: np.ndarray, *, end_id: int) -> float:
+    end_positions = np.flatnonzero(token_ids == end_id)
+    if end_positions.size != 1:
+        raise ValueError("expected exactly one <end>")
+    end_pos = int(end_positions[0])
+    positions = np.arange(end_pos, dtype=np.int64)
+    targets = token_ids[1 : end_pos + 1]
+    return -float(np.sum(log_probs[positions, targets]))
+
+
+def _strict_loss_torch(
+    logits: torch.Tensor,
+    token_ids: np.ndarray,
+    *,
+    end_id: int,
+    logit_clip: float | None,
+) -> torch.Tensor:
+    """Strict next-token CE through ``<end>`` from Torch logits."""
+    log_probs = _finite_log_softmax(logits, logit_clip=logit_clip)
+    row_losses: list[torch.Tensor] = []
+    for row in range(token_ids.shape[0]):
+        end_positions = np.flatnonzero(token_ids[row] == end_id)
+        if end_positions.size != 1:
+            raise ValueError("expected exactly one <end>")
+        end_pos = int(end_positions[0])
+        row_losses.append(-log_probs[row, np.arange(end_pos), token_ids[row, 1 : end_pos + 1]].sum())
+    return torch.stack(row_losses).mean()
+
+
+def _greedy_loss_torch(
+    logits: torch.Tensor,
+    token_ids: np.ndarray,
+    tokenizer,
+    *,
+    logit_clip: float | None,
+) -> torch.Tensor:
+    """Compute hard-assigned greedy loss from Torch logits.
+
+    Greedy assignments are chosen from detached host log-probs, but the returned
+    loss gathers from Torch ``log_softmax(logits)``, so ``loss.backward()`` gives
+    gradients for the selected token logits.
+    """
+    log_probs = _finite_log_softmax(logits, logit_clip=logit_clip)
+    log_probs_np = log_probs.detach().cpu().numpy()
+    position_token_ids = np.asarray([_token_id(tokenizer, f"<p{index}>") for index in range(2000)], dtype=np.int64)
+    begin_id = _token_id(tokenizer, "<begin_statements>")
+    contact_id = _token_id(tokenizer, "<contact>")
+    end_id = _token_id(tokenizer, "<end>")
+
+    row_losses: list[torch.Tensor] = []
+    for row in range(token_ids.shape[0]):
+        matched = greedy_matched_contact_block_loss(
+            log_probs_np[row],
+            token_ids[row],
+            begin_statements_token_id=begin_id,
+            contact_token_id=contact_id,
+            end_token_id=end_id,
+            position_token_ids=position_token_ids,
+        )
+        end_positions = np.flatnonzero(token_ids[row] == end_id)
+        begin_positions = np.flatnonzero(token_ids[row] == begin_id)
+        if end_positions.size != 1 or begin_positions.size != 1:
+            raise ValueError("expected exactly one <begin_statements> and one <end>")
+        begin_pos = int(begin_positions[0])
+        end_pos = int(end_positions[0])
+
+        row_loss = -log_probs[row, np.arange(begin_pos), token_ids[row, 1 : begin_pos + 1]].sum()
+        for choice in matched.choices:
+            slot_start = begin_pos + 1 + 3 * choice.slot_index
+            left_token, right_token = choice.oriented_tokens
+            row_loss = row_loss - log_probs[row, slot_start - 1, contact_id]
+            row_loss = row_loss - log_probs[row, slot_start, left_token]
+            row_loss = row_loss - log_probs[row, slot_start + 1, right_token]
+        row_loss = row_loss - log_probs[row, end_pos - 1, end_id]
+        row_losses.append(row_loss)
+    return torch.stack(row_losses).mean()
+
+
+def _logit_grad_stats(loss_fn, logits: torch.Tensor) -> tuple[float, float, float, int]:
+    grad_logits = logits.detach().clone().requires_grad_(True)
+    loss = loss_fn(grad_logits)
+    loss.backward()
+    grad = grad_logits.grad
+    if grad is None:
+        raise RuntimeError("gradient check failed: logits.grad is None")
+    return (
+        float(loss.detach().cpu()),
+        float(grad.norm().detach().cpu()),
+        float(grad.abs().mean().detach().cpu()),
+        int((grad.abs() > 0).sum().item()),
+    )
+
+
+def _check_logits_gradient(
+    logits: torch.Tensor,
+    token_ids: np.ndarray,
+    tokenizer,
+    *,
+    end_id: int,
+    logit_clip: float | None,
+) -> None:
+    strict_stats = _logit_grad_stats(
+        lambda grad_logits: _strict_loss_torch(
+            grad_logits,
+            token_ids,
+            end_id=end_id,
+            logit_clip=logit_clip,
+        ),
+        logits,
+    )
+    greedy_stats = _logit_grad_stats(
+        lambda grad_logits: _greedy_loss_torch(
+            grad_logits,
+            token_ids,
+            tokenizer,
+            logit_clip=logit_clip,
+        ),
+        logits,
+    )
+    print("gradient check:")
+    print(
+        "  strict:     "
+        f"loss={strict_stats[0]:.4f} grad_norm={strict_stats[1]:.6f} "
+        f"mean_abs_grad={strict_stats[2]:.8f} nonzero_logit_grads={strict_stats[3]}"
+    )
+    print(
+        "  greedy_set: "
+        f"loss={greedy_stats[0]:.4f} grad_norm={greedy_stats[1]:.6f} "
+        f"mean_abs_grad={greedy_stats[2]:.8f} nonzero_logit_grads={greedy_stats[3]}"
+    )
+    print(
+        "  delta:      "
+        f"loss={greedy_stats[0] - strict_stats[0]:.4f} "
+        f"grad_norm={greedy_stats[1] - strict_stats[1]:.6f}"
+    )
+
+
+def compare_once(args: argparse.Namespace) -> None:
+    model_path = Path(args.model) if Path(args.model).is_dir() else resolve_model(args.model)
+    print(f"loading model from {model_path}")
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_file=str(model_path / "tokenizer.json"),
+        unk_token="<UNK>",
+        pad_token="<pad>",
+        eos_token="<eos>",
+    )
+    dtype_by_name = {
+        "auto": "auto",
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+    }
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path,
+        torch_dtype=dtype_by_name[args.dtype],
+        device_map=args.device_map,
+        attn_implementation=args.attn_implementation,
+        local_files_only=True,
+    )
+    model.eval()
+
+    docs = DOCS[: args.num_examples]
+    if args.foldbench_jsonl is not None:
+        docs = _load_foldbench_jsonl(
+            Path(args.foldbench_jsonl),
+            max_contacts=args.max_contacts,
+            limit=args.num_examples,
+        )
+        print(
+            f"loaded {len(docs)} real docs from {args.foldbench_jsonl} "
+            f"with max_contacts={args.max_contacts}"
+        )
+    input_ids, attention_mask = _encode_batch(docs, tokenizer)
+    print(f"batch shape: {tuple(input_ids.shape)}")
+    first_device = next(model.parameters()).device
+    with torch.no_grad():
+        outputs = model(
+            input_ids=input_ids.to(first_device),
+            attention_mask=attention_mask.to(first_device),
+            use_cache=False,
+        )
+        logits = outputs.logits
+        log_probs = _finite_log_softmax(logits, logit_clip=args.logit_clip).cpu().numpy()
+    token_ids = input_ids.numpy()
+
+    position_token_ids = np.asarray([_token_id(tokenizer, f"<p{index}>") for index in range(2000)], dtype=np.int64)
+    begin_id = _token_id(tokenizer, "<begin_statements>")
+    contact_id = _token_id(tokenizer, "<contact>")
+    end_id = _token_id(tokenizer, "<end>")
+
+    strict_losses = []
+    greedy_losses = []
+    for row in range(token_ids.shape[0]):
+        strict = _strict_loss(log_probs[row], token_ids[row], end_id=end_id)
+        greedy = greedy_matched_contact_block_loss(
+            log_probs[row],
+            token_ids[row],
+            begin_statements_token_id=begin_id,
+            contact_token_id=contact_id,
+            end_token_id=end_id,
+            position_token_ids=position_token_ids,
+        ).loss
+        strict_losses.append(strict)
+        greedy_losses.append(greedy)
+        print(f"doc {row}: strict={strict:.4f} greedy_set={greedy:.4f} delta={greedy - strict:.4f}")
+    strict_mean = float(np.mean(strict_losses))
+    greedy_mean = float(np.mean(greedy_losses))
+    print(f"mean: strict={strict_mean:.4f} greedy_set={greedy_mean:.4f} delta={greedy_mean - strict_mean:.4f}")
+    if args.check_gradient:
+        _check_logits_gradient(
+            logits,
+            token_ids,
+            tokenizer,
+            end_id=end_id,
+            logit_clip=args.logit_clip,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model",
+        default="contacts-v1-exp120-1.5B",
+        help="MODELS.yaml nickname or local HF model directory.",
+    )
+    parser.add_argument("--device-map", default="auto")
+    parser.add_argument("--dtype", choices=("auto", "bfloat16", "float16", "float32"), default="bfloat16")
+    parser.add_argument(
+        "--attn-implementation",
+        default="eager",
+        choices=("eager", "sdpa", "flash_attention_2"),
+        help="Use eager attention by default for smoke-test numerical stability.",
+    )
+    parser.add_argument("--num-examples", type=int, default=len(DOCS))
+    parser.add_argument(
+        "--foldbench-jsonl",
+        help="Optional JSONL with input_seq and contacts columns, e.g. exp82 foldbench_dev.jsonl.",
+    )
+    parser.add_argument(
+        "--max-contacts",
+        type=int,
+        default=None,
+        help="Use only the first N contacts from each JSONL row to keep T4 smoke memory bounded.",
+    )
+    parser.add_argument(
+        "--logit-clip",
+        type=float,
+        default=50.0,
+        help="Clamp model logits before log_softmax for fp16 smoke stability. Use 'nan' to disable.",
+    )
+    parser.add_argument(
+        "--check-gradient",
+        action="store_true",
+        help="Backprop through the Torch gather loss to the logits. This avoids full model backprop/OOM.",
+    )
+    args = parser.parse_args()
+    if math.isnan(args.logit_clip):
+        args.logit_clip = None
+    compare_once(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/summary_narrative.md
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/summary_narrative.md
@@ -10,4 +10,10 @@ The current serialized next-token objective penalizes arbitrary contact ordering
 
 ## Results so far
 
-Implementation in progress.
+The greedy-set objective now trains inside Levanter's jitted `Trainer` loop and logs greedy-set validation loss. On a short 1×H100 rerun, greedy validation reached `5.393` and auxiliary next-token CE validation reached `5.419` at step 74. The earlier 300-step stock next-token H100 run reached CE `4.19192`, so this is not yet a fair same-step win for greedy.
+
+On 4×GB200, high-LR (`3.1623e-3`) runs looked unstable/overfit: next-token finished with CE eval `5.516`, while greedy finished with greedy-set eval `5.674` after disabling the auxiliary next-token CE hook for multi-GPU greedy runs. That hook currently hits a fused-CE axis mismatch on local multi-GPU meshes.
+
+## Next
+
+Run lower-LR (`3e-4`) 8×H100 comparisons and keep multi-GPU greedy validation on the greedy-set metric until next-token CE eval is made non-fused or otherwise mesh-safe.

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/summary_narrative.md
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/summary_narrative.md
@@ -1,0 +1,13 @@
+# Summary slides — contacts-v1 greedy set loss
+
+## What we're doing
+
+Prototype a contacts-v1-specific greedy latent-order loss that treats the contact list as an unordered set during training.
+
+## Why
+
+The current serialized next-token objective penalizes arbitrary contact ordering and orientation choices. A greedy set loss may let the model learn easy contacts first and use those emitted contacts as context for harder ones.
+
+## Results so far
+
+Implementation in progress.

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
@@ -17,6 +17,7 @@ a contacts-v1 greedy latent-set objective.
 import argparse
 import dataclasses
 import os
+from collections.abc import Callable
 from datetime import timedelta
 
 import jmp
@@ -485,6 +486,34 @@ def _run_single_pass_smoke(config: TrainLmOnPodConfig) -> None:
         print(f"[exp156] single-pass greedy-set smoke loss = {float(loss):.6f}")
 
 
+def _gpu_telemetry_enabled() -> bool:
+    return EXP156_ACCELERATOR == "gpu" and os.environ.get("EXP156_ENABLE_GPU_TELEMETRY", "1") != "0"
+
+
+def _run_with_gpu_telemetry(pod_config: TrainLmOnPodConfig, train_fn: Callable[[TrainLmOnPodConfig], None]) -> None:
+    if not _gpu_telemetry_enabled():
+        train_fn(pod_config)
+        return
+
+    try:
+        from marin.monitoring.gpu_telemetry import NvidiaSmiTelemetryConfig, nvidia_smi_telemetry
+    except ModuleNotFoundError:
+        from exp156_gpu_telemetry import NvidiaSmiTelemetryConfig, nvidia_smi_telemetry
+
+    output_uri = f"{pod_config.output_path.rstrip('/')}/telemetry/gpu"
+    telemetry_config = NvidiaSmiTelemetryConfig(
+        output_uri=output_uri,
+        interval=float(os.environ.get("EXP156_GPU_TELEMETRY_INTERVAL", "5")),
+        records_per_chunk=int(os.environ.get("EXP156_GPU_TELEMETRY_RECORDS_PER_CHUNK", "120")),
+        max_queue_items=int(os.environ.get("EXP156_GPU_TELEMETRY_MAX_QUEUE_ITEMS", "10000")),
+        log_every=int(os.environ.get("EXP156_GPU_TELEMETRY_LOG_EVERY", "120")),
+        stop_timeout=float(os.environ.get("EXP156_GPU_TELEMETRY_STOP_TIMEOUT", "30")),
+    )
+    print(f"[exp156] writing GPU telemetry to {output_uri}")
+    with nvidia_smi_telemetry(telemetry_config):
+        train_fn(pod_config)
+
+
 def _run_with_pinned_tokenizer(pod_config: TrainLmOnPodConfig) -> None:
     """Stage tokenizer and optional HF warm-start before custom training."""
     from marinfold.registry import resolve_model
@@ -525,12 +554,20 @@ def _run_stock_next_token_train(pod_config: TrainLmOnPodConfig) -> None:
     )
 
 
+def _run_stock_next_token_train_with_telemetry(pod_config: TrainLmOnPodConfig) -> None:
+    _run_with_gpu_telemetry(pod_config, _run_stock_next_token_train)
+
+
+def _run_greedy_set_train_with_telemetry(pod_config: TrainLmOnPodConfig) -> None:
+    _run_with_gpu_telemetry(pod_config, _run_with_pinned_tokenizer)
+
+
 def _train_job(pod_config: TrainLmOnPodConfig) -> None:
     if LOSS_KIND == "next-token":
-        remote(_run_stock_next_token_train, resources=pod_config.resources)(pod_config)
+        remote(_run_stock_next_token_train_with_telemetry, resources=pod_config.resources)(pod_config)
         return
     if LOSS_KIND == "greedy-set":
-        remote(_run_with_pinned_tokenizer, resources=pod_config.resources)(pod_config)
+        remote(_run_greedy_set_train_with_telemetry, resources=pod_config.resources)(pod_config)
         return
     raise ValueError(f"unsupported EXP156_LOSS_KIND={LOSS_KIND!r}")
 
@@ -573,6 +610,13 @@ def _identity_config(
             "shuffle": True,
             "mixture_block_size": 1,
             "block_cross_document_attention": True,
+        },
+        "gpu_telemetry": {
+            "enabled": EXP156_ACCELERATOR == "gpu" and os.environ.get("EXP156_ENABLE_GPU_TELEMETRY", "1") != "0",
+            "interval": float(os.environ.get("EXP156_GPU_TELEMETRY_INTERVAL", "5")),
+            "records_per_chunk": int(os.environ.get("EXP156_GPU_TELEMETRY_RECORDS_PER_CHUNK", "120")),
+            "max_queue_items": int(os.environ.get("EXP156_GPU_TELEMETRY_MAX_QUEUE_ITEMS", "10000")),
+            "log_every": int(os.environ.get("EXP156_GPU_TELEMETRY_LOG_EVERY", "120")),
         },
         "trainer": {
             "train_batch_size": train_batch_size,
@@ -691,7 +735,16 @@ def build_step() -> ArtifactStep[LevanterCheckpoint]:
             pad_tokenizer_to_match_model=True,
         )
         env_vars = {"WANDB_ENTITY": "open-athena", "WANDB_PROJECT": "MarinFold"}
-        for env_name in ("WANDB_API_KEY", "WANDB_MODE"):
+        for env_name in (
+            "WANDB_API_KEY",
+            "WANDB_MODE",
+            "EXP156_ENABLE_GPU_TELEMETRY",
+            "EXP156_GPU_TELEMETRY_INTERVAL",
+            "EXP156_GPU_TELEMETRY_RECORDS_PER_CHUNK",
+            "EXP156_GPU_TELEMETRY_MAX_QUEUE_ITEMS",
+            "EXP156_GPU_TELEMETRY_LOG_EVERY",
+            "EXP156_GPU_TELEMETRY_STOP_TIMEOUT",
+        ):
             env_value = os.environ.get(env_name)
             if env_value:
                 env_vars[env_name] = env_value

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
@@ -1,17 +1,17 @@
 # Copyright The MarinFold Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Build or launch the exp156 contacts-v1 greedy set-loss prototype.
+"""Build or launch the exp156 contacts-v1 greedy set-loss experiment.
 
 This follows the exp147 custom-experiment shape: the experiment owns the launch
 script and the nonstandard training entrypoint instead of routing through
 Levanter's stock ``train_lm.main`` loss function.
 
-Current state: the Marin/Iris config plumbing is scaffolded, but the actual
-Levanter ``Trainer`` loop is deliberately left behind
-``run_contacts_v1_greedy_train_lm``. That is the next code we should write
-carefully: it must replace the stock ``model.compute_next_token_loss`` call with
-a contacts-v1 greedy latent-set objective.
+The experiment can run either stock next-token CE or the contacts-v1 greedy
+latent-set objective. The greedy arm uses a custom Levanter ``Trainer`` loop so
+it can replace ``model.compute_next_token_loss`` with contacts-v1 target parsing
+and greedy pair matching while still using standard checkpointing, evaluation
+hooks, W&B tracking, and optional GPU telemetry.
 """
 
 import argparse
@@ -391,7 +391,9 @@ def run_contacts_v1_greedy_train_lm(config: TrainLmOnPodConfig) -> None:
 
 def _run_greedy_train(config: TrainLmOnPodConfig) -> None:
     """Run Levanter Trainer with the contacts-v1 greedy set loss."""
+    import equinox as eqx
     import levanter
+    import levanter.callbacks as callbacks
     import levanter.trainer
     from levanter.trainer import Trainer
     from marin.training.training import _prepare_training_run
@@ -425,6 +427,7 @@ def _run_greedy_train(config: TrainLmOnPodConfig) -> None:
         vocab_size = len(tokenizer)
         Vocab = round_axis_for_partitioning(Axis("vocab", vocab_size), trainer.parameter_axis_mapping)
         train_dataset = train_config.data.train_set(Pos, train_config.trainer.batch_schedule, key=data_key)
+        validation_sets = train_config.data.validation_sets(Pos)
 
         model = train_config.model.build(Vocab, key=model_key)
         if train_config.initialize_from_hf:
@@ -445,6 +448,47 @@ def _run_greedy_train(config: TrainLmOnPodConfig) -> None:
             model = named_jit(trainer.mp.cast_to_param, trainer.parameter_axis_mapping)(model)
 
         state = trainer.initial_state(training_key, model=model)
+
+        @eqx.filter_jit
+        def _greedy_eval_loss(eval_model, example):
+            eval_model = trainer.mp.cast_to_compute(eval_model)
+            loss, _metrics = _loss(eval_model, example, key=None)
+            return loss, {}
+
+        @eqx.filter_jit
+        def _next_token_eval_loss(eval_model, example):
+            eval_model = trainer.mp.cast_to_compute(eval_model)
+            loss = eval_model.compute_next_token_loss(example, key=None)
+            return loss, {}
+
+        if not validation_sets:
+            print("[exp156] no validation datasets provided for greedy-set run")
+        for name, dataset in validation_sets.items():
+            eval_name = name or "validation"
+            greedy_loader = trainer.data_loader(dataset, trainer.EvalBatch)
+            trainer.add_hook(
+                callbacks.compute_validation_loss(
+                    _greedy_eval_loss,
+                    greedy_loader,
+                    max_batches=train_config.trainer.max_eval_batches,
+                    name=f"{eval_name}/greedy_set",
+                ),
+                every=train_config.trainer.steps_per_eval,
+            )
+            if os.environ.get("EXP156_ENABLE_GREEDY_NEXT_TOKEN_EVAL", "1") == "1":
+                next_token_loader = trainer.data_loader(dataset, trainer.EvalBatch)
+                trainer.add_hook(
+                    callbacks.compute_validation_loss(
+                        _next_token_eval_loss,
+                        next_token_loader,
+                        max_batches=train_config.trainer.max_eval_batches,
+                        name=f"{eval_name}/next_token",
+                    ),
+                    every=train_config.trainer.steps_per_eval,
+                )
+            else:
+                print(f"[exp156] skipping next-token validation hook for {eval_name}")
+
         train_loader = trainer.data_loader(train_dataset).iter_from_step(state.step)
         trainer.train(state, train_loader)
     trainer.tracker.finish()
@@ -585,12 +629,13 @@ def _identity_config(
     max_eval_batches: int | None,
 ) -> dict[str, object]:
     """Return stable experiment decisions used for artifact fingerprinting."""
+    learning_rate = float(os.environ.get("EXP156_LEARNING_RATE", "3.1623e-3"))
     return {
         "name": name,
         "model": MODEL_CONFIG,
         "initialize_from_hf": INITIALIZE_FROM_HF,
         "optimizer": AdamConfig(
-            learning_rate=3.1623e-3,
+            learning_rate=learning_rate,
             weight_decay=0.2,
             beta1=0.9,
             beta2=0.95,

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
@@ -85,6 +85,8 @@ else:
     default_val_glob = f"{ROOT}/exp53_contacts_v1_5x/documents/val/*.parquet"
 CONTACTS_V1_TRAIN_GLOB = os.environ.get("EXP156_TRAIN_GLOB", default_train_glob)
 CONTACTS_V1_VAL_GLOB = os.environ.get("EXP156_VAL_GLOB", default_val_glob)
+TOKENIZED_TRAIN_CACHE = os.environ.get("EXP156_TOKENIZED_TRAIN_CACHE")
+TOKENIZED_VAL_CACHE = os.environ.get("EXP156_TOKENIZED_VAL_CACHE")
 
 CONTACTS_TOKENIZER_REPO = "timodonnell/contacts-v1-tokenizer"
 CONTACTS_TOKENIZER_REVISION = "5d68a24a899f"
@@ -174,6 +176,22 @@ def _tokenized_step(*, split: str, paths: list[str]) -> ArtifactStep[TokenizedCa
             disk="10g",
             zone=TPU_ZONE if EXP156_ACCELERATOR == "tpu" else None,
         ),
+    )
+
+
+def _cached_tokenized_step(*, split: str, paths: list[str], cache_root: str | None) -> ArtifactStep[TokenizedCache]:
+    """Return an adopted mirror when both copied cache roots are configured."""
+    if cache_root is None:
+        return _tokenized_step(split=split, paths=paths)
+    return ArtifactStep.adopt(
+        name=f"tokenized/contacts-v1-{split}",
+        version=DATA_VERSION,
+        source=cache_root,
+        kind=TokenizedCache,
+        config={
+            "tokenizer": CONTACTS_TOKENIZER_REPO,
+            "format": {"text_key": "document"},
+        },
     )
 
 
@@ -693,8 +711,20 @@ def _identity_config(
 
 def build_step() -> ArtifactStep[LevanterCheckpoint]:
     """Build the lazy training artifact without submitting it."""
-    train = _tokenized_step(split="train", paths=[CONTACTS_V1_TRAIN_GLOB])
-    validation = _tokenized_step(split="val", paths=[CONTACTS_V1_VAL_GLOB])
+    if (TOKENIZED_TRAIN_CACHE is None) != (TOKENIZED_VAL_CACHE is None):
+        raise ValueError(
+            "EXP156_TOKENIZED_TRAIN_CACHE and EXP156_TOKENIZED_VAL_CACHE must be set together"
+        )
+    train = _cached_tokenized_step(
+        split="train",
+        paths=[CONTACTS_V1_TRAIN_GLOB],
+        cache_root=TOKENIZED_TRAIN_CACHE,
+    )
+    validation = _cached_tokenized_step(
+        split="val",
+        paths=[CONTACTS_V1_VAL_GLOB],
+        cache_root=TOKENIZED_VAL_CACHE,
+    )
     steps = int(os.environ.get("EXP156_STEPS", "10"))
     steps_per_eval = int(os.environ.get("EXP156_STEPS_PER_EVAL", "10"))
     train_batch_size = int(os.environ.get("EXP156_TRAIN_BATCH_SIZE", "16"))

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
@@ -563,7 +563,10 @@ def _run_with_gpu_telemetry(pod_config: TrainLmOnPodConfig, train_fn: Callable[[
     try:
         from marin.monitoring.gpu_telemetry import NvidiaSmiTelemetryConfig, nvidia_smi_telemetry
     except ModuleNotFoundError:
-        from exp156_gpu_telemetry import NvidiaSmiTelemetryConfig, nvidia_smi_telemetry
+        from experiments.exp156_models_contacts_v1_greedy_set_loss.exp156_gpu_telemetry import (
+            NvidiaSmiTelemetryConfig,
+            nvidia_smi_telemetry,
+        )
 
     output_uri = f"{pod_config.output_path.rstrip('/')}/telemetry/gpu"
     telemetry_config = NvidiaSmiTelemetryConfig(

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
@@ -34,7 +34,8 @@ from iris.client.client import get_iris_ctx
 from levanter.adaptor import NoAdaptorConfig
 from levanter.checkpoint import CheckpointerConfig
 from levanter.compat.hf_checkpoints import HFCompatConfig
-from levanter.data.text.datasets import DatasetComponent, LmDataConfig
+from levanter.data.text.datasets import DatasetComponent, LmDataConfig, UrlDatasetSourceConfig
+from levanter.data.text.formats import TextLmDatasetFormat
 from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
 from levanter.main.train_lm import TrainLmConfig
 from levanter.models.qwen import Qwen3Config
@@ -179,20 +180,22 @@ def _tokenized_step(*, split: str, paths: list[str]) -> ArtifactStep[TokenizedCa
     )
 
 
-def _cached_tokenized_step(*, split: str, paths: list[str], cache_root: str | None) -> ArtifactStep[TokenizedCache]:
-    """Return an adopted mirror when both copied cache roots are configured."""
-    if cache_root is None:
-        return _tokenized_step(split=split, paths=paths)
-    return ArtifactStep.adopt(
-        name=f"tokenized/contacts-v1-{split}",
-        version=DATA_VERSION,
-        source=cache_root,
-        kind=TokenizedCache,
-        config={
-            "tokenizer": CONTACTS_TOKENIZER_REPO,
-            "format": {"text_key": "document"},
-        },
+def _mirrored_cache_component(cache_root: str) -> DatasetComponent:
+    """Build a Levanter component for a legacy mirrored cache without an artifact record.
+
+    The exp67 cache's ``.artifact.json`` is the legacy JSON literal ``null``, so
+    ``TokenizedCache.raw_load`` cannot adopt it. Its Levanter cache layout is
+    nevertheless complete and validated; construct the same component that a
+    typed cache would expose, with contacts-v1's document-text format.
+    """
+    source = UrlDatasetSourceConfig(
+        tags=[],
+        train_urls=[],
+        validation_urls=[],
+        cache_dir=cache_root,
+        format=TextLmDatasetFormat(text_key="document"),
     )
+    return DatasetComponent(source=source, cache_dir=source.cache_dir, format=source.format, tags=source.tags)
 
 
 def _component(cache: TokenizedCache) -> DatasetComponent:
@@ -636,8 +639,8 @@ def _train_job(pod_config: TrainLmOnPodConfig) -> None:
 
 def _identity_config(
     ctx: StepContext,
-    train: ArtifactStep[TokenizedCache],
-    validation: ArtifactStep[TokenizedCache],
+    train: ArtifactStep[TokenizedCache] | None,
+    validation: ArtifactStep[TokenizedCache] | None,
     *,
     name: str,
     steps: int,
@@ -666,8 +669,8 @@ def _identity_config(
             "implementation": "stock Levanter CE" if LOSS_KIND == "next-token" else "custom Trainer greedy set loss",
         },
         "data": {
-            "train": ctx.artifact_path(train),
-            "validation": ctx.artifact_path(validation),
+            "train": TOKENIZED_TRAIN_CACHE or ctx.artifact_path(train),
+            "validation": TOKENIZED_VAL_CACHE or ctx.artifact_path(validation),
             "tokenizer": CONTACTS_TOKENIZER,
             "format": "contacts-v1 serialized parquet documents",
             "shuffle": True,
@@ -715,16 +718,8 @@ def build_step() -> ArtifactStep[LevanterCheckpoint]:
         raise ValueError(
             "EXP156_TOKENIZED_TRAIN_CACHE and EXP156_TOKENIZED_VAL_CACHE must be set together"
         )
-    train = _cached_tokenized_step(
-        split="train",
-        paths=[CONTACTS_V1_TRAIN_GLOB],
-        cache_root=TOKENIZED_TRAIN_CACHE,
-    )
-    validation = _cached_tokenized_step(
-        split="val",
-        paths=[CONTACTS_V1_VAL_GLOB],
-        cache_root=TOKENIZED_VAL_CACHE,
-    )
+    train = None if TOKENIZED_TRAIN_CACHE else _tokenized_step(split="train", paths=[CONTACTS_V1_TRAIN_GLOB])
+    validation = None if TOKENIZED_VAL_CACHE else _tokenized_step(split="val", paths=[CONTACTS_V1_VAL_GLOB])
     steps = int(os.environ.get("EXP156_STEPS", "10"))
     steps_per_eval = int(os.environ.get("EXP156_STEPS_PER_EVAL", "10"))
     train_batch_size = int(os.environ.get("EXP156_TRAIN_BATCH_SIZE", "16"))
@@ -755,8 +750,12 @@ def build_step() -> ArtifactStep[LevanterCheckpoint]:
         val_key = "tokenized/contacts-v1-val"
         data = LmDataConfig(
             components={
-                train_key: _component(ctx.resolved(train)),
-                val_key: _component(ctx.resolved(validation)),
+                train_key: _mirrored_cache_component(TOKENIZED_TRAIN_CACHE)
+                if TOKENIZED_TRAIN_CACHE
+                else _component(ctx.resolved(train)),
+                val_key: _mirrored_cache_component(TOKENIZED_VAL_CACHE)
+                if TOKENIZED_VAL_CACHE
+                else _component(ctx.resolved(validation)),
             },
             train_weights={train_key: 1.0, val_key: 0.0},
             tokenizer=CONTACTS_TOKENIZER,
@@ -837,7 +836,7 @@ def build_step() -> ArtifactStep[LevanterCheckpoint]:
         artifact_type=LevanterCheckpoint,
         run=_train_job,
         build_config=build_config,
-        deps=(train, validation),
+        deps=tuple(step for step in (train, validation) if step is not None),
         runtime_args={"train_resources": RESOURCES},
     )
 

--- a/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
+++ b/experiments/exp156_models_contacts_v1_greedy_set_loss/train.py
@@ -1,0 +1,744 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build or launch the exp156 contacts-v1 greedy set-loss prototype.
+
+This follows the exp147 custom-experiment shape: the experiment owns the launch
+script and the nonstandard training entrypoint instead of routing through
+Levanter's stock ``train_lm.main`` loss function.
+
+Current state: the Marin/Iris config plumbing is scaffolded, but the actual
+Levanter ``Trainer`` loop is deliberately left behind
+``run_contacts_v1_greedy_train_lm``. That is the next code we should write
+carefully: it must replace the stock ``model.compute_next_token_loss`` call with
+a contacts-v1 greedy latent-set objective.
+"""
+
+import argparse
+import dataclasses
+import os
+from datetime import timedelta
+
+import jmp
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+import numpy as np
+from fray.types import ResourceConfig
+import haliax as hax
+from haliax import Axis
+from haliax.partitioning import ResourceAxis, named_jit, round_axis_for_partitioning
+from huggingface_hub import snapshot_download
+from iris.client.client import get_iris_ctx
+from levanter.adaptor import NoAdaptorConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.compat.hf_checkpoints import HFCompatConfig
+from levanter.data.text.datasets import DatasetComponent, LmDataConfig
+from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
+from levanter.main.train_lm import TrainLmConfig
+from levanter.models.qwen import Qwen3Config
+from levanter.optim.config import AdamConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import Trainer, TrainerConfig
+from levanter.utils.mesh import MeshConfig
+from marin.execution.lazy import ArtifactStep, StepContext, lower
+from marin.execution.remote import remote
+from marin.execution.step_runner import StepRunner
+from marin.experiment.data import tokenized
+from marin.experiment.namespacing import user_namespaced_name
+from marin.processing.tokenize.tokenize import TokenizedCache
+from marin.training.training import LevanterCheckpoint, TrainLmOnPodConfig, run_levanter_train_lm
+from marinfold.document_structures.contacts_v1.greedy_set_loss import (
+    greedy_matched_contact_block_loss,
+    parse_contact_block_targets,
+)
+
+DEFAULT_COREWEAVE_BASE_PREFIX = "s3://marin-us-east-02a/marin/protein-structure/MarinFold"
+DEFAULT_COREWEAVE_CONTACTS_V1_PREFIX = "s3://marin-us-east-02a/MarinFold/data/document_structures/contacts_v1"
+DEFAULT_GCS_BASE_PREFIX = "gs://marin-us-east5/protein-structure/MarinFold"
+
+
+def _default_base_prefix() -> str:
+    if "EXP156_BASE_PREFIX" in os.environ:
+        return os.environ["EXP156_BASE_PREFIX"].rstrip("/")
+    marin_prefix = os.environ.get("MARIN_PREFIX")
+    if marin_prefix is not None and marin_prefix.startswith("s3://"):
+        return f"{marin_prefix.rstrip('/')}/protein-structure/MarinFold"
+    if os.environ.get("EXP156_ACCELERATOR", "gpu") == "gpu":
+        return DEFAULT_COREWEAVE_BASE_PREFIX
+    return DEFAULT_GCS_BASE_PREFIX
+
+
+ROOT = _default_base_prefix()
+MARIN_PREFIX = f"{ROOT}/exp156_contacts_v1_greedy_set_loss"
+os.environ["MARIN_PREFIX"] = MARIN_PREFIX
+
+# CoreWeave jobs should use S3, not GCS. The contacts-v1 mirror currently lives
+# under the top-level MarinFold/data prefix, while exp156 outputs default under
+# s3://.../marin/protein-structure/MarinFold.
+if os.environ.get("EXP156_ACCELERATOR", "gpu") == "gpu":
+    default_train_glob = f"{DEFAULT_COREWEAVE_CONTACTS_V1_PREFIX}/train/*.parquet"
+    default_val_glob = f"{DEFAULT_COREWEAVE_CONTACTS_V1_PREFIX}/val/*.parquet"
+else:
+    default_train_glob = f"{ROOT}/exp53_contacts_v1_5x/documents/train/*.parquet"
+    default_val_glob = f"{ROOT}/exp53_contacts_v1_5x/documents/val/*.parquet"
+CONTACTS_V1_TRAIN_GLOB = os.environ.get("EXP156_TRAIN_GLOB", default_train_glob)
+CONTACTS_V1_VAL_GLOB = os.environ.get("EXP156_VAL_GLOB", default_val_glob)
+
+CONTACTS_TOKENIZER_REPO = "timodonnell/contacts-v1-tokenizer"
+CONTACTS_TOKENIZER_REVISION = "5d68a24a899f"
+CONTACTS_TOKENIZER = f"{CONTACTS_TOKENIZER_REPO}@{CONTACTS_TOKENIZER_REVISION}"
+TOKENIZER_ALLOW_PATTERNS = (
+    "tokenizer*",
+    "chat_template*",
+    "special_tokens*",
+    "added_tokens*",
+    "vocab*",
+    "merges*",
+    "spiece*",
+    "*.tiktoken",
+)
+ARTIFACT_VERSION = os.environ.get("EXP156_VERSION", "exp156-dev")
+DATA_VERSION = os.environ.get("EXP156_DATA_VERSION", "2026.07.24")
+
+MODEL_CONFIG = Qwen3Config(
+    max_seq_len=8192,
+    hidden_dim=2048,
+    intermediate_dim=8192,
+    num_heads=32,
+    num_kv_heads=8,
+    num_layers=24,
+    rope=Llama3RotaryEmbeddingsConfig(),
+)
+
+EXP156_ACCELERATOR = os.environ.get("EXP156_ACCELERATOR", "gpu")
+TPU_TYPE = os.environ.get("EXP156_TPU", "v6e-8")
+TPU_ZONE = os.environ.get("EXP156_ZONE", "us-east5-b")
+GPU_TYPE = os.environ.get("EXP156_GPU", "H100")
+GPU_COUNT = int(os.environ.get("EXP156_GPU_COUNT", "1"))
+
+if EXP156_ACCELERATOR == "gpu":
+    RESOURCES = ResourceConfig.with_gpu(
+        GPU_TYPE,
+        count=GPU_COUNT,
+        cpu=float(os.environ.get("EXP156_CPU", "16")),
+        ram=os.environ.get("EXP156_RAM", "128g"),
+        disk=os.environ.get("EXP156_DISK", "200g"),
+    )
+elif EXP156_ACCELERATOR == "tpu":
+    RESOURCES = ResourceConfig.with_tpu(
+        TPU_TYPE,
+        slice_count=1,
+        cpu=32,
+        ram="128g",
+        disk="50g",
+        zone=TPU_ZONE,
+    )
+else:
+    raise ValueError(f"unsupported EXP156_ACCELERATOR={EXP156_ACCELERATOR!r}")
+
+# Start from the current best contacts-v1 HF export by default. On CoreWeave we
+# stage this from the open-athena HF bucket to the local worker cache, then pass
+# the local directory to Levanter's HF initializer.
+INITIALIZE_FROM_HF = os.environ.get("EXP156_INITIALIZE_FROM_HF", "contacts-v1-exp120-1.5B")
+LOSS_KIND = os.environ.get("EXP156_LOSS_KIND", "greedy-set")
+
+TAGS = (
+    "protein",
+    "contacts-v1",
+    "greedy-set-loss",
+    "latent-order",
+    "qwen3",
+    "exp156",
+    "prototype",
+)
+TOKEN_AXES = (
+    ResourceAxis.REPLICA_DCN,
+    ResourceAxis.REPLICA,
+    ResourceAxis.DATA,
+)
+
+
+def _tokenized_step(*, split: str, paths: list[str]) -> ArtifactStep[TokenizedCache]:
+    return tokenized(
+        name=f"tokenized/contacts-v1-{split}",
+        paths=paths,
+        tokenizer=CONTACTS_TOKENIZER_REPO,
+        version=DATA_VERSION,
+        validation=split != "train",
+        text_key="document",
+        resources=ResourceConfig.with_cpu(
+            cpu=4,
+            ram="16g",
+            disk="10g",
+            zone=TPU_ZONE if EXP156_ACCELERATOR == "tpu" else None,
+        ),
+    )
+
+
+def _component(cache: TokenizedCache) -> DatasetComponent:
+    # Greedy parsing expects one contacts-v1 document per row. Keep the baseline
+    # arm unpacked too unless explicitly overridden, so the 1000-step comparison
+    # changes the loss rather than the packing semantics.
+    pack = os.environ.get("EXP156_PACK", "0") == "1"
+    return dataclasses.replace(cache.as_component(), pack=pack)
+
+
+def _with_local_tokenizer_and_hf_init(
+    pod_config: TrainLmOnPodConfig,
+    *,
+    tokenizer_path: str,
+    hf_init_path: str | None,
+) -> TrainLmOnPodConfig:
+    train_config = dataclasses.replace(
+        pod_config.train_config,
+        data=dataclasses.replace(
+            pod_config.train_config.data,
+            tokenizer=tokenizer_path,
+        ),
+    )
+    if hf_init_path is not None:
+        train_config = dataclasses.replace(
+            train_config,
+            initialize_from_hf=hf_init_path,
+            pad_tokenizer_to_match_model=True,
+        )
+    return dataclasses.replace(pod_config, train_config=train_config)
+
+
+def _token_id(tokenizer, token: str) -> int:
+    token_id = tokenizer.convert_tokens_to_ids(token)
+    if token_id is None or int(token_id) < 0:
+        raise ValueError(f"token {token!r} is absent from tokenizer")
+    return int(token_id)
+
+
+def _position_token_ids(tokenizer, *, count: int = 2000) -> np.ndarray:
+    return np.asarray([_token_id(tokenizer, f"<p{index}>") for index in range(count)], dtype=np.int64)
+
+
+def contacts_v1_greedy_jax_loss(
+    log_probs: jnp.ndarray,
+    token_ids: jnp.ndarray,
+    *,
+    begin_statements_token_id: int,
+    contact_token_id: int,
+    end_token_id: int,
+    max_contact_slots: int,
+) -> jnp.ndarray:
+    """Differentiable hard-assignment contacts-v1 loss for one token row.
+
+    The contact-slot assignment is discrete (`argmax`) and therefore treated as
+    stop-gradient. The returned CE gathers from JAX `log_probs`, so gradients
+    flow to the selected token logits.
+    """
+    seq_len = token_ids.shape[0]
+    positions = jnp.arange(seq_len)
+    begin_position = jnp.argmax(token_ids == begin_statements_token_id)
+    after_begin = positions > begin_position
+    end_candidates = jnp.where(after_begin & (token_ids == end_token_id), positions, seq_len - 1)
+    end_position = jnp.min(end_candidates)
+
+    prefix_positions = positions < begin_position
+    prefix_targets = jnp.roll(token_ids, -1)
+    prefix_loss = -jnp.sum(jnp.where(prefix_positions, log_probs[positions, prefix_targets], 0.0))
+    prefix_count = jnp.sum(prefix_positions.astype(jnp.float32))
+
+    contact_mask = (token_ids == contact_token_id) & (positions > begin_position) & (positions < end_position)
+    slot_positions = jnp.where(contact_mask, size=max_contact_slots, fill_value=0)[0]
+    n_slots_total = jnp.sum(contact_mask.astype(jnp.int32))
+    n_slots = jnp.minimum(n_slots_total, max_contact_slots)
+    slot_index = jnp.arange(max_contact_slots)
+    valid_slot = slot_index < n_slots
+
+    left_tokens = token_ids[jnp.minimum(slot_positions + 1, seq_len - 1)]
+    right_tokens = token_ids[jnp.minimum(slot_positions + 2, seq_len - 1)]
+    pair_left = jnp.minimum(left_tokens, right_tokens)
+    pair_right = jnp.maximum(left_tokens, right_tokens)
+
+    marker_scores = log_probs[jnp.maximum(slot_positions - 1, 0), contact_token_id]
+    left_pred_positions = slot_positions
+    right_pred_positions = jnp.minimum(slot_positions + 1, seq_len - 1)
+    forward = log_probs[left_pred_positions[:, None], pair_left[None, :]] + log_probs[
+        right_pred_positions[:, None], pair_right[None, :]
+    ]
+    reverse = log_probs[left_pred_positions[:, None], pair_right[None, :]] + log_probs[
+        right_pred_positions[:, None], pair_left[None, :]
+    ]
+    pair_scores = marker_scores[:, None] + jnp.maximum(forward, reverse)
+
+    def _match_one(carry, slot_i):
+        remaining, loss = carry
+        candidate_mask = remaining & valid_slot
+        masked_scores = jnp.where(candidate_mask, pair_scores[slot_i], -jnp.inf)
+        pair_i = jnp.argmax(masked_scores)
+        best_score = pair_scores[slot_i, pair_i]
+        use_slot = valid_slot[slot_i]
+        remaining = remaining.at[pair_i].set(jnp.where(use_slot, False, remaining[pair_i]))
+        loss = loss - jnp.where(use_slot, best_score, 0.0)
+        return (remaining, loss), None
+
+    initial_remaining = valid_slot
+    (_, pair_loss), _ = jax.lax.scan(
+        _match_one,
+        (initial_remaining, jnp.asarray(0.0, dtype=log_probs.dtype)),
+        jnp.arange(max_contact_slots),
+    )
+    end_loss = -log_probs[jnp.maximum(end_position - 1, 0), end_token_id]
+    denom = jnp.maximum(prefix_count + 3.0 * n_slots.astype(jnp.float32) + 1.0, 1.0)
+    return (prefix_loss + pair_loss + end_loss) / denom
+
+
+def contacts_v1_greedy_batch_loss(
+    model,
+    example,
+    tokenizer,
+    *,
+    key=None,
+    max_contact_slots: int,
+) -> tuple[jnp.ndarray, dict[str, jnp.ndarray]]:
+    logits = model(example.tokens, example.attn_mask, key=key)
+    log_probs = jax.nn.log_softmax(logits.array, axis=-1)
+    tokens = example.tokens.array
+    begin_id = _token_id(tokenizer, "<begin_statements>")
+    contact_id = _token_id(tokenizer, "<contact>")
+    end_id = _token_id(tokenizer, "<end>")
+    losses = jax.vmap(
+        lambda row_log_probs, row_tokens: contacts_v1_greedy_jax_loss(
+            row_log_probs,
+            row_tokens,
+            begin_statements_token_id=begin_id,
+            contact_token_id=contact_id,
+            end_token_id=end_id,
+            max_contact_slots=max_contact_slots,
+        )
+    )(log_probs, tokens)
+    loss = jnp.mean(losses)
+    return loss, {"greedy_set_loss": loss}
+
+
+def contacts_v1_greedy_single_pass_smoke_loss(model, example, tokenizer, *, key=None) -> jnp.ndarray:
+    """Run one model forward and compute a hard-matched greedy-set loss.
+
+    Host NumPy is used only to choose the greedy pair assignment. The returned
+    loss gathers from the original JAX log-probabilities, so gradients flow to
+    the selected logits. The assignment itself is hard / stop-gradient.
+    """
+    logits = model(example.tokens, example.attn_mask, key=key)
+    log_probs = jax.nn.log_softmax(logits.array, axis=-1)
+    log_probs_np = np.asarray(jax.device_get(log_probs))
+    tokens_np = np.asarray(jax.device_get(example.tokens.array))
+
+    begin_id = _token_id(tokenizer, "<begin_statements>")
+    contact_id = _token_id(tokenizer, "<contact>")
+    end_id = _token_id(tokenizer, "<end>")
+    position_ids = _position_token_ids(tokenizer)
+
+    row_losses: list[jnp.ndarray] = []
+    for row in range(tokens_np.shape[0]):
+        targets = parse_contact_block_targets(
+            tokens_np[row],
+            begin_statements_token_id=begin_id,
+            contact_token_id=contact_id,
+            end_token_id=end_id,
+            position_token_ids=position_ids,
+        )
+        matched = greedy_matched_contact_block_loss(
+            log_probs_np[row],
+            tokens_np[row],
+            begin_statements_token_id=begin_id,
+            contact_token_id=contact_id,
+            end_token_id=end_id,
+            position_token_ids=position_ids,
+        )
+
+        prefix_positions = jnp.arange(targets.begin_position)
+        prefix_targets = jnp.asarray(tokens_np[row, 1 : targets.begin_position + 1])
+        row_loss = -jnp.sum(log_probs[row, prefix_positions, prefix_targets])
+        for choice in matched.choices:
+            marker_pos, left_pos, right_pos = targets.slot_positions[choice.slot_index]
+            left_token, right_token = choice.oriented_tokens
+            row_loss = row_loss - log_probs[row, int(marker_pos) - 1, contact_id]
+            row_loss = row_loss - log_probs[row, int(left_pos) - 1, left_token]
+            row_loss = row_loss - log_probs[row, int(right_pos) - 1, right_token]
+        row_loss = row_loss - log_probs[row, targets.end_position - 1, end_id]
+        row_losses.append(row_loss)
+    return jnp.mean(jnp.stack(row_losses))
+
+
+def run_contacts_v1_greedy_train_lm(config: TrainLmOnPodConfig) -> None:
+    """Run Levanter training with the contacts-v1 greedy set loss.
+
+    This is the custom entrypoint that will replace Levanter's stock
+    ``train_lm.main`` call. The stock path hardcodes::
+
+        model.compute_next_token_loss(example)
+
+    Here we need to construct ``Trainer(..., contacts_v1_greedy_loss)`` instead.
+    The remaining work is to decide the batch object consumed by that loss:
+
+    1. a tokenized ``LmExample`` plus parser state reconstructed from token ids,
+       or
+    2. a contacts-v1 document batch carrying explicit sequence prefix and contact
+       pairs, similar in spirit to PR #144's custom document batch.
+    """
+    if os.environ.get("EXP156_SINGLE_PASS_SMOKE") == "1":
+        _run_single_pass_smoke(config)
+        return
+    _run_greedy_train(config)
+
+
+def _run_greedy_train(config: TrainLmOnPodConfig) -> None:
+    """Run Levanter Trainer with the contacts-v1 greedy set loss."""
+    import levanter
+    import levanter.trainer
+    from levanter.trainer import Trainer
+    from marin.training.training import _prepare_training_run
+
+    config, train_config, env = _prepare_training_run(config)
+    for key, value in env.items():
+        os.environ.setdefault(key, value)
+
+    tokenizer = train_config.data.the_tokenizer
+    levanter.trainer.initialize(train_config)
+    optimizer = train_config.optimizer.build(train_config.trainer.num_train_steps)
+    max_contact_slots = int(os.environ.get("EXP156_MAX_CONTACT_SLOTS", "1024"))
+
+    def _loss(model, example, *, key=None):
+        return contacts_v1_greedy_batch_loss(
+            model,
+            example,
+            tokenizer,
+            key=key,
+            max_contact_slots=max_contact_slots,
+        )
+
+    with Trainer(train_config.trainer, optimizer, _loss) as trainer:
+        seed = train_config.trainer.seed
+        data_key, model_key, training_key = jrandom.split(jrandom.PRNGKey(seed), 3)
+        if train_config.data_seed is not None:
+            data_key = jrandom.PRNGKey(train_config.data_seed)
+
+        train_length = train_config.train_seq_len or train_config.model.max_seq_len
+        Pos = train_config.model.max_Pos.resize(train_length)
+        vocab_size = len(tokenizer)
+        Vocab = round_axis_for_partitioning(Axis("vocab", vocab_size), trainer.parameter_axis_mapping)
+        train_dataset = train_config.data.train_set(Pos, train_config.trainer.batch_schedule, key=data_key)
+
+        model = train_config.model.build(Vocab, key=model_key)
+        if train_config.initialize_from_hf:
+            if not isinstance(train_config.model, HFCompatConfig):
+                raise TypeError("initialize_from_hf requires an HF-compatible model config")
+            converter = train_config.model.hf_checkpoint_converter().replaced(
+                reference_checkpoint=str(train_config.initialize_from_hf),
+                tokenizer=tokenizer,
+            )
+            if train_config.pad_tokenizer_to_match_model:
+                converter = converter.with_tokenizer_padded_to_match_model()
+            model = converter.load_pretrained(
+                train_config.model.model_type,
+                config=train_config.model,
+                axis_mapping=trainer.parameter_axis_mapping,
+                dtype=trainer.mp.compute_dtype,
+            )
+            model = named_jit(trainer.mp.cast_to_param, trainer.parameter_axis_mapping)(model)
+
+        state = trainer.initial_state(training_key, model=model)
+        train_loader = trainer.data_loader(train_dataset).iter_from_step(state.step)
+        trainer.train(state, train_loader)
+    trainer.tracker.finish()
+
+
+def _run_single_pass_smoke(config: TrainLmOnPodConfig) -> None:
+    """Build one batch/model and evaluate the smoke-only greedy loss once."""
+    import jax.random as jrandom
+    import levanter.trainer
+    from haliax import Axis
+    from haliax.partitioning import round_axis_for_partitioning
+    from levanter.trainer import Trainer
+    from marin.training.training import _prepare_training_run
+
+    config, train_config, env = _prepare_training_run(config)
+    for key, value in env.items():
+        os.environ.setdefault(key, value)
+
+    tokenizer = train_config.data.the_tokenizer
+    levanter.trainer.initialize(train_config)
+    optimizer = train_config.optimizer.build(train_config.trainer.num_train_steps)
+
+    def _zero_loss(_model, _example, *, key=None):
+        return jnp.asarray(0.0, dtype=jnp.float32)
+
+    with Trainer(train_config.trainer, optimizer, _zero_loss) as trainer:
+        seed = train_config.trainer.seed
+        data_key, model_key, training_key = jrandom.split(jrandom.PRNGKey(seed), 3)
+        train_length = train_config.train_seq_len or train_config.model.max_seq_len
+        Pos = train_config.model.max_Pos.resize(train_length)
+        vocab_size = len(tokenizer)
+        Vocab = round_axis_for_partitioning(Axis("vocab", vocab_size), trainer.parameter_axis_mapping)
+        train_dataset = train_config.data.train_set(Pos, train_config.trainer.batch_schedule, key=data_key)
+        state = trainer.initial_state(training_key, model_init=lambda: train_config.model.build(Vocab, key=model_key))
+        loader = trainer.data_loader(train_dataset).iter_from_step(0)
+        batch = next(iter(loader))
+        example = batch[0] if isinstance(batch, tuple) else batch
+        loss = contacts_v1_greedy_single_pass_smoke_loss(state.model, example, tokenizer)
+        print(f"[exp156] single-pass greedy-set smoke loss = {float(loss):.6f}")
+
+
+def _run_with_pinned_tokenizer(pod_config: TrainLmOnPodConfig) -> None:
+    """Stage tokenizer and optional HF warm-start before custom training."""
+    from marinfold.registry import resolve_model
+
+    tokenizer_path = snapshot_download(
+        repo_id=CONTACTS_TOKENIZER_REPO,
+        revision=CONTACTS_TOKENIZER_REVISION,
+        allow_patterns=list(TOKENIZER_ALLOW_PATTERNS),
+    )
+    hf_init = pod_config.train_config.initialize_from_hf
+    hf_init_path = str(resolve_model(hf_init)) if isinstance(hf_init, str) and hf_init else None
+    run_contacts_v1_greedy_train_lm(
+        _with_local_tokenizer_and_hf_init(
+            pod_config,
+            tokenizer_path=tokenizer_path,
+            hf_init_path=hf_init_path,
+        )
+    )
+
+
+def _run_stock_next_token_train(pod_config: TrainLmOnPodConfig) -> None:
+    """Run the baseline stock Levanter CE loss with the same staged assets."""
+    from marinfold.registry import resolve_model
+
+    tokenizer_path = snapshot_download(
+        repo_id=CONTACTS_TOKENIZER_REPO,
+        revision=CONTACTS_TOKENIZER_REVISION,
+        allow_patterns=list(TOKENIZER_ALLOW_PATTERNS),
+    )
+    hf_init = pod_config.train_config.initialize_from_hf
+    hf_init_path = str(resolve_model(hf_init)) if isinstance(hf_init, str) and hf_init else None
+    run_levanter_train_lm(
+        _with_local_tokenizer_and_hf_init(
+            pod_config,
+            tokenizer_path=tokenizer_path,
+            hf_init_path=hf_init_path,
+        )
+    )
+
+
+def _train_job(pod_config: TrainLmOnPodConfig) -> None:
+    if LOSS_KIND == "next-token":
+        remote(_run_stock_next_token_train, resources=pod_config.resources)(pod_config)
+        return
+    if LOSS_KIND == "greedy-set":
+        remote(_run_with_pinned_tokenizer, resources=pod_config.resources)(pod_config)
+        return
+    raise ValueError(f"unsupported EXP156_LOSS_KIND={LOSS_KIND!r}")
+
+
+def _identity_config(
+    ctx: StepContext,
+    train: ArtifactStep[TokenizedCache],
+    validation: ArtifactStep[TokenizedCache],
+    *,
+    name: str,
+    steps: int,
+    steps_per_eval: int,
+    train_batch_size: int,
+    per_device_parallelism: int,
+    max_eval_batches: int | None,
+) -> dict[str, object]:
+    """Return stable experiment decisions used for artifact fingerprinting."""
+    return {
+        "name": name,
+        "model": MODEL_CONFIG,
+        "initialize_from_hf": INITIALIZE_FROM_HF,
+        "optimizer": AdamConfig(
+            learning_rate=3.1623e-3,
+            weight_decay=0.2,
+            beta1=0.9,
+            beta2=0.95,
+            warmup=0.1,
+            lr_schedule="cosine",
+            min_lr_ratio=0.1,
+        ),
+        "loss": {
+            "kind": LOSS_KIND,
+            "implementation": "stock Levanter CE" if LOSS_KIND == "next-token" else "custom Trainer greedy set loss",
+        },
+        "data": {
+            "train": ctx.artifact_path(train),
+            "validation": ctx.artifact_path(validation),
+            "tokenizer": CONTACTS_TOKENIZER,
+            "format": "contacts-v1 serialized parquet documents",
+            "shuffle": True,
+            "mixture_block_size": 1,
+            "block_cross_document_attention": True,
+        },
+        "trainer": {
+            "train_batch_size": train_batch_size,
+            "per_device_parallelism": per_device_parallelism,
+            "num_train_steps": steps,
+            "steps_per_eval": steps_per_eval,
+            "max_eval_batches": max_eval_batches,
+            "precision": "p=f32,c=bfloat16",
+            "mesh": {"replica": 1, "data": -1, "model": 1},
+            "resources": {
+                "accelerator": EXP156_ACCELERATOR,
+                "gpu_type": GPU_TYPE if EXP156_ACCELERATOR == "gpu" else None,
+                "gpu_count": GPU_COUNT if EXP156_ACCELERATOR == "gpu" else None,
+                "tpu_type": TPU_TYPE if EXP156_ACCELERATOR == "tpu" else None,
+                "tpu_zone": TPU_ZONE if EXP156_ACCELERATOR == "tpu" else None,
+            },
+        },
+        "wandb": {
+            "entity": "open-athena",
+            "project": "MarinFold",
+            "group": "exp156-contacts-v1-greedy-set-loss",
+            "name": name,
+            "tags": TAGS,
+        },
+        "hf_save_steps": steps,
+        "data_seed": 0,
+    }
+
+
+def build_step() -> ArtifactStep[LevanterCheckpoint]:
+    """Build the lazy training artifact without submitting it."""
+    train = _tokenized_step(split="train", paths=[CONTACTS_V1_TRAIN_GLOB])
+    validation = _tokenized_step(split="val", paths=[CONTACTS_V1_VAL_GLOB])
+    steps = int(os.environ.get("EXP156_STEPS", "10"))
+    steps_per_eval = int(os.environ.get("EXP156_STEPS_PER_EVAL", "10"))
+    train_batch_size = int(os.environ.get("EXP156_TRAIN_BATCH_SIZE", "16"))
+    per_device_parallelism = int(os.environ.get("EXP156_PER_DEVICE_PARALLELISM", "1"))
+    max_eval_batches_env = os.environ.get("EXP156_MAX_EVAL_BATCHES", "1")
+    max_eval_batches = (
+        int(max_eval_batches_env) if max_eval_batches_env is not None else None
+    )
+    default_name = f"exp156-contacts-v1-{LOSS_KIND}-from-exp120-{steps}s-bs{train_batch_size}"
+    name = os.environ.get("EXP156_NAME", default_name)
+
+    def build_config(ctx: StepContext) -> TrainLmOnPodConfig | dict[str, object]:
+        identity = _identity_config(
+            ctx,
+            train,
+            validation,
+            name=name,
+            steps=steps,
+            steps_per_eval=steps_per_eval,
+            train_batch_size=train_batch_size,
+            per_device_parallelism=per_device_parallelism,
+            max_eval_batches=max_eval_batches,
+        )
+        if ctx.is_fingerprint:
+            return identity
+
+        train_key = "tokenized/contacts-v1-train"
+        val_key = "tokenized/contacts-v1-val"
+        data = LmDataConfig(
+            components={
+                train_key: _component(ctx.resolved(train)),
+                val_key: _component(ctx.resolved(validation)),
+            },
+            train_weights={train_key: 1.0, val_key: 0.0},
+            tokenizer=CONTACTS_TOKENIZER,
+            cache_dir=None,
+            auto_build_caches=False,
+            shuffle=True,
+            mixture_block_size=1,
+            block_cross_document_attention=True,
+        )
+        trainer = TrainerConfig(
+            id=name,
+            tracker=WandbConfig(
+                entity="open-athena",
+                project="MarinFold",
+                name=name,
+                tags=list(TAGS),
+                group="exp156-contacts-v1-greedy-set-loss",
+                replicate_path=ctx.output_path,
+            ),
+            mp=jmp.get_policy("p=f32,c=bfloat16"),
+            train_batch_size=train_batch_size,
+            per_device_parallelism=per_device_parallelism,
+            num_train_steps=steps,
+            steps_per_eval=steps_per_eval,
+            checkpointer=CheckpointerConfig(
+                save_interval=timedelta(minutes=10),
+                keep=[{"every": steps}],
+            ),
+            mesh=MeshConfig(
+                axes={"replica": 1, "data": -1, "model": 1},
+                compute_mapping={
+                    "token": TOKEN_AXES,
+                    "token_repeat": TOKEN_AXES,
+                },
+            ),
+            per_device_eval_parallelism=-1,
+            max_eval_batches=max_eval_batches,
+            allow_nondivisible_batch_size=True,
+        )
+        train_config = TrainLmConfig(
+            data=data,
+            trainer=trainer,
+            model=MODEL_CONFIG,
+            optimizer=identity["optimizer"],
+            z_loss_weight=0.0,
+            train_seq_len=8192,
+            hf_save_steps=steps,
+            data_seed=0,
+            adapter=NoAdaptorConfig(),
+            initialize_from_hf=INITIALIZE_FROM_HF,
+            pad_tokenizer_to_match_model=True,
+        )
+        env_vars = {"WANDB_ENTITY": "open-athena", "WANDB_PROJECT": "MarinFold"}
+        for env_name in ("WANDB_API_KEY", "WANDB_MODE"):
+            env_value = os.environ.get(env_name)
+            if env_value:
+                env_vars[env_name] = env_value
+        return TrainLmOnPodConfig(
+            train_config=train_config,
+            resources=ctx.runtime_arg("train_resources"),
+            output_path=ctx.output_path,
+            env_vars=env_vars,
+            auto_build_caches=False,
+        )
+
+    return ArtifactStep(
+        name=user_namespaced_name(f"checkpoints/{name}", ARTIFACT_VERSION),
+        version=ARTIFACT_VERSION,
+        artifact_type=LevanterCheckpoint,
+        run=_train_job,
+        build_config=build_config,
+        deps=(train, validation),
+        runtime_args={"train_resources": RESOURCES},
+    )
+
+
+def build_steps() -> list[ArtifactStep[LevanterCheckpoint]]:
+    """Build the single-step launch list used by tests and the CLI."""
+    return [build_step()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Submit the lowered graph. Without this flag, only print the plan.",
+    )
+    args = parser.parse_args(argv)
+    lowered = lower(build_step())
+    if not args.run:
+        print(lowered)
+        return 0
+    if get_iris_ctx() is None:
+        parser.error(
+            "--run must execute inside an Iris coordinator job; launch this "
+            "experiment as an Iris job first"
+        )
+    StepRunner().run([lowered])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/marinfold/marinfold/document_structures/contacts_v1/greedy_set_loss.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/greedy_set_loss.py
@@ -1,0 +1,224 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Greedy latent-order contact-set loss prototype.
+
+This module is intentionally small and model-agnostic. It does not run a
+transformer. Instead, it defines pair-slot target selection for a training loop
+that can supply teacher-forced next-token log probabilities.
+
+The objective is a hard/Viterbi relaxation of contacts-v1's arbitrary contact
+ordering and pair orientation. At each contact slot, any remaining unordered
+contact pair is valid. The model chooses the easiest remaining pair as a whole,
+with pair orientation treated as latent.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class ContactBlockTargets:
+    """Parsed contacts-v1 structure block from one tokenized document."""
+
+    begin_position: int
+    end_position: int
+    slot_positions: np.ndarray
+    pairs: np.ndarray
+
+
+@dataclass(frozen=True)
+class MatchedPairChoice:
+    """One pair-slot assignment chosen by greedy matching."""
+
+    slot_index: int
+    pair_index: int
+    pair: tuple[int, int]
+    oriented_tokens: tuple[int, int]
+    log_prob: float
+
+
+@dataclass(frozen=True)
+class MatchedContactBlockLoss:
+    """Loss details for the single-pass pair-block matching prototype."""
+
+    loss: float
+    prefix_loss: float
+    pair_loss: float
+    end_loss: float
+    choices: tuple[MatchedPairChoice, ...]
+
+
+def parse_contact_block_targets(
+    token_ids: np.ndarray,
+    *,
+    begin_statements_token_id: int,
+    contact_token_id: int,
+    end_token_id: int,
+    position_token_ids: np.ndarray,
+) -> ContactBlockTargets:
+    """Parse contacts-v1 ``<begin_statements>`` triples from one token row."""
+    token_ids = np.asarray(token_ids)
+    begin_matches = np.flatnonzero(token_ids == begin_statements_token_id)
+    if begin_matches.size != 1:
+        raise ValueError(f"expected exactly one <begin_statements>, got {begin_matches.size}")
+    begin_position = int(begin_matches[0])
+
+    end_matches = np.flatnonzero(token_ids[begin_position + 1 :] == end_token_id)
+    if end_matches.size == 0:
+        raise ValueError("structure block has no <end> token")
+    end_position = begin_position + 1 + int(end_matches[0])
+
+    token_to_position = {int(token_id): pos for pos, token_id in enumerate(position_token_ids)}
+    slot_positions: list[tuple[int, int, int]] = []
+    pairs: list[tuple[int, int]] = []
+    cursor = begin_position + 1
+    while cursor < end_position:
+        if cursor + 2 >= end_position:
+            raise ValueError("structure block ended inside a contact triple")
+        if int(token_ids[cursor]) != contact_token_id:
+            raise ValueError(f"expected <contact> at token position {cursor}")
+        left_token = int(token_ids[cursor + 1])
+        right_token = int(token_ids[cursor + 2])
+        if left_token not in token_to_position or right_token not in token_to_position:
+            raise ValueError(f"contact at token position {cursor} does not use <p*> endpoints")
+        left = token_to_position[left_token]
+        right = token_to_position[right_token]
+        if left == right:
+            raise ValueError(f"self-contact at token position {cursor}: <p{left}>")
+        slot_positions.append((cursor, cursor + 1, cursor + 2))
+        pairs.append(tuple(sorted((left, right))))
+        cursor += 3
+
+    if len(set(pairs)) != len(pairs):
+        raise ValueError("structure block contains duplicate unordered contact pairs")
+    return ContactBlockTargets(
+        begin_position=begin_position,
+        end_position=end_position,
+        slot_positions=np.asarray(slot_positions, dtype=np.int64).reshape((-1, 3)),
+        pairs=np.asarray(pairs, dtype=np.int64).reshape((-1, 2)),
+    )
+
+
+def greedy_matched_contact_block_loss(
+    log_probs: np.ndarray,
+    token_ids: np.ndarray,
+    *,
+    begin_statements_token_id: int,
+    contact_token_id: int,
+    end_token_id: int,
+    position_token_ids: np.ndarray,
+) -> MatchedContactBlockLoss:
+    """Single-pass contacts-v1 loss with greedy order/orientation matching.
+
+    ``log_probs[position]`` predicts ``token_ids[position + 1]``. Prefix tokens
+    through ``<begin_statements>`` and the final ``<end>`` are exact CE. Contact
+    triples are matched greedily to unused expected pairs, ignoring serialized
+    order and pair orientation.
+    """
+    targets = parse_contact_block_targets(
+        token_ids,
+        begin_statements_token_id=begin_statements_token_id,
+        contact_token_id=contact_token_id,
+        end_token_id=end_token_id,
+        position_token_ids=position_token_ids,
+    )
+    log_probs = np.asarray(log_probs)
+    token_ids = np.asarray(token_ids)
+    if log_probs.ndim != 2:
+        raise ValueError(f"log_probs must have shape [position, vocab], got {log_probs.shape}")
+    if log_probs.shape[0] != token_ids.shape[0]:
+        raise ValueError("log_probs and token_ids must have the same position length")
+
+    prefix_loss = -float(
+        np.sum(log_probs[np.arange(targets.begin_position), token_ids[1 : targets.begin_position + 1]])
+    )
+    pair_scores = _pair_score_matrix(
+        log_probs,
+        targets=targets,
+        contact_token_id=contact_token_id,
+        position_token_ids=position_token_ids,
+    )
+
+    remaining = np.ones(targets.pairs.shape[0], dtype=bool)
+    pair_loss = 0.0
+    choices: list[MatchedPairChoice] = []
+    for slot_index in range(targets.slot_positions.shape[0]):
+        masked_scores = np.where(remaining, pair_scores[slot_index], -np.inf)
+        pair_index = int(np.argmax(masked_scores))
+        if not np.isfinite(masked_scores[pair_index]):
+            raise ValueError("no remaining contact pair to match")
+        remaining[pair_index] = False
+        score = float(pair_scores[slot_index, pair_index])
+        pair_loss -= score
+        left_token, right_token = _best_orientation_tokens(
+            log_probs,
+            slot_positions=targets.slot_positions[slot_index],
+            pair=targets.pairs[pair_index],
+            position_token_ids=position_token_ids,
+        )
+        choices.append(
+            MatchedPairChoice(
+                slot_index=slot_index,
+                pair_index=pair_index,
+                pair=tuple(int(x) for x in targets.pairs[pair_index]),
+                oriented_tokens=(left_token, right_token),
+                log_prob=score,
+            )
+        )
+
+    end_loss = -float(log_probs[targets.end_position - 1, end_token_id])
+    return MatchedContactBlockLoss(
+        loss=prefix_loss + pair_loss + end_loss,
+        prefix_loss=prefix_loss,
+        pair_loss=pair_loss,
+        end_loss=end_loss,
+        choices=tuple(choices),
+    )
+
+
+def _pair_score_matrix(
+    log_probs: np.ndarray,
+    *,
+    targets: ContactBlockTargets,
+    contact_token_id: int,
+    position_token_ids: np.ndarray,
+) -> np.ndarray:
+    """Return ``[slot, pair]`` log-prob scores with best orientation."""
+    n_slots = targets.slot_positions.shape[0]
+    n_pairs = targets.pairs.shape[0]
+    scores = np.empty((n_slots, n_pairs), dtype=np.float64)
+    for slot_index, (marker_pos, left_pos, right_pos) in enumerate(targets.slot_positions):
+        contact_score = float(log_probs[marker_pos - 1, contact_token_id])
+        for pair_index, (first, second) in enumerate(targets.pairs):
+            first_token = int(position_token_ids[first])
+            second_token = int(position_token_ids[second])
+            forward = float(log_probs[left_pos - 1, first_token] + log_probs[right_pos - 1, second_token])
+            reverse = float(log_probs[left_pos - 1, second_token] + log_probs[right_pos - 1, first_token])
+            scores[slot_index, pair_index] = contact_score + max(forward, reverse)
+    return scores
+
+
+def _best_orientation_tokens(
+    log_probs: np.ndarray,
+    *,
+    slot_positions: np.ndarray,
+    pair: np.ndarray,
+    position_token_ids: np.ndarray,
+) -> tuple[int, int]:
+    _, left_pos, right_pos = slot_positions
+    first_token = int(position_token_ids[int(pair[0])])
+    second_token = int(position_token_ids[int(pair[1])])
+    forward = float(log_probs[left_pos - 1, first_token] + log_probs[right_pos - 1, second_token])
+    reverse = float(log_probs[left_pos - 1, second_token] + log_probs[right_pos - 1, first_token])
+    return (first_token, second_token) if forward >= reverse else (second_token, first_token)
+
+
+__all__ = [
+    "ContactBlockTargets",
+    "MatchedContactBlockLoss",
+    "MatchedPairChoice",
+    "greedy_matched_contact_block_loss",
+    "parse_contact_block_targets",
+]

--- a/marinfold/pyproject.toml
+++ b/marinfold/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pyarrow",
     "pyyaml>=6",
     "tokenizers>=0.15",
-    "transformers>=4.40,<5",
+    "transformers>=4.40,<6",
 ]
 
 [project.optional-dependencies]

--- a/marinfold/tests/document_structures/contacts_v1/test_greedy_set_loss.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_greedy_set_loss.py
@@ -1,0 +1,83 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import numpy as np
+
+from marinfold.document_structures.contacts_v1.greedy_set_loss import (
+    greedy_matched_contact_block_loss,
+    parse_contact_block_targets,
+)
+
+
+def test_parse_contact_block_targets_reads_contact_triples() -> None:
+    contact = 5
+    begin = 9
+    end = 10
+    position_token_ids = np.arange(20, 30, dtype=np.int64)
+    token_ids = np.asarray(
+        [2, 8, 20, 86, begin, contact, 23, 24, contact, 27, 21, end, 1],
+        dtype=np.int64,
+    )
+
+    targets = parse_contact_block_targets(
+        token_ids,
+        begin_statements_token_id=begin,
+        contact_token_id=contact,
+        end_token_id=end,
+        position_token_ids=position_token_ids,
+    )
+
+    assert targets.begin_position == 4
+    assert targets.end_position == 11
+    np.testing.assert_array_equal(targets.slot_positions, [[5, 6, 7], [8, 9, 10]])
+    np.testing.assert_array_equal(targets.pairs, [[3, 4], [1, 7]])
+
+
+def test_greedy_matched_contact_block_loss_ignores_pair_order_and_orientation() -> None:
+    contact = 5
+    begin = 9
+    end = 10
+    position_token_ids = np.arange(20, 30, dtype=np.int64)
+    token_ids = np.asarray(
+        [2, 8, 20, 86, begin, contact, 23, 24, contact, 27, 21, end, 1],
+        dtype=np.int64,
+    )
+    log_probs = np.full((len(token_ids), 128), -100.0, dtype=np.float32)
+
+    # Exact prefix: positions 0..3 predict token_ids[1..4].
+    for pos in range(4):
+        log_probs[pos, token_ids[pos + 1]] = -0.01
+
+    # Slot 0 is serialized as pair (3, 4), but the model best matches pair (1, 7)
+    # in reverse orientation: left=<p7>, right=<p1>.
+    log_probs[4, contact] = -0.02
+    log_probs[5, int(position_token_ids[7])] = -0.03
+    log_probs[6, int(position_token_ids[1])] = -0.04
+    log_probs[5, int(position_token_ids[3])] = -2.0
+    log_probs[6, int(position_token_ids[4])] = -2.0
+
+    # Slot 1 then must match the remaining pair (3, 4).
+    log_probs[7, contact] = -0.05
+    log_probs[8, int(position_token_ids[3])] = -0.06
+    log_probs[9, int(position_token_ids[4])] = -0.07
+
+    log_probs[10, end] = -0.08
+
+    result = greedy_matched_contact_block_loss(
+        log_probs,
+        token_ids,
+        begin_statements_token_id=begin,
+        contact_token_id=contact,
+        end_token_id=end,
+        position_token_ids=position_token_ids,
+    )
+
+    assert [choice.pair for choice in result.choices] == [(1, 7), (3, 4)]
+    assert result.choices[0].oriented_tokens == (
+        int(position_token_ids[7]),
+        int(position_token_ids[1]),
+    )
+    expected = 4 * 0.01 + (0.02 + 0.03 + 0.04) + (0.05 + 0.06 + 0.07) + 0.08
+    assert math.isclose(result.loss, expected, rel_tol=1e-6)


### PR DESCRIPTION
## Summary

- adds contacts-v1 greedy latent contact-set loss implementation and tests
- adds exp156 training/evaluation launcher with stock next-token vs greedy-set arms
- records current H100/GB200 smoke-run findings and caveats in the experiment docs
- adds greedy-set validation hooks, optional auxiliary next-token validation for greedy runs, and configurable `EXP156_LEARNING_RATE`

## Current status

- 1×H100 short greedy eval succeeded with both greedy-set and next-token validation losses.
- 4×GB200 next-token and greedy runs completed; high-LR runs looked unstable/overfit.
- Multi-GPU greedy next-token eval is disabled by default for current runs via `EXP156_ENABLE_GREEDY_NEXT_TOKEN_EVAL=0` because Levanter's fused CE path can hit an axis-size mismatch on local multi-GPU meshes.
- Follow-up 8×H100 lower-LR runs are in flight outside this PR.

## Testing

- `python3 -m py_compile experiments/exp156_models_contacts_v1_greedy_set_loss/train.py`
- `uv run --project marinfold pytest marinfold/tests/document_structures/contacts_v1/test_greedy_set_loss.py`

Note: `uv run --project experiments/exp156_models_contacts_v1_greedy_set_loss ...` failed on macOS while resolving CUDA/NVIDIA wheels for the GPU extra; used direct `python3 -m py_compile` for syntax validation instead.
