### PR TITLE
inference: repair transformers-5 rope on load; promote #117 to default model

### DIFF
--- a/marinfold/marinfold/MODELS.yaml
+++ b/marinfold/marinfold/MODELS.yaml
@@ -3,14 +3,31 @@
 # is omitted) to the HF URL below, downloads it, and dispatches to the first
 # `document_structures` impl the entry lists. See registry.py.
 
-# Current best: exp120 (issue #120) — a 1-epoch, re-heated-LR continue-train of
-# the #75 model on the ORIGINAL contacts-v1 round-0 data (the "re-epoch" arm that
-# beat fine-tuning on the exp100 regenerated docs). Best downstream contact
-# prediction so far: long-range R-precision 0.279 / AUC 0.886 vs the #75 base's
-# 0.270 / 0.881 (554-protein eval set, exp89 harness). contacts-v1 tokenizer
-# co-located; exported to the bucket by exp120.
-- nickname: contacts-v1-exp120-1.5B
+# Current best: exp117 (issue #117) — eric-czech's expanded contacts-v1 sweep
+# winner. Qwen3 1.47B, 16 epochs, lr 3.1623e-3 / wd 0.2 / global batch 256;
+# eval/tokenized/contacts-v1-val/loss 2.7037. R-precision 0.534 (all) / 0.482
+# (long), AUC 0.933 on the 554-protein eval set — vs exp120's 0.436 / 0.379
+# (#169, exp82 rollout inference; see experiments/exp180_.../README.md for the
+# full progression). contacts-v1 tokenizer co-located.
+#
+# This export was written by transformers 5.12.1 and states rope as a
+# `rope_parameters` block, which the pinned transformers 4.x ignores in favour
+# of the architecture default. marinfold's inference path repairs it on load
+# (see marinfold/inference/_config.py) — worth 0.77 nats/token on real
+# documents. A bare AutoModelForCausalLM.from_pretrained on this directory
+# loads a broken model without complaining.
+- nickname: contacts-v1-exp117-1.5B
   default: true
+  url: https://huggingface.co/open-athena/marinfold-exp117/tree/main/prot-exp117-cv1-s02-1_5b-e16-lr3p162e-3-wd0p2-bs256-europe-west4/hf/step-35679
+  wandb_url: https://wandb.ai/eric-czech/marin/runs/prot-exp117-cv1-s02-1_5b-e16-lr3p162e-3-wd0p2-bs256-europe-west4
+  document_structures:
+    - contacts-v1
+# Previous default: exp120 (issue #120) — a 1-epoch, re-heated-LR continue-train
+# of the #75 model on the ORIGINAL contacts-v1 round-0 data (the "re-epoch" arm
+# that beat fine-tuning on the exp100 regenerated docs). Long-range R-precision
+# 0.279 / AUC 0.886 vs the #75 base's 0.270 / 0.881 under the exp89 pairwise
+# harness. contacts-v1 tokenizer co-located; exported to the bucket by exp120.
+- nickname: contacts-v1-exp120-1.5B
   url: https://huggingface.co/buckets/open-athena/MarinFold/tree/checkpoints/exp120-cv1-1_5b-orig-lr3e-4-e1-cos/hf/step-1005
   wandb_url: https://wandb.ai/open-athena/MarinFold/runs/exp120-cv1-1_5b-orig-lr3e-4-e1-cos-fb79f7
   document_structures:

--- a/marinfold/marinfold/MODELS.yaml
+++ b/marinfold/marinfold/MODELS.yaml
@@ -10,15 +10,18 @@
 # (#169, exp82 rollout inference; see experiments/exp180_.../README.md for the
 # full progression). contacts-v1 tokenizer co-located.
 #
-# This export was written by transformers 5.12.1 and states rope as a
-# `rope_parameters` block, which the pinned transformers 4.x ignores in favour
-# of the architecture default. marinfold's inference path repairs it on load
-# (see marinfold/inference/_config.py) — worth 0.77 nats/token on real
-# documents. A bare AutoModelForCausalLM.from_pretrained on this directory
-# loads a broken model without complaining.
+# This is OUR republished copy of eric-czech's export, not the original. The
+# weights are byte-identical; only config.json differs. His export was written
+# by transformers 5.12.1 and states rope as a `rope_parameters` block, which
+# the pinned transformers 4.x ignores in favour of the architecture default —
+# loading rope_theta 10000 where the model was trained with 500000, worth 0.77
+# nats/token on real documents, silently. Our copy states rope in both 4.x and
+# 5.x terms, so a plain AutoModelForCausalLM.from_pretrained is correct with no
+# marinfold code in the loop. See the PROVENANCE.md beside the weights,
+# scripts/repair_checkpoint_config.py, and issue #180.
 - nickname: contacts-v1-exp117-1.5B
   default: true
-  url: https://huggingface.co/open-athena/marinfold-exp117/tree/main/prot-exp117-cv1-s02-1_5b-e16-lr3p162e-3-wd0p2-bs256-europe-west4/hf/step-35679
+  url: https://huggingface.co/buckets/open-athena/MarinFold/tree/checkpoints/prot-exp117-cv1-s02-1_5b-e16-lr3p162e-3-wd0p2-bs256-europe-west4/hf/step-35679
   wandb_url: https://wandb.ai/eric-czech/marin/runs/prot-exp117-cv1-s02-1_5b-e16-lr3p162e-3-wd0p2-bs256-europe-west4
   document_structures:
     - contacts-v1

--- a/marinfold/marinfold/inference/_config.py
+++ b/marinfold/marinfold/inference/_config.py
@@ -82,10 +82,11 @@ def repair_rope(config: dict) -> dict:
     if rope_type in _UNSCALED_ROPE_TYPES:
         out["rope_scaling"] = None
     else:
-        # transformers 4.x reads `rope_type`; older configs used `type`. Write
-        # both so either validator is satisfied.
+        # `rope_type` is what transformers >=4.36 reads; the legacy `type`
+        # alias is deliberately not added. Under transformers 5.x
+        # `rope_scaling` is an alias of `rope_parameters`, so anything put here
+        # is surfaced there too — keep it to what the loader needs.
         params.setdefault("rope_type", rope_type)
-        params.setdefault("type", rope_type)
         out["rope_scaling"] = params
     return out
 
@@ -97,6 +98,32 @@ def read_config(model_path: Path) -> dict:
         return {}
     with open(path) as fh:
         return json.load(fh)
+
+
+def repair_config_file(config_path: Path) -> bool:
+    """Rewrite a ``config.json`` in place so *any* loader reads the right rope.
+
+    marinfold's own backends repair on load, but a checkpoint published to the
+    Hub is read by plenty of code that is not marinfold — a bare
+    ``AutoModelForCausalLM.from_pretrained``, someone else's eval worker, a
+    Colab. Those all silently get the wrong rope. Fixing the artifact is the
+    only thing that helps them.
+
+    The result carries **both** shapes: ``rope_parameters`` is left in place
+    and ``rope_theta`` / ``rope_scaling`` are added. Verified to load correctly
+    under transformers 4.57 *and* 5.14 — under 5.x ``rope_scaling`` is an alias
+    of ``rope_parameters``, and the added top-level ``rope_theta`` is ignored
+    in favour of the one inside the block, so 5.x behaviour is unchanged.
+
+    Returns True if the file was rewritten, False if it already read correctly.
+    """
+    config_path = Path(config_path)
+    with open(config_path) as fh:
+        raw = json.load(fh)
+    if not needs_rope_repair(raw):
+        return False
+    config_path.write_text(json.dumps(repair_rope(raw), indent=2) + "\n")
+    return True
 
 
 def load_config(model_path: Path):

--- a/marinfold/marinfold/inference/_config.py
+++ b/marinfold/marinfold/inference/_config.py
@@ -1,0 +1,114 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared model-config loading for the inference backends.
+
+Companion to :mod:`._tokenizer`, and kept torch-free for the same reason:
+the MLX / vLLM backends reuse it without pulling in the ``[transformers]``
+extra's torch dependency.
+
+The problem it solves. A levanter checkpoint exported by **transformers 5.x**
+writes its rope settings as a single ``rope_parameters`` block::
+
+    "rope_parameters": {"rope_type": "llama3", "rope_theta": 500000,
+                        "factor": 8.0, "low_freq_factor": 1.0,
+                        "high_freq_factor": 4.0,
+                        "original_max_position_embeddings": 8192}
+
+marinfold pins ``transformers>=4.40,<5``, which reads ``rope_theta`` and
+``rope_scaling`` instead. It does not error on the 5.x shape — it *ignores*
+it and falls back to the architecture default, so a checkpoint that was
+trained with Llama3 rope at theta 500000 loads with **theta 10000 and no
+scaling**. A 50x error in the rope base, silently, at load time.
+
+This is the config-side twin of the ``tokenizer_class: TokenizersBackend``
+breakage in :mod:`._tokenizer`, from the same exporter, and both were first
+seen on the #117 checkpoints (MarinFold #89, #169). Every future
+transformers-5 export carries it.
+
+Measured on the #117 checkpoint over three real contacts-v1 documents
+(experiments/exp82 benchmark set), repaired vs as-published: mean NLL **2.414
+vs 3.179 nats/token**. For scale, the whole #75 -> #117 model generation was
+worth 0.053 nats. The damage grows with sequence length — +0.25 nats at 361
+tokens, +1.34 at 683 — which is the signature of a wrong rope base.
+
+One expected noise source: transformers 4.x warns that
+``original_max_position_embeddings`` (8192) is not *less than*
+``max_position_embeddings`` (8192). That equality is what levanter's
+``Llama3RotaryEmbeddingsConfig()`` default produces and what the model was
+trained with, so it is reproduced deliberately. The warning does not stop the
+llama3 scaling being applied. Do not "fix" it by changing either value — that
+would make inference diverge from training.
+"""
+
+import json
+from pathlib import Path
+
+# Keys inside a transformers-5 ``rope_parameters`` block that are the *base*
+# frequency rather than part of the scaling spec.
+_ROPE_THETA_KEYS = ("rope_theta", "theta", "base")
+# ``rope_type`` values that mean "no scaling" — for these, transformers 4.x
+# wants ``rope_scaling`` left as None rather than a dict.
+_UNSCALED_ROPE_TYPES = (None, "default")
+
+
+def needs_rope_repair(config: dict) -> bool:
+    """True if ``config`` carries transformers-5 rope that 4.x would ignore."""
+    if not isinstance(config.get("rope_parameters"), dict):
+        return False
+    # If the 4.x keys are already present the exporter (or a previous repair)
+    # wrote both shapes; nothing to do.
+    return "rope_theta" not in config and "rope_scaling" not in config
+
+
+def repair_rope(config: dict) -> dict:
+    """Return ``config`` with ``rope_parameters`` restated in 4.x terms.
+
+    The input is not mutated. ``rope_parameters`` is kept as well as
+    translated: it is inert under 4.x, and leaving it in place means a
+    repaired directory still round-trips under transformers 5.x.
+    """
+    if not needs_rope_repair(config):
+        return config
+
+    out = dict(config)
+    params = dict(out["rope_parameters"])
+
+    theta = next((params.pop(k) for k in _ROPE_THETA_KEYS if k in params), None)
+    if theta is not None:
+        out["rope_theta"] = theta
+
+    rope_type = params.get("rope_type", params.get("type"))
+    if rope_type in _UNSCALED_ROPE_TYPES:
+        out["rope_scaling"] = None
+    else:
+        # transformers 4.x reads `rope_type`; older configs used `type`. Write
+        # both so either validator is satisfied.
+        params.setdefault("rope_type", rope_type)
+        params.setdefault("type", rope_type)
+        out["rope_scaling"] = params
+    return out
+
+
+def read_config(model_path: Path) -> dict:
+    """Read ``config.json`` from a checkpoint directory. Empty dict if absent."""
+    path = Path(model_path) / "config.json"
+    if not path.exists():
+        return {}
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def load_config(model_path: Path):
+    """Load a checkpoint's config, repairing transformers-5 rope if present.
+
+    Returns a ``PretrainedConfig`` suitable for passing to
+    ``from_pretrained(..., config=...)``. Import of transformers is deferred
+    so the module stays importable in torch-free environments.
+    """
+    from transformers import AutoConfig
+
+    raw = read_config(model_path)
+    if not needs_rope_repair(raw):
+        return AutoConfig.from_pretrained(str(model_path))
+    return AutoConfig.for_model(**repair_rope(raw))

--- a/marinfold/marinfold/inference/_tokenizer.py
+++ b/marinfold/marinfold/inference/_tokenizer.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
+from marinfold.inference._config import needs_rope_repair, read_config, repair_rope
+
 # Special-token / length keys we carry over from a checkpoint's
 # ``tokenizer_config.json`` when falling back to a raw
 # ``PreTrainedTokenizerFast`` (see :func:`load_tokenizer`). The
@@ -94,18 +96,38 @@ def tokenizer_source_path(model_path: Path) -> str:
 
 
 def model_source_path(model_path: Path) -> str:
-    """Return a model path whose tokenizer is loadable by a combined loader.
+    """Return a checkpoint directory a path-based loader can read as-is.
 
-    Some consumers — notably ``mlx_lm.load`` — insist on loading the model
-    and tokenizer from the same directory. If the checkpoint tokenizer loads
-    normally, return ``model_path`` unchanged. Otherwise, create the repaired
-    tokenizer directory from :func:`tokenizer_source_path` and symlink every
-    missing model artifact into it. This keeps large weights in place while
-    presenting the combined loader with one complete, loadable directory.
+    Some consumers — ``mlx_lm.load``, and vLLM's engine — load the model and
+    its tokenizer from a directory themselves, so they cannot be handed a
+    repaired Python object. This builds them one.
+
+    Two things may need repairing, both from the same transformers-5 exporter
+    and both silent rather than fatal:
+
+    * the tokenizer, whose ``tokenizer_class`` (``"TokenizersBackend"``)
+      ``AutoTokenizer`` cannot resolve — see :func:`tokenizer_source_path`;
+    * ``config.json``, whose ``rope_parameters`` block our pinned
+      transformers 4.x ignores, falling back to the architecture's default
+      rope — see :mod:`marinfold.inference._config`.
+
+    If neither needs repair, ``model_path`` is returned unchanged. Otherwise a
+    temp directory is populated with symlinks to every checkpoint artifact —
+    keeping the large weights in place — and the repaired files are written
+    over the corresponding links.
     """
-    source_path = Path(tokenizer_source_path(model_path))
-    if source_path == model_path:
+    tokenizer_path = Path(tokenizer_source_path(model_path))
+    raw_config = read_config(model_path)
+    repair_config = needs_rope_repair(raw_config)
+
+    if tokenizer_path == model_path and not repair_config:
         return str(model_path)
+
+    source_path = tokenizer_path
+    if source_path == model_path:
+        # Only the config is broken, so there is no repaired tokenizer dir to
+        # build on; start a fresh overlay.
+        source_path = Path(tempfile.mkdtemp(prefix="marinfold-checkpoint-"))
 
     for model_entry in model_path.iterdir():
         destination = source_path / model_entry.name
@@ -114,4 +136,11 @@ def model_source_path(model_path: Path) -> str:
         destination.symlink_to(
             model_entry.resolve(), target_is_directory=model_entry.is_dir()
         )
+
+    if repair_config:
+        # Replace the symlink rather than writing through it — that would
+        # rewrite the user's checkpoint in place.
+        destination = source_path / "config.json"
+        destination.unlink(missing_ok=True)
+        destination.write_text(json.dumps(repair_rope(raw_config), indent=2))
     return str(source_path)

--- a/marinfold/marinfold/inference/_transformers.py
+++ b/marinfold/marinfold/inference/_transformers.py
@@ -29,6 +29,8 @@ import torch
 from transformers import AutoModelForCausalLM
 from transformers.cache_utils import DynamicCache
 
+from marinfold.inference._config import load_config as _load_config
+
 # Re-exported for backward compatibility: the shared loader used to live
 # here. Tests and callers may still import it from this module.
 from marinfold.inference._tokenizer import load_tokenizer as _load_tokenizer
@@ -94,8 +96,14 @@ class TransformersBackend:
         self._tail_batch_size = tail_batch_size
         torch_dtype = _resolve_dtype(dtype)
         self._tokenizer = _load_tokenizer(model_path)
+        # Pass the config explicitly rather than letting from_pretrained read
+        # it: a transformers-5 export states rope as `rope_parameters`, which
+        # our pinned transformers 4.x silently ignores in favour of the
+        # architecture default (theta 10000, no scaling). See _config.
         self._model = (
-            AutoModelForCausalLM.from_pretrained(str(model_path), dtype=torch_dtype)
+            AutoModelForCausalLM.from_pretrained(
+                str(model_path), config=_load_config(model_path), dtype=torch_dtype
+            )
             .to(self._device)
             .eval()
         )

--- a/marinfold/marinfold/inference/_vllm.py
+++ b/marinfold/marinfold/inference/_vllm.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import numpy as np
 from vllm import LLM, SamplingParams, TokensPrompt
 
-from marinfold.inference._tokenizer import tokenizer_source_path
+from marinfold.inference._tokenizer import model_source_path
 
 
 class VllmBackend:
@@ -46,15 +46,17 @@ class VllmBackend:
             )
         self._tail_batch_size = tail_batch_size
         self._top_k_logprobs = top_k_logprobs
-        # vLLM builds its tokenizer internally from a path via
-        # AutoTokenizer, which chokes on marinfold training-export
-        # checkpoints (tokenizer_class == "TokenizersBackend"). Point it at
-        # a repaired tokenizer dir when the checkpoint's own config is
-        # unresolvable; otherwise this returns model_path unchanged.
-        tokenizer_path = tokenizer_source_path(model_path)
+        # vLLM loads both the weights and, internally via AutoTokenizer, the
+        # tokenizer from paths — so neither a repaired config object nor a
+        # repaired tokenizer object can be handed to it. model_source_path
+        # supplies a symlink overlay carrying whichever of the two a
+        # transformers-5 export broke (unresolvable tokenizer_class; rope
+        # stated as `rope_parameters`), and returns model_path unchanged when
+        # nothing needs repair.
+        source_path = model_source_path(model_path)
         self._llm = LLM(
-            model=str(model_path),
-            tokenizer=tokenizer_path,
+            model=source_path,
+            tokenizer=source_path,
             dtype=dtype,
             gpu_memory_utilization=gpu_memory_utilization,
             enforce_eager=True,

--- a/marinfold/tests/test_config.py
+++ b/marinfold/tests/test_config.py
@@ -1,0 +1,138 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared, torch-free model-config loader.
+
+The failure these guard against is silent: transformers 4.x does not error on
+a transformers-5 ``rope_parameters`` block, it ignores it and uses the
+architecture's default rope. So every assertion here is about *values*, not
+about whether loading raised.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("transformers")
+
+from marinfold.inference._config import (  # noqa: E402
+    load_config,
+    needs_rope_repair,
+    read_config,
+    repair_rope,
+)
+
+# The rope block a levanter checkpoint exported by transformers 5.12.1 writes
+# for `Llama3RotaryEmbeddingsConfig()` — verbatim from the #117 checkpoint.
+TF5_ROPE = {
+    "factor": 8.0,
+    "low_freq_factor": 1.0,
+    "high_freq_factor": 4.0,
+    "original_max_position_embeddings": 8192,
+    "rope_type": "llama3",
+    "rope_theta": 500000,
+}
+
+
+def _write_config(directory: Path, **overrides) -> Path:
+    config = {
+        "model_type": "qwen3",
+        "architectures": ["Qwen3ForCausalLM"],
+        "vocab_size": 2845,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 16,
+        "max_position_embeddings": 8192,
+    }
+    config.update(overrides)
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "config.json").write_text(json.dumps(config))
+    return directory
+
+
+def test_transformers5_export_is_detected(tmp_path):
+    assert needs_rope_repair(read_config(_write_config(tmp_path, rope_parameters=TF5_ROPE)))
+
+
+def test_transformers4_export_is_left_alone(tmp_path):
+    raw = read_config(
+        _write_config(tmp_path, rope_theta=500000, rope_scaling={"rope_type": "llama3"})
+    )
+    assert not needs_rope_repair(raw)
+    assert repair_rope(raw) is raw
+
+
+def test_export_carrying_both_shapes_is_left_alone(tmp_path):
+    """A previously repaired directory must not be repaired again."""
+    raw = read_config(
+        _write_config(tmp_path, rope_parameters=TF5_ROPE, rope_theta=500000,
+                      rope_scaling={"rope_type": "llama3"})
+    )
+    assert not needs_rope_repair(raw)
+
+
+def test_no_rope_block_at_all(tmp_path):
+    assert not needs_rope_repair(read_config(_write_config(tmp_path)))
+
+
+def test_missing_config_is_not_an_error(tmp_path):
+    assert read_config(tmp_path) == {}
+    assert not needs_rope_repair({})
+
+
+def test_repair_moves_theta_out_and_scaling_across(tmp_path):
+    repaired = repair_rope(read_config(_write_config(tmp_path, rope_parameters=TF5_ROPE)))
+    assert repaired["rope_theta"] == 500000
+    assert repaired["rope_scaling"]["rope_type"] == "llama3"
+    assert repaired["rope_scaling"]["factor"] == 8.0
+    # rope_theta belongs at the top level, not inside the scaling spec.
+    assert "rope_theta" not in repaired["rope_scaling"]
+    # The 5.x block is kept so a repaired directory still loads under 5.x.
+    assert repaired["rope_parameters"] == TF5_ROPE
+
+
+def test_repair_does_not_mutate_its_input(tmp_path):
+    raw = read_config(_write_config(tmp_path, rope_parameters=TF5_ROPE))
+    before = json.dumps(raw, sort_keys=True)
+    repair_rope(raw)
+    assert json.dumps(raw, sort_keys=True) == before
+
+
+def test_unscaled_rope_type_yields_no_scaling(tmp_path):
+    raw = read_config(
+        _write_config(tmp_path, rope_parameters={"rope_type": "default",
+                                                 "rope_theta": 10_000})
+    )
+    repaired = repair_rope(raw)
+    assert repaired["rope_theta"] == 10_000
+    assert repaired["rope_scaling"] is None
+
+
+def test_loaded_config_carries_the_trained_rope(tmp_path):
+    """The end the bug actually shows up at: the values transformers reads.
+
+    Without the repair this loads theta 10000 and no scaling — a 50x error in
+    the rope base, applied silently.
+    """
+    config = load_config(_write_config(tmp_path, rope_parameters=TF5_ROPE))
+    assert config.rope_theta == 500000
+    assert config.rope_scaling is not None
+    assert config.rope_scaling["rope_type"] == "llama3"
+    assert config.rope_scaling["factor"] == 8.0
+    # Architecture fields must survive the round-trip through for_model().
+    assert config.vocab_size == 2845
+    assert config.num_hidden_layers == 2
+    assert config.num_key_value_heads == 2
+
+
+def test_loaded_config_matches_autoconfig_when_no_repair_needed(tmp_path):
+    from transformers import AutoConfig
+
+    directory = _write_config(tmp_path, rope_theta=500000)
+    assert load_config(directory).to_dict() == AutoConfig.from_pretrained(
+        str(directory)
+    ).to_dict()

--- a/scripts/repair_checkpoint_config.py
+++ b/scripts/repair_checkpoint_config.py
@@ -1,0 +1,133 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Find and fix checkpoints whose rope block only transformers 5.x can read.
+
+Why this exists. A checkpoint exported by transformers 5.x states rope as a
+``rope_parameters`` block. Anything reading it with transformers 4.x — which is
+what MarinFold pins, and what a lot of downstream code uses — does not error,
+it *ignores* the block and falls back to the architecture default. On the #117
+checkpoint that means rope theta 10000 instead of the trained 500000, worth
+**0.77 nats/token** on real documents (MarinFold #180, PR #184).
+
+MarinFold's own inference path repairs this on load, so the CLI and the eval
+harness are correct either way. This script is for everything else — a bare
+``AutoModelForCausalLM.from_pretrained``, a foreign eval worker, a Colab. The
+only thing that helps those is a corrected artifact.
+
+The repair is **additive**: ``rope_parameters`` stays and ``rope_theta`` /
+``rope_scaling`` are added alongside, so the file reads correctly under both
+transformers majors. Verified on 4.57 and 5.14.
+
+Two modes, both narrow on purpose:
+
+``--survey``
+    Read-only. Report which published checkpoints carry the defect. Writes
+    nothing, anywhere.
+
+``<dir>``
+    Repair a **local** checkpoint directory in place. This is the supported
+    route: copy the checkpoint down, repair it, and republish under
+    ``open-athena/MarinFold`` with a PROVENANCE.md — as
+    ``contacts-v1-exp117-1.5B`` was. Deliberately *not* an in-place rewrite of
+    somebody else's published repo: those belong to the experiment that
+    produced them, and a silent third-party edit is worse than a clearly
+    labelled republished copy.
+
+    uv run --with huggingface-hub --with numpy --with fsspec --with pyyaml \\
+        python scripts/repair_checkpoint_config.py --survey
+    uv run ... python scripts/repair_checkpoint_config.py ~/staged/step-35679
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "marinfold"))
+
+from marinfold.inference._config import (  # noqa: E402
+    needs_rope_repair,
+    repair_config_file,
+    repair_rope,
+)
+
+# Repos swept by --survey. Bucket-hosted checkpoints exported by transformers
+# 4.x (exp75 via exp89, exp120) read correctly and are not listed.
+SURVEY_REPOS = (
+    "open-athena/marinfold-exp117",
+    "open-athena/marinfold-exp146",
+    "open-athena/marinfold-exp75",
+)
+
+
+def survey(repos) -> int:
+    from huggingface_hub import HfApi, hf_hub_download
+
+    api = HfApi()
+    affected = clean = 0
+    for repo in repos:
+        try:
+            configs = sorted(
+                f for f in api.list_repo_files(repo)
+                if f.endswith("config.json") and "/hf/" in f and "tokenizer" not in f
+            )
+        except Exception as exc:  # noqa: BLE001 — report and continue
+            print(f"!! {repo}: {type(exc).__name__}: {exc}")
+            continue
+        print(f"\n### {repo}  ({len(configs)} model configs)")
+        for path in configs:
+            raw = json.loads(Path(hf_hub_download(repo, path)).read_text())
+            if not needs_rope_repair(raw):
+                print(f"  ok       {path}  (rope_theta={raw.get('rope_theta')})")
+                clean += 1
+                continue
+            fixed = repair_rope(raw)
+            affected += 1
+            print(f"  AFFECTED {path}")
+            print(f"             exported by transformers {raw.get('transformers_version')}")
+            print(f"             4.x reads the architecture default; the trained "
+                  f"value is rope_theta={fixed['rope_theta']}")
+    print(f"\n{affected} affected, {clean} correct")
+    if affected:
+        print("Fix: download the checkpoint, run this script on the local copy, "
+              "then republish under open-athena/MarinFold with a PROVENANCE.md.")
+    return 0
+
+
+def repair_local(directory: Path) -> int:
+    config_path = directory / "config.json"
+    if not config_path.exists():
+        print(f"!! no config.json in {directory}")
+        return 1
+    if repair_config_file(config_path):
+        fixed = json.loads(config_path.read_text())
+        print(f"repaired {config_path}")
+        print(f"  rope_theta   = {fixed['rope_theta']}")
+        print(f"  rope_scaling = {fixed['rope_scaling']}")
+        print("  rope_parameters kept, so transformers 5.x is unaffected")
+    else:
+        print(f"{config_path} already reads correctly under transformers 4.x")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("directory", nargs="?", type=Path,
+                    help="local checkpoint directory to repair in place")
+    ap.add_argument("--survey", action="store_true",
+                    help="read-only: report affected published checkpoints")
+    ap.add_argument("--repo", action="append", default=None,
+                    help="override the --survey repo list (repeatable)")
+    a = ap.parse_args()
+
+    if a.survey:
+        return survey(a.repo or SURVEY_REPOS)
+    if a.directory is None:
+        ap.error("pass a checkpoint directory, or --survey")
+    return repair_local(a.directory)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Makes eric-czech's #117 sweep winner the default model — and fixes the silent
correctness bug that promoting it uncovered.

## The bug

A levanter checkpoint exported by **transformers 5.12.1** states rope as a
`rope_parameters` block:

```json
"rope_parameters": {"rope_type": "llama3", "rope_theta": 500000, "factor": 8.0, ...}
```

marinfold pins `transformers>=4.40,<5`, which reads `rope_theta` /
`rope_scaling`. It does **not** error on the 5.x shape — it ignores it and uses
the architecture default:

```
rope_theta   = 10000.0   ← trained with 500000
rope_scaling = None      ← trained with llama3, factor 8.0
```

A 50× error in the rope base, with no warning. Same exporter and same silence
as the `tokenizer_class: TokenizersBackend` breakage PR #165 fixed.

## What it costs

The #117 checkpoint over three real contacts-v1 documents (exp82's benchmark
set), repaired vs as-published:

| document | tokens | repaired | as published | Δ |
|---|---:|---:|---:|---:|
| 1UBQ | 361 | 1.817 | 2.068 | +0.25 |
| 1QYS | 420 | 2.410 | 2.678 | +0.27 |
| 7BNY | 683 | 2.732 | 4.074 | **+1.34** |
| **mean** | | **2.414** | **3.179** | **+0.765** |

**0.765 nats/token.** The entire #75 → #117 model generation was worth 0.053
nats. The damage grows with sequence length, which is the signature of a wrong
rope base.

This will affect every transformers-5 export — #146, #150, #155 and #160 are
all downstream of the same exporter.

## Changes

- **`inference/_config.py`** (new) — detect and translate the 5.x block. Keeps
  `rope_parameters` in place so a repaired directory still loads under 5.x, and
  is a no-op when the 4.x keys are already present (so a repaired directory is
  never repaired twice).
- **`_transformers.py`** — pass the repaired config to `from_pretrained`.
- **`_tokenizer.py: model_source_path`** — now overlays a repaired
  `config.json` as well as a repaired tokenizer, for loaders that take a path
  rather than an object. It replaces the symlink instead of writing through it,
  so the user's checkpoint is never modified in place.
- **`_vllm.py`** — load weights and tokenizer from that overlay.
- **`MODELS.yaml`** — `contacts-v1-exp117-1.5B` becomes the default.

## The promotion

| | exp120 (was default) | **exp117 (now)** |
|---|---:|---:|
| contacts-v1-val loss | 2.7213 | **2.7037** |
| R-precision, all | 0.436 | **0.534** |
| R-precision, long | 0.379 | **0.482** |
| AUC | 0.906 | **0.933** |

554-protein eval set, exp82 rollout inference, numbers from #169. Full
progression in `experiments/exp180_.../README.md`.

The checkpoint is public, anonymously readable, and ships its tokenizer
co-located, so it satisfies the usual conventions. Note it lives in a model
repo (`open-athena/marinfold-exp117`) rather than the bucket the other
contacts-v1 entries use — the registry already handles both URL shapes.

## Testing

`tests/test_config.py` (new, 10 cases) asserts on *values* rather than on
loading succeeding, since the failure mode is silent: theta lands at the top
level, scaling carries across, the input is not mutated, an already-repaired
config is left alone, `rope_type: default` yields no scaling, and a
transformers-4 export is byte-identical to plain `AutoConfig`.

30 passed across `test_config` / `test_tokenizer` / `test_registry`.

End-to-end: the default nickname resolves through the registry to the HF
snapshot, the config comes back with theta 500000 and llama3 scaling, the
tokenizer loads through the existing fallback, and `model_source_path` returns
an overlay carrying both repairs.

## One thing reviewers will see

transformers 4.x warns that `original_max_position_embeddings` (8192) is not
less than `max_position_embeddings` (8192). That equality is what levanter's
`Llama3RotaryEmbeddingsConfig()` default produces and what the model was
trained with, so it is reproduced deliberately; the scaling is still applied.
Documented in `_config.py` so nobody "fixes" it and silently diverges inference
from training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
