### PR TITLE
Follow parse.py's ONE_LETTER_TO_THREE rename into the experiments

### DIFF
--- a/experiments/exp100_data_only_correct_documents_contacts_v1/select_targets.py
+++ b/experiments/exp100_data_only_correct_documents_contacts_v1/select_targets.py
@@ -43,7 +43,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from marinfold.document_structures.contacts_v1 import residues_from_sequence
-from marinfold.document_structures.contacts_v1.parse import _ONE_LETTER_TO_THREE
+from marinfold.document_structures.contacts_v1.parse import ONE_LETTER_TO_THREE
 
 NUM_POS = 2000          # contacts-v1 position-token wrap
 MIN_SEP = 6             # contacts-v1 min_seq_separation
@@ -55,7 +55,7 @@ CONTACT_RE = re.compile(r"<contact>\s+<p(\d+)>\s+<p(\d+)>")
 NTERM_RE = re.compile(r"<n-term>\s+<p(\d+)>")
 RES_RE = re.compile(r"<p(\d+)>\s+<([A-Z]{3})>")
 
-THREE_TO_ONE = {three: one for one, three in _ONE_LETTER_TO_THREE.items()}
+THREE_TO_ONE = {three: one for one, three in ONE_LETTER_TO_THREE.items()}
 
 
 def shard_path(i: int) -> str:

--- a/experiments/exp120_models_regen_vs_reepoch_contacts_v1/select_round0_val.py
+++ b/experiments/exp120_models_regen_vs_reepoch_contacts_v1/select_round0_val.py
@@ -47,7 +47,7 @@ RES_RE = re.compile(r"<p(\d+)>\s+<([A-Z]{3})>")
 
 # Standard 3-letter -> 1-letter amino-acid map (matches contacts-v1 residues;
 # unknown/non-standard fall back to "X"). Equivalent to exp100 parse_doc's
-# THREE_TO_ONE derived from marinfold's _ONE_LETTER_TO_THREE.
+# THREE_TO_ONE derived from marinfold's ONE_LETTER_TO_THREE.
 THREE_TO_ONE = {
     "ALA": "A", "ARG": "R", "ASN": "N", "ASP": "D", "CYS": "C", "GLN": "Q",
     "GLU": "E", "GLY": "G", "HIS": "H", "ILE": "I", "LEU": "L", "LYS": "K",

--- a/experiments/exp200_models_rl_post_training_best_of_n/prep_prompt_pool.py
+++ b/experiments/exp200_models_rl_post_training_best_of_n/prep_prompt_pool.py
@@ -44,7 +44,7 @@ from marinfold.document_structures.contacts_v1 import (
     build_document,
     residues_from_sequence,
 )
-from marinfold.document_structures.contacts_v1.parse import _ONE_LETTER_TO_THREE
+from marinfold.document_structures.contacts_v1.parse import ONE_LETTER_TO_THREE
 
 TRAIN_DIR = (
     "marin-us-east5/protein-structure/MarinFold/exp53_contacts_v1_5x/documents/train"
@@ -57,7 +57,7 @@ BEGIN = "<begin_statements>"
 CONTACT_RE = re.compile(r"<contact>\s+<p(\d+)>\s+<p(\d+)>")
 NTERM_RE = re.compile(r"<n-term>\s+<p(\d+)>")
 RES_RE = re.compile(r"<p(\d+)>\s+<([A-Z]{3})>")
-THREE_TO_ONE = {three: one for one, three in _ONE_LETTER_TO_THREE.items()}
+THREE_TO_ONE = {three: one for one, three in ONE_LETTER_TO_THREE.items()}
 
 
 def shard_path(i: int) -> str:

--- a/experiments/exp94_evals_sequence_knn_baseline/knn_lib.py
+++ b/experiments/exp94_evals_sequence_knn_baseline/knn_lib.py
@@ -36,7 +36,7 @@ import numpy as np
 # --- document parsing -------------------------------------------------------
 
 # Standard-20 three-letter -> one-letter, inverted from contacts_v1/parse.py's
-# `_ONE_LETTER_TO_THREE`. Anything else in a document (only ever <UNK>) -> "X".
+# `ONE_LETTER_TO_THREE`. Anything else in a document (only ever <UNK>) -> "X".
 ONE_TO_THREE = {
     "A": "ALA", "R": "ARG", "N": "ASN", "D": "ASP", "C": "CYS",
     "Q": "GLN", "E": "GLU", "G": "GLY", "H": "HIS", "I": "ILE",

--- a/experiments/exp98_data_generate_rollouts_contacts_v1_train/select_targets.py
+++ b/experiments/exp98_data_generate_rollouts_contacts_v1_train/select_targets.py
@@ -37,7 +37,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from marinfold.document_structures.contacts_v1 import residues_from_sequence
-from marinfold.document_structures.contacts_v1.parse import _ONE_LETTER_TO_THREE
+from marinfold.document_structures.contacts_v1.parse import ONE_LETTER_TO_THREE
 
 NUM_POS = 2000          # contacts-v1 position-token wrap
 MIN_SEP = 6             # contacts-v1 min_seq_separation
@@ -49,7 +49,7 @@ CONTACT_RE = re.compile(r"<contact>\s+<p(\d+)>\s+<p(\d+)>")
 NTERM_RE = re.compile(r"<n-term>\s+<p(\d+)>")
 RES_RE = re.compile(r"<p(\d+)>\s+<([A-Z]{3})>")
 
-THREE_TO_ONE = {three: one for one, three in _ONE_LETTER_TO_THREE.items()}
+THREE_TO_ONE = {three: one for one, three in ONE_LETTER_TO_THREE.items()}
 
 
 def shard_path(i: int) -> str:


### PR DESCRIPTION
[PR #221](https://github.com/Open-Athena/MarinFold/pull/221) (exp218) made contacts-v1's `_ONE_LETTER_TO_THREE` public as `ONE_LETTER_TO_THREE` and updated `read.py`, but three experiment callers kept importing the private name and now fail at import time:

```
ImportError: cannot import name '_ONE_LETTER_TO_THREE' from
'marinfold.document_structures.contacts_v1.parse'
```

`exp98` and `exp100` take marinfold as an in-repo path dependency (`marinfold = { path = "../../marinfold" }`), so they pick the rename up immediately.

## Changes

Import + use sites:
- `experiments/exp200_models_rl_post_training_best_of_n/prep_prompt_pool.py` (lines 47, 60)
- `experiments/exp98_data_generate_rollouts_contacts_v1_train/select_targets.py` (lines 40, 52)
- `experiments/exp100_data_only_correct_documents_contacts_v1/select_targets.py` (lines 46, 58)

Prose-only references to the old name in comments:
- `experiments/exp94_evals_sequence_knn_baseline/knn_lib.py:39`
- `experiments/exp120_models_regen_vs_reepoch_contacts_v1/select_round0_val.py:50`

Mechanical rename only — no behavior change. `grep -rn _ONE_LETTER_TO_THREE` is now empty repo-wide.

## Verification

```
cd marinfold && uv run --extra contacts-v1 pytest tests -q
423 passed, 3 skipped in 16.97s
```

The suite doesn't reach the experiment callers, so I also imported each fixed module directly (the actual failure mode). All three execute their module bodies cleanly and build the expected 20-entry `THREE_TO_ONE` (`ALA`→`A`, `TRP`→`W`). Confirmed the old name genuinely raises `ImportError` against current `parse.py`, so the bug was real rather than latent.

Also checked that `exp94`'s hardcoded `ONE_TO_THREE` still equals marinfold's map, so the comment it carries remains accurate.

## One thing worth noting

`exp200` does not declare `marinfold` in its `pyproject.toml` at all — its dependency list is the pinned `marin-*==0.2.76.dev31155643335` RL stack and nothing else. So `prep_prompt_pool.py` would raise `ModuleNotFoundError` in that experiment's own environment regardless of this rename; it resolves marinfold only from an ambient install or `PYTHONPATH`. Fixing the name is still correct and keeps the file consistent with the rest of the repo, but exp200's dependency declaration is a separate pre-existing gap that this PR does not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)