### PR TITLE
testing automated reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ PRIVATE_INFRA_NOTES.md
 # for monitoring state files, and by debugging / TDD skills generally)
 scratch/
 
+# macOS Finder metadata
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]


### PR DESCRIPTION
Adds `.DS_Store` to `.gitignore` so macOS Finder metadata stops showing up as untracked in `git status`.

Deliberately trivial — this PR exists to exercise the automated review workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNrrw1gLkpWFdA9pFQGGDg