### PR TITLE
exp245: log eval-test read 2 — helico#14 folding evaluation

### DIFF
--- a/experiments/exp245_evals_foldbench_held_out_monomers/data/eval_test_reads.md
+++ b/experiments/exp245_evals_foldbench_held_out_monomers/data/eval_test_reads.md
@@ -12,9 +12,10 @@ entries then the set is spent and needs replacing — sample recent PDB directly
 rather than re-filtering a curated benchmark
 ([#241](https://github.com/Open-Athena/MarinFold/issues/241)).
 
-| # | date | scored | why | R-precision (all) |
+| # | date | scored | why | result (metric named per row) |
 |---|---|---|---|---|
-| 1 | 2026-08-18 | #232 `m2-p06` decontam, #232 `m1-p02` decontam, #199 CW cooldown (contaminated reference) — plus all five baselines | The set's construction read ([#245](https://github.com/Open-Athena/MarinFold/issues/245)): establishing whether the historical FoldBench-100 (now eval-val) was over-reporting, which is what licenses using eval-val freely from here on. Nothing was selected on the result. | 0.538 / 0.493 / 0.613; Protenix-v2 single-seq 0.265, ESMFold 0.753, ESMFold2 0.792, Protenix-v2 + MSA 0.845, seq-KNN 0.582 (unfiltered corpus) / 0.426 (decontaminated) |
+| 1 | 2026-08-18 | #232 `m2-p06` decontam, #232 `m1-p02` decontam, #199 CW cooldown (contaminated reference) — plus all five baselines | The set's construction read ([#245](https://github.com/Open-Athena/MarinFold/issues/245)): establishing whether the historical FoldBench-100 (now eval-val) was over-reporting, which is what licenses using eval-val freely from here on. Nothing was selected on the result. | **R-precision (all)**: 0.538 / 0.493 / 0.613; Protenix-v2 single-seq 0.265, ESMFold 0.753, ESMFold2 0.792, Protenix-v2 + MSA 0.845, seq-KNN 0.582 (unfiltered corpus) / 0.426 (decontaminated) |
+| 2 | 2026-08-19 | Helico `contacts-msafree-01` step 6000, seven conditioning arms, plus Protenix-v2 single-seq and +MSA as folding baselines | The folding half of #245's question, filed as [Open-Athena/helico#14](https://github.com/Open-Athena/helico/issues/14): does contact quality carry into structure accuracy? Reported in lDDT, not R-precision. Both eval sets were scored together and nothing was selected on eval-test — every arm was fixed before the run, and eval-val agrees with eval-test to within 0.014 for all nine predictors. | **lDDT** (eval-test, 210 units common to all arms): Helico + `m2-p06` contacts top-L **0.619**, top-L/2 0.603, top-L/5 0.558; Helico + oracle contacts 0.860; Helico + Protenix-v2 +MSA contacts 0.828; Helico + Protenix-v2 single-seq contacts 0.394; Helico, no contacts 0.364. Baselines: Protenix-v2 + MSA 0.860, Protenix-v2 single sequence 0.400. |
 
 ## What a read costs
 


### PR DESCRIPTION
exp245's ledger requires every eval-test read to be recorded. [Open-Athena/helico#14](https://github.com/Open-Athena/helico/issues/14) is one: it scored all 333 units with Helico, conditioned on contacts from `exp232-decontam-m2-p06-step145199`, and reports **lDDT after folding** rather than contact R-precision.

Nothing was selected on eval-test. Every arm was fixed before the run, both sets were scored together, and all nine predictors agree between eval-val and eval-test to within 0.014 — so #245's conclusion that eval-val is an unbiased stand-in holds in this metric too.

The ledger's last column previously read "R-precision (all)"; it now names the metric per row, since entry 2 is in lDDT.

Headline from that read, on the 210 eval-test units common to every arm:

| predictor | lDDT |
| --- | ---: |
| Helico + `m2-p06` contacts, top-L | 0.619 |
| Helico + oracle contacts | 0.860 |
| Helico + Protenix-v2 +MSA contacts | 0.828 |
| Helico + Protenix-v2 single-seq contacts | 0.394 |
| Helico, no contacts | 0.364 |
| Protenix-v2 + MSA | 0.860 |
| Protenix-v2 single sequence | 0.400 |

The contact arms reproduce #245's published precision at L, L/2 and L/5 on 326/326 mapped targets to floating point, so the contact quality feeding each arm is exactly the number this experiment published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)