### PR TITLE
UPDATES: correct the #85 LR re-heat claim (editor's note)

### DIFF
--- a/UPDATES.md
+++ b/UPDATES.md
@@ -94,6 +94,7 @@
 * Looks like our quick-and-dirty model trained on contacts-v1 does not [perform well](https://github.com/Open-Athena/MarinFold/issues/82#issuecomment-4720288663) at all.
 * However, [Eric&#39;s sweep](https://github.com/Open-Athena/MarinFold/issues/61#issuecomment-4752161683) generated models with significantly improved eval perplexities than my quick-and-dirty model. So we are evaluating his best model now ([#89](https://github.com/Open-Athena/MarinFold/issues/89)). We will see if this changes the story.
 * While we were waiting for @Eric Czech 's sweep, I tried re-heating my quick-and-dirty model and doing another epoch. That improved eval loss somewhat but is still worse than best model from Eric's sweep ([#85](https://github.com/Open-Athena/MarinFold/issues/85))
+  * _[Editor's note, 2026-07-30: the re-heat did **not** improve eval loss. It finished at `contacts-v1-val` **2.9801** against #67's **2.9800**, and its five eval points run 2.9825 / 2.9828 / 2.9843 / 2.9820 / 2.9801 — no progress over the checkpoint it restarted from. The rest of the sentence stands: it was well short of Eric's sweep. Found while assembling the progress tracker in [#180](https://github.com/Open-Athena/MarinFold/issues/180).]_
 * Implemented a simple inference algorithm for our contacts-v1 models ([#82](https://github.com/Open-Athena/MarinFold/issues/82))
 * Evals: we now include ESMFold2 as a comparison ([#78](https://github.com/Open-Athena/MarinFold/issues/78))
 


### PR DESCRIPTION
The week-of-June-22 entry reads:

> While we were waiting for Eric's sweep, I tried re-heating my quick-and-dirty
> model and doing another epoch. **That improved eval loss somewhat** but is
> still worse than best model from Eric's sweep (#85)

The re-heat did not improve eval loss. From W&B
(`protein-contacts-1_5b-contacts-v1-unmasked-reheat-e3-bs512-5fc77c`):

| step | 250 | 500 | 750 | 1000 | 1124 |
|---|---|---|---|---|---|
| `contacts-v1-val` | 2.9825 | 2.9828 | 2.9843 | 2.9820 | **2.9801** |

#67, the checkpoint it warm-restarted from, finished at **2.9800**. So a full
extra epoch at a re-heated LR bought nothing measurable — arguably 0.0001 the
wrong way.

The rest of the sentence stands: it was well short of Eric's sweep.

Corrected with a dated editor's note under the original bullet rather than by
editing the sentence, so the record of what we believed at the time survives.

Found while assembling the progress tracker in #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)