### PR TITLE
Fix models uv resolution for local runs

### DIFF
--- a/models/pyproject.toml
+++ b/models/pyproject.toml
@@ -20,14 +20,10 @@ dependencies = [
     "marin-rigging",
 ]
 
-[project.optional-dependencies]
-# Iris's remote worker runs `uv sync --all-packages --no-group dev`, so a
-# dev group must exist (even if empty) for --no-group to work.
-tpu = ["marin-core[tpu]; sys_platform == 'linux'"]
-# GPU (CUDA) install for CoreWeave H100 runs (cw-rno2a / cw-us-east-02a). Mirrors
-# the `tpu` extra but pulls the CUDA jax build. `marin-core[gpu]` transitively
-# brings `marin-levanter[gpu]`. First used by exp108 (3B Qwen on CoreWeave).
-gpu = ["marin-core[gpu]; sys_platform == 'linux'"]
+# Accelerator extras belong in experiment packages, where each experiment can
+# choose one backend and configure the corresponding torch/jax package indexes.
+# Keeping GPU/TPU extras here makes uv try to solve both optional accelerator
+# stacks for every local `uv run`, even when the caller only wants CPU tests.
 
 [dependency-groups]
 dev = []


### PR DESCRIPTION
## Summary
- remove accelerator extras from the shared models package
- document that accelerator backend selection belongs in experiment packages with their torch/jax index routing
- avoid uv resolving incompatible GPU/TPU optional stacks during plain local models commands

## Validation
- reproduced on fresh origin/main: `cd models && uv run pytest tests/test_document_loss.py` fails during uv resolution with marinfold-models[gpu]
- fixed branch: `cd models && uv lock --dry-run` resolves successfully

Note: `uv run python -c 'import marinfold_models'` now gets past resolution but cannot install on this macOS x86_64 host because current jaxlib has no macOS x86_64 wheel; that is a separate platform-support issue.