### PR TITLE
Audit + repair rope config on published bucket checkpoints; sweep the bucket in --survey

### DIFF
--- a/scripts/repair_checkpoint_config.py
+++ b/scripts/repair_checkpoint_config.py
@@ -23,7 +23,11 @@ Two modes, both narrow on purpose:
 
 ``--survey``
     Read-only. Report which published checkpoints carry the defect. Writes
-    nothing, anywhere.
+    nothing, anywhere. Sweeps both the HF *model repos* below **and** the
+    ``open-athena/MarinFold`` bucket — the bucket was originally left out on
+    the assumption that everything in it was a transformers 4.x export, which
+    was wrong: exp120 and exp108 were 5.x exports and had been serving the
+    defect since publication (MarinFold #197).
 
 ``<dir>``
     Repair a **local** checkpoint directory in place. This is the supported
@@ -53,20 +57,54 @@ from marinfold.inference._config import (  # noqa: E402
     repair_rope,
 )
 
-# Repos swept by --survey. Bucket-hosted checkpoints exported by transformers
-# 4.x (exp75 via exp89, exp120) read correctly and are not listed.
+# HF *model repos* swept by --survey.
 SURVEY_REPOS = (
     "open-athena/marinfold-exp117",
     "open-athena/marinfold-exp146",
     "open-athena/marinfold-exp75",
 )
 
+# The HF *bucket*, swept as well. Buckets are a separate storage layer: the
+# model-repo API (list_repo_files / hf_hub_download) does not see into them,
+# hence the parallel code path below.
+SURVEY_BUCKET = "open-athena/MarinFold"
+SURVEY_BUCKET_PREFIX = "checkpoints/"
 
-def survey(repos) -> int:
+
+def _report(path: str, raw: dict, tally: dict) -> None:
+    """Classify one config and print a line for it. Mutates ``tally``."""
+    if needs_rope_repair(raw):
+        tally["affected"] += 1
+        fixed = repair_rope(raw)
+        print(f"  AFFECTED {path}")
+        print(f"             exported by transformers {raw.get('transformers_version')}")
+        print(f"             4.x reads the architecture default; the trained "
+              f"value is rope_theta={fixed['rope_theta']}")
+        return
+
+    # Neither shape present. Nothing in the file says what rope was trained, so
+    # this script cannot repair it — but it is not "ok" either: every loader
+    # silently takes the architecture default. Recover the true values from the
+    # levanter run config (the ``rope=`` argument on the model config, or its
+    # default) and write them in by hand.
+    if raw.get("rope_theta") is None and not isinstance(raw.get("rope_parameters"), dict):
+        tally["unknown"] += 1
+        print(f"  NO ROPE  {path}")
+        print(f"             exported by transformers {raw.get('transformers_version')}")
+        print( "             no rope_theta, no rope_parameters — loaders fall back to "
+               "the architecture default. Check the levanter run config.")
+        return
+
+    tally["clean"] += 1
+    scaling = raw.get("rope_scaling")
+    rope_type = scaling.get("rope_type") if isinstance(scaling, dict) else None
+    print(f"  ok       {path}  (rope_theta={raw.get('rope_theta')}, rope_type={rope_type})")
+
+
+def _survey_repos(repos, tally) -> None:
     from huggingface_hub import HfApi, hf_hub_download
 
     api = HfApi()
-    affected = clean = 0
     for repo in repos:
         try:
             configs = sorted(
@@ -78,21 +116,54 @@ def survey(repos) -> int:
             continue
         print(f"\n### {repo}  ({len(configs)} model configs)")
         for path in configs:
-            raw = json.loads(Path(hf_hub_download(repo, path)).read_text())
-            if not needs_rope_repair(raw):
-                print(f"  ok       {path}  (rope_theta={raw.get('rope_theta')})")
-                clean += 1
-                continue
-            fixed = repair_rope(raw)
-            affected += 1
-            print(f"  AFFECTED {path}")
-            print(f"             exported by transformers {raw.get('transformers_version')}")
-            print(f"             4.x reads the architecture default; the trained "
-                  f"value is rope_theta={fixed['rope_theta']}")
-    print(f"\n{affected} affected, {clean} correct")
-    if affected:
+            _report(path, json.loads(Path(hf_hub_download(repo, path)).read_text()), tally)
+
+
+def _survey_bucket(bucket: str, prefix: str, tally) -> None:
+    """Sweep a HF bucket. Needs huggingface_hub >= 1.5 for the bucket API.
+
+    ``token=False`` throughout: the bucket is anon-readable, and a stale cached
+    credential would otherwise 401 a read-only survey.
+    """
+    try:
+        from huggingface_hub import BucketFile, download_bucket_files, list_bucket_tree
+    except ImportError:
+        print(f"\n!! {bucket}: needs huggingface_hub>=1.5 for the bucket API — skipped")
+        return
+
+    import tempfile
+
+    try:
+        entries = list_bucket_tree(bucket, prefix=prefix, recursive=True, token=False)
+        configs = sorted(
+            (f for f in entries
+             if isinstance(f, BucketFile)
+             and f.path.endswith("/config.json") and "tokenizer" not in f.path),
+            key=lambda f: f.path,
+        )
+    except Exception as exc:  # noqa: BLE001 — report and continue
+        print(f"!! {bucket}: {type(exc).__name__}: {exc}")
+        return
+
+    print(f"\n### bucket {bucket}/{prefix}  ({len(configs)} model configs)")
+    with tempfile.TemporaryDirectory() as tmp:
+        pairs = [(f, Path(tmp) / f"{i}.json") for i, f in enumerate(configs)]
+        download_bucket_files(bucket, pairs, raise_on_missing_files=True, token=False)
+        for f, local in pairs:
+            _report(f.path, json.loads(local.read_text()), tally)
+
+
+def survey(repos, bucket=SURVEY_BUCKET, prefix=SURVEY_BUCKET_PREFIX) -> int:
+    tally = {"affected": 0, "clean": 0, "unknown": 0}
+    _survey_repos(repos, tally)
+    if bucket:
+        _survey_bucket(bucket, prefix, tally)
+
+    print(f"\n{tally['affected']} affected, {tally['unknown']} with no rope info, "
+          f"{tally['clean']} correct")
+    if tally["affected"]:
         print("Fix: download the checkpoint, run this script on the local copy, "
-              "then republish under open-athena/MarinFold with a PROVENANCE.md.")
+              "then republish with a PROVENANCE.md.")
     return 0
 
 
@@ -119,11 +190,14 @@ def main() -> int:
     ap.add_argument("--survey", action="store_true",
                     help="read-only: report affected published checkpoints")
     ap.add_argument("--repo", action="append", default=None,
-                    help="override the --survey repo list (repeatable)")
+                    help="override the --survey model-repo list (repeatable)")
+    ap.add_argument("--no-bucket", action="store_true",
+                    help="skip the bucket sweep during --survey")
     a = ap.parse_args()
 
     if a.survey:
-        return survey(a.repo or SURVEY_REPOS)
+        return survey(a.repo or SURVEY_REPOS,
+                      bucket=None if a.no_bucket else SURVEY_BUCKET)
     if a.directory is None:
         ap.error("pass a checkpoint directory, or --survey")
     return repair_local(a.directory)


### PR DESCRIPTION
Found while publishing exp175's checkpoint (#197): the bucket-published exp120
config has no `rope_theta` and no `rope_scaling`, so `transformers` falls back
to its defaults when loading it.

## What the audit found

All nine `checkpoints/*/config.json` in `open-athena/MarinFold` were compared
against the levanter run config each came from.

**Two were defective** — both transformers 5.12.1 exports carrying rope solely
as a `rope_parameters` block, which transformers 4.x does not read and does not
error on:

| checkpoint | trained | 4.x actually loaded |
|---|---|---|
| `exp120-cv1-1_5b-orig-lr3e-4-e1-cos/hf/step-1005` | 500000 + llama3 | 10000, no scaling |
| `plm-exp108-cv1-3b-e16-lr2e-3-wd0p2-v3/hf/step-71311` | 500000 + llama3 | 10000, no scaling |

The lowest-frequency `inv_freq` component came out **354x too large**. Same
defect and same cost bracket (0.77 nats/token) as #180.

**Two Llama checkpoints look wrong but are correct.**
`protein-contacts-1_5b-distance-masked-70f8f5` (exp0) and
`protein-contacts-1_5b-3.5e-4-contacts-v1-unmasked-3b5cf2` (exp67) carry
`rope_theta: 10000` / `rope_scaling: null`. Both were trained with a bare
`LlamaConfig`, whose `rope` field defaults to
`DefaultRotaryEmbeddingsConfig(theta=10000)` — so 10000/no-scaling is exactly
what levanter trained. Not touched.

The remaining five (exp75, exp117, exp163, exp166, exp175) were already correct.

## What was published

Config-only. **The weights were not touched** — for each of the two affected
checkpoints, only `config.json` changed, and within it only the two keys
`rope_theta` and `rope_scaling`. A `PROVENANCE.md` was added to each recording
the repair. The bucket now audits 9/9 clean.

Verification, on the real `from_pretrained` path:

- repaired configs reproduce levanter's `Llama3RotaryEmbeddingsConfig()` rope
  under transformers **4.57.6** to within float32 rounding (max |diff| 4.2e-08)
- under transformers **5.12.1** the effective `inv_freq` is **bit-identical**
  before and after, so the additive fix does not regress 5.x

## The code change in this PR

`--survey` only looked at three HF *model repos* and explicitly skipped the
bucket, on a comment asserting bucket checkpoints "read correctly". That comment
is why this sat undetected. The sweep now covers the bucket too (a separate
storage layer — `list_repo_files` / `hf_hub_download` do not see into it, hence
the parallel code path).

It also classifies a third state: a config with neither `rope_parameters` nor
`rope_theta` used to print as `ok (rope_theta=None)`. This script can't repair
that — nothing in the file says what rope was trained — but it isn't correct
either, so it now reports as `NO ROPE` and points at the levanter run config.

`marinfold/tests/test_config.py` passes (10 tests).

## Follow-up, not in this PR

The published `PROVENANCE.md` for exp117 and exp166 tells readers to regenerate
with `scripts/repair_published_configs.py`, which does not exist — the script is
`scripts/repair_checkpoint_config.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)