### PR TITLE
Add an optional minimum new contact budget to CLI and sampling API

### DIFF
--- a/marinfold/README.md
+++ b/marinfold/README.md
@@ -67,13 +67,13 @@ stopping. Repeated contact statements count; this does not enforce unique
 pairs or subtract retractions.
 
 ```bash
-marinfold infer --model 1.5B --backend transformers \
+marinfold infer --backend transformers \
   --input-sequence MGDIQVQVNIDDNGKAAAAQ \
   --method rollout --n-rollouts 10 --min-new-contacts 30 --out preds.json
 ```
 
 The same option is available on `contacts-v1 infer` / `evaluate`, and on
-`InferenceConfig(model="1.5B", method="rollout", min_new_contacts=30)` for
+`InferenceConfig(model=None, method="rollout", min_new_contacts=30)` for
 `predict` / `evaluate`. Their output remains an aggregated contact-score map.
 
 For notebook code sampling a prompt that already contains, for example,
@@ -83,7 +83,7 @@ For notebook code sampling a prompt that already contains, for example,
 from marinfold import load_backend
 from marinfold.document_structures.contacts_v1 import sample_contacts
 
-backend = load_backend("transformers", model="1.5B")
+backend = load_backend("transformers", model=None)
 # prompt is a contacts-v1 document through your 10th contact, without <end>.
 prefix = backend.tokenizer.encode(prompt, add_special_tokens=False)
 [new_tokens] = sample_contacts(

--- a/marinfold/README.md
+++ b/marinfold/README.md
@@ -56,6 +56,50 @@ from marinfold.document_structures.contacts_v1 import (
 )
 ```
 
+## Require a minimum number of new contacts
+
+For contacts-v1 rollouts, `min_new_contacts` blocks `<end>` until each
+completion emits that many complete `<contact> <p_i> <p_j>` statements.
+Contacts already in the prompt do not count. Once the minimum is reached,
+the model samples normally and may emit more contacts before `<end>`.
+Omitting the option (or passing zero to `sample_contacts`) preserves normal
+stopping. Repeated contact statements count; this does not enforce unique
+pairs or subtract retractions.
+
+```bash
+marinfold infer --model 1.5B --backend transformers \
+  --input-sequence MGDIQVQVNIDDNGKAAAAQ \
+  --method rollout --n-rollouts 10 --min-new-contacts 30 --out preds.json
+```
+
+The same option is available on `contacts-v1 infer` / `evaluate`, and on
+`InferenceConfig(model="1.5B", method="rollout", min_new_contacts=30)` for
+`predict` / `evaluate`. Their output remains an aggregated contact-score map.
+
+For notebook code sampling a prompt that already contains, for example,
+10 contacts:
+
+```python
+from marinfold import load_backend
+from marinfold.document_structures.contacts_v1 import sample_contacts
+
+backend = load_backend("transformers", model="1.5B")
+# prompt is a contacts-v1 document through your 10th contact, without <end>.
+prefix = backend.tokenizer.encode(prompt, add_special_tokens=False)
+[new_tokens] = sample_contacts(
+    backend, [prefix], min_new_contacts=30, max_new_tokens=512,
+)
+completion = backend.tokenizer.decode(new_tokens, skip_special_tokens=False)
+```
+
+`max_new_tokens` is a hard cap across the entire completion; leave headroom
+for think tokens and other statements, and stay within the model's context
+window including the prompt. An impossible budget raises `ValueError`;
+failure to reach the contact minimum within the token cap raises
+`RuntimeError`. Sampling supports transformers and vLLM; MLX has no rollout
+sampler. Budgeted sampling may make multiple generation calls, resuming
+from the generated prefix while counting completed statements.
+
 ## Backends
 
 | Backend | When to use | Extra |

--- a/marinfold/marinfold/cli.py
+++ b/marinfold/marinfold/cli.py
@@ -148,12 +148,24 @@ def _make_inference_config(
     input_path: Path | None = None,
 ) -> Any:
     """Build the impl's InferenceConfig from the parsed CLI args."""
+    options = {
+        name: value
+        for name in ("method", "n_rollouts", "min_new_contacts")
+        if (value := getattr(args, name)) is not None
+    }
+    supported = {field.name for field in dataclasses.fields(impl.InferenceConfig)}
+    for name in options:
+        if name not in supported:
+            raise SystemExit(
+                f"--{name.replace('_', '-')} is not supported by this document structure."
+            )
     return impl.InferenceConfig(
         model=model_spec,
         input_path=input_path,
         backend=args.backend,
         batch_size=args.batch_size,
         dtype=args.dtype,
+        **options,
     )
 
 
@@ -270,6 +282,19 @@ def _emit_evaluate_plots(
 
 
 def _add_common(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--method", choices=("pairwise", "rollout"), default=None,
+        help="contacts-v1 readout (default pairwise). Rollout samples completions.",
+    )
+    p.add_argument(
+        "--n-rollouts", type=int, default=None,
+        help="Number of contacts-v1 rollout completions (default 100).",
+    )
+    p.add_argument(
+        "--min-new-contacts", type=int, default=None,
+        help="With --method rollout, block <end> until each completion emits "
+             "this many complete new contact statements. Omit for normal stopping.",
+    )
     p.add_argument(
         "--model", default=None,
         help="MODELS.yaml nickname (e.g. '1B') or a local directory "

--- a/marinfold/marinfold/cli.py
+++ b/marinfold/marinfold/cli.py
@@ -20,10 +20,10 @@ Dispatch is driven by packaged ``MODELS.yaml``:
    ``marinfold.document_structures.contacts_and_distances_v1``) and
    the appropriate function (``predict`` / ``evaluate``) is called.
 
-For impl-specific flags (seed-N sweeps, distance cap, …) use the
-per-impl ``cli.py`` instead. The top-level CLI keeps its surface
-narrow on purpose, but it does expose ``--batch-size`` because that
-one is useful for tuning backend memory / throughput across impls.
+The dispatcher owns common options such as ``--batch-size``. A selected
+implementation may expose ``add_inference_arguments(parser)`` to register
+its own inference options; matching InferenceConfig fields receive their
+parsed values. Lower-level tools stay on the per-impl ``cli.py``.
 """
 
 import argparse
@@ -148,25 +148,18 @@ def _make_inference_config(
     input_path: Path | None = None,
 ) -> Any:
     """Build the impl's InferenceConfig from the parsed CLI args."""
-    options = {
-        name: value
-        for name in ("method", "n_rollouts", "min_new_contacts")
-        if (value := getattr(args, name)) is not None
-    }
-    supported = {field.name for field in dataclasses.fields(impl.InferenceConfig)}
-    for name in options:
-        if name not in supported:
-            raise SystemExit(
-                f"--{name.replace('_', '-')} is not supported by this document structure."
-            )
-    return impl.InferenceConfig(
+    options = dict(
         model=model_spec,
         input_path=input_path,
         backend=args.backend,
         batch_size=args.batch_size,
         dtype=args.dtype,
-        **options,
     )
+    parsed = vars(args)
+    for field in dataclasses.fields(impl.InferenceConfig):
+        if field.name not in options and field.name in parsed:
+            options[field.name] = parsed[field.name]
+    return impl.InferenceConfig(**options)
 
 
 def _structures_from_sequence(impl: ModuleType, seq: str) -> list:
@@ -283,19 +276,6 @@ def _emit_evaluate_plots(
 
 def _add_common(p: argparse.ArgumentParser) -> None:
     p.add_argument(
-        "--method", choices=("pairwise", "rollout"), default=None,
-        help="contacts-v1 readout (default pairwise). Rollout samples completions.",
-    )
-    p.add_argument(
-        "--n-rollouts", type=int, default=None,
-        help="Number of contacts-v1 rollout completions (default 100).",
-    )
-    p.add_argument(
-        "--min-new-contacts", type=int, default=None,
-        help="With --method rollout, block <end> until each completion emits "
-             "this many complete new contact statements. Omit for normal stopping.",
-    )
-    p.add_argument(
         "--model", default=None,
         help="MODELS.yaml nickname (e.g. '1B') or a local directory "
              "with a model + tokenizer. Defaults to the MODELS.yaml "
@@ -328,7 +308,8 @@ def _add_common(p: argparse.ArgumentParser) -> None:
     )
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser(impl: ModuleType | None = None) -> argparse.ArgumentParser:
+    """Build common arguments and any selected implementation's extensions."""
     parser = argparse.ArgumentParser(
         prog="marinfold",
         description="MarinFold CLI: run a trained protein-document LLM "
@@ -393,12 +374,34 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_eval.set_defaults(func=cmd_evaluate)
 
+    register = getattr(impl, "add_inference_arguments", None)
+    if register is not None:
+        register(p_inf)
+        register(p_eval)
     return parser
 
 
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Select a document format before parsing its inference arguments.
+
+    The selection pass reads common flags, without loading
+    weights. Root help and invalid subcommands use the common parser alone.
+    """
+    argv = list(sys.argv[1:] if argv is None else argv)
+    impl = None
+    if argv and argv[0] in ("infer", "evaluate"):
+        selector = argparse.ArgumentParser(add_help=False)
+        _add_common(selector)
+        selected, _ = selector.parse_known_args(argv[1:])
+        _, structure = _resolve_model_and_structure(
+            selected.model, selected.document_structure,
+        )
+        impl = _load_impl(structure)
+    return build_parser(impl).parse_args(argv)
+
+
 def main(argv: list[str] | None = None) -> int:
-    parser = build_parser()
-    args = parser.parse_args(argv)
+    args = parse_args(argv)
     args.func(args)
     return 0
 

--- a/marinfold/marinfold/document_structures/contacts_v1/__init__.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/__init__.py
@@ -51,6 +51,7 @@ from .generate import (
     generate_sequence_only_document,
 )
 from .inference import (
+    add_inference_arguments,
     ContactStructure,
     InferenceConfig,
     evaluate,
@@ -109,6 +110,7 @@ __all__ = [
     "RawContact",
     "ResidueInfo",
     "all_domain_tokens",
+    "add_inference_arguments",
     "analyze_structure",
     "analyzed_from_row",
     "analyzed_to_row",

--- a/marinfold/marinfold/document_structures/contacts_v1/__init__.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/__init__.py
@@ -57,6 +57,7 @@ from .inference import (
     predict,
     structure_from_sequence,
 )
+from .sampling import sample_contacts
 from .parse import (
     ANALYZED_ROW_COLUMNS,
     DEFAULT_CIF_COLUMN,
@@ -126,5 +127,6 @@ __all__ = [
     "plot_infer_pdf",
     "predict",
     "residues_from_sequence",
+    "sample_contacts",
     "structure_from_sequence",
 ]

--- a/marinfold/marinfold/document_structures/contacts_v1/cli.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/cli.py
@@ -234,6 +234,7 @@ def _inference_config(args: argparse.Namespace) -> inference.InferenceConfig:
         temperature=args.temperature,
         top_p=args.top_p,
         top_k=args.top_k,
+        min_new_contacts=args.min_new_contacts,
     )
 
 
@@ -417,6 +418,10 @@ def build_parser() -> argparse.ArgumentParser:
         p.add_argument("--n-rollouts", type=int, default=100,
                        help="(--method rollout) sampled completions to vote over "
                             "(default 100).")
+        p.add_argument("--min-new-contacts", type=int, default=None,
+                       help="(--method rollout) block <end> until each completion "
+                            "emits this many complete new contact statements. "
+                            "Omit for normal stopping; token limits still apply.")
         p.add_argument("--temperature", type=float, default=1.0,
                        help="(--method rollout) sampling temperature (default 1.0).")
         p.add_argument("--top-p", type=float, default=0.95,

--- a/marinfold/marinfold/document_structures/contacts_v1/cli.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/cli.py
@@ -401,13 +401,7 @@ def build_parser() -> argparse.ArgumentParser:
                        help="Inference runtime. 'vllm' (Linux+GPU, default), "
                             "'transformers' (anywhere torch installs), or 'mlx' "
                             "(Apple Silicon native).")
-        p.add_argument("--method", choices=("pairwise", "rollout"),
-                       default="pairwise",
-                       help="Contact readout. 'pairwise' (default, fast) scores "
-                            "P(contact) per pair; 'rollout' (exp82's best, "
-                            "~150x slower) votes over sampled completions with a "
-                            "pairwise tie-break, and needs --backend vllm or "
-                            "transformers (not mlx).")
+        inference.add_inference_arguments(p)
         p.add_argument("--min-seq-separation", type=int, default=6,
                        help="Smallest |i-j| that can be a contact (default 6, "
                             "matching the contacts-v1 data).")
@@ -415,13 +409,6 @@ def build_parser() -> argparse.ArgumentParser:
                        help="(--method pairwise) resample the sequence definition "
                             "this many times and average P(contact) (test-time "
                             "augmentation; default 1).")
-        p.add_argument("--n-rollouts", type=int, default=100,
-                       help="(--method rollout) sampled completions to vote over "
-                            "(default 100).")
-        p.add_argument("--min-new-contacts", type=int, default=None,
-                       help="(--method rollout) block <end> until each completion "
-                            "emits this many complete new contact statements. "
-                            "Omit for normal stopping; token limits still apply.")
         p.add_argument("--temperature", type=float, default=1.0,
                        help="(--method rollout) sampling temperature (default 1.0).")
         p.add_argument("--top-p", type=float, default=0.95,

--- a/marinfold/marinfold/document_structures/contacts_v1/inference.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/inference.py
@@ -72,6 +72,7 @@ from marinfold import Backend, EvalResult, load_backend
 
 from .generate import GenerationConfig, build_document
 from .read import live_contacts
+from .sampling import _token_id, sample_contacts
 from .parse import (
     RawContact,
     ResidueInfo,
@@ -84,7 +85,6 @@ from .vocab import (
     BEGIN_STRUCTURE_TOKEN,
     CONTACT_TOKEN,
     CONTEXT_LENGTH,
-    END_TOKEN,
     NAME,
     NUM_POSITION_INDICES,
     position_token,
@@ -159,6 +159,12 @@ class InferenceConfig:
     fan-out backends batch internally (pairwise tails / rollout completions).
     ``keep_matrix`` adds the dense per-structure score matrix to each
     ``predict`` record.
+
+    ``min_new_contacts`` (rollout only) blocks end until each completion
+    emits this many complete contact statements. None keeps normal stopping.
+    Duplicates count and retractions do not undo the emitted count. A token
+    budget that cannot reach the minimum raises instead of returning a short
+    completion. See :func:`sample_contacts` for sampling prompted contacts.
     """
 
     model: str | None
@@ -177,6 +183,15 @@ class InferenceConfig:
     temperature: float = 1.0
     top_p: float = 0.95
     top_k: int = 50
+    min_new_contacts: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.min_new_contacts is None:
+            return
+        if not isinstance(self.min_new_contacts, int) or self.min_new_contacts < 0:
+            raise ValueError("min_new_contacts must be a non-negative integer or None.")
+        if self.method != "rollout":
+            raise ValueError("min_new_contacts requires method='rollout'.")
 
 
 @dataclass(frozen=True)
@@ -245,25 +260,6 @@ def _prefix_and_positions(
     nterm = result.n_term_index
     seq_positions = [(nterm + k) % NUM_POSITION_INDICES for k in range(result.seq_len)]
     return prefix, seq_positions, result.seq_len
-
-
-def _token_id(tokenizer, token: str) -> int:
-    """Resolve one domain token to its id; fail loudly on an UNK collapse.
-
-    A wrong / missing contacts-v1 tokenizer maps every ``<pX>`` / ``<contact>``
-    to the UNK id, which would otherwise silently produce a garbage contact
-    map. Catch it here, the way the contacts-and-distances-v1 distance-bin
-    resolver does.
-    """
-    tid = tokenizer.convert_tokens_to_ids(token)
-    unk_id = getattr(tokenizer, "unk_token_id", None)
-    if tid is None or (unk_id is not None and tid == unk_id):
-        raise ValueError(
-            f"Tokenizer has no dedicated id for {token!r} (got {tid}). The "
-            f"tokenizer is missing the contacts-v1 vocabulary — make sure it "
-            f"is co-located with the model."
-        )
-    return int(tid)
 
 
 def _fwd_matrix(
@@ -392,7 +388,6 @@ def _rollout_score_matrix(
     ``NotImplementedError`` from :meth:`Backend.sample_completions`.
     """
     tokenizer = backend.tokenizer
-    stop_id = _token_id(tokenizer, END_TOKEN)
 
     prefixes: list[list[int]] = []
     position_maps: list[dict[int, int]] = []
@@ -407,15 +402,19 @@ def _rollout_score_matrix(
 
     max_new = min(
         CONTEXT_LENGTH - len(prefixes[0]),
-        _ROLLOUT_TOKENS_PER_RESIDUE * seq_len + _ROLLOUT_TOKENS_CONSTANT,
+        max(
+            _ROLLOUT_TOKENS_PER_RESIDUE * seq_len + _ROLLOUT_TOKENS_CONSTANT,
+            3 * (cfg.min_new_contacts or 0) + 1,
+        ),
     )
-    completions = backend.sample_completions(
+    completions = sample_contacts(
+        backend,
         prefixes,
         max_new_tokens=max_new,
+        min_new_contacts=cfg.min_new_contacts,
         temperature=cfg.temperature,
         top_p=cfg.top_p,
         top_k=cfg.top_k,
-        stop_token_id=stop_id,
         batch_size=_adaptive_sample_batch(seq_len, cfg.batch_size),
     )
 
@@ -650,6 +649,8 @@ def predict(
         record["n_rollouts" if cfg.method == "rollout" else "ensemble_k"] = (
             cfg.n_rollouts if cfg.method == "rollout" else cfg.ensemble_k
         )
+        if cfg.min_new_contacts is not None:
+            record["min_new_contacts"] = cfg.min_new_contacts
         if cfg.keep_matrix:
             record["score_matrix"] = _band_masked(
                 score, seq_len, cfg.min_seq_separation
@@ -855,6 +856,8 @@ def evaluate(
             "n_rollouts": cfg.n_rollouts,
             "n_structures": n_scored,
             "per_structure_n_residues": per_structure_n_residues,
+            **({"min_new_contacts": cfg.min_new_contacts}
+               if cfg.min_new_contacts is not None else {}),
         },
     )
 

--- a/marinfold/marinfold/document_structures/contacts_v1/inference.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/inference.py
@@ -58,6 +58,7 @@ The model forward pass goes through :mod:`marinfold.inference`; this module
 is backend-agnostic (vLLM / transformers / MLX).
 """
 
+import argparse
 import math
 import warnings
 from collections import defaultdict
@@ -192,6 +193,24 @@ class InferenceConfig:
             raise ValueError("min_new_contacts must be a non-negative integer or None.")
         if self.method != "rollout":
             raise ValueError("min_new_contacts requires method='rollout'.")
+
+
+def add_inference_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register contacts-v1 sampling options for either CLI entry point."""
+    parser.add_argument(
+        "--method", choices=("pairwise", "rollout"), default="pairwise",
+        help="Contact readout (default pairwise). Rollout samples completions.",
+    )
+    parser.add_argument(
+        "--n-rollouts", type=int, default=100,
+        help="Number of rollout completions (default 100).",
+    )
+    parser.add_argument(
+        "--min-new-contacts", type=int, default=None,
+        help="With --method rollout, block <end> until each completion emits "
+             "this many complete new contact statements. Omit for normal "
+             "stopping; token limits still apply.",
+    )
 
 
 @dataclass(frozen=True)

--- a/marinfold/marinfold/document_structures/contacts_v1/sampling.py
+++ b/marinfold/marinfold/document_structures/contacts_v1/sampling.py
@@ -1,0 +1,163 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contact-budget sampling using the backends' native EOS suppression.
+
+Decode in segments whose length is the minimum number of tokens still
+needed to complete the contact budget. EOS is suppressed throughout each
+segment. Recount at its boundary, then resume ordinary sampling as soon
+as the budget is met. This never suppresses EOS past the requested minimum,
+even with think tokens, malformed statements, or partial contact triples.
+"""
+
+from collections import defaultdict
+from typing import Any
+
+from marinfold import Backend
+
+from .vocab import CONTACT_TOKEN, END_TOKEN, NUM_POSITION_INDICES, position_token
+
+
+def _token_id(tokenizer: Any, token: str) -> int:
+    """Resolve one domain token to its id; fail loudly on an UNK collapse.
+
+    A wrong / missing contacts-v1 tokenizer maps every position or contact
+    token to UNK, which would silently corrupt contact scoring and counting.
+    """
+    tid = tokenizer.convert_tokens_to_ids(token)
+    unk_id = getattr(tokenizer, "unk_token_id", None)
+    if tid is None or (unk_id is not None and tid == unk_id):
+        raise ValueError(
+            f"Tokenizer has no dedicated id for {token!r} (got {tid}). The "
+            f"tokenizer is missing the contacts-v1 vocabulary — make sure it "
+            f"is co-located with the model."
+        )
+    return int(tid)
+
+
+def _contact_progress(
+    tokens: list[int], contact_id: int, position_ids: set[int]
+) -> tuple[int, int]:
+    """Return complete emitted triples and the length of a trailing partial."""
+    count = sum(
+        head == contact_id and a in position_ids and b in position_ids
+        for head, a, b in zip(tokens, tokens[1:], tokens[2:])
+    )
+    if tokens and tokens[-1] == contact_id:
+        return count, 1
+    if len(tokens) >= 2 and tokens[-2] == contact_id and tokens[-1] in position_ids:
+        return count, 2
+    return count, 0
+
+
+def sample_contacts(
+    backend: Backend,
+    prefix_token_ids_batch: list[list[int]],
+    *,
+    max_new_tokens: int,
+    min_new_contacts: int | None = None,
+    temperature: float = 1.0,
+    top_p: float = 0.95,
+    top_k: int = 50,
+    seed: int | None = None,
+    batch_size: int | None = None,
+) -> list[list[int]]:
+    """Sample contacts-v1 completions, optionally requiring new contacts.
+
+    Args:
+        backend: A sampling backend (transformers or vLLM).
+        prefix_token_ids_batch: Equal-length prompts, which may already
+            contain contacts. Prompts should end at a statement boundary.
+        max_new_tokens: Total generated-token cap per completion, across
+            all segments, including any final end token.
+        min_new_contacts: Minimum complete ``<contact> <p_i> <p_j>``
+            statements in each completion. Prompt contacts do not count.
+            Duplicates count as emitted statements; retractions do not undo
+            this count. This is not a minimum of unique or live pairs.
+            None or zero leaves the backend's ordinary sampling unchanged.
+        temperature: Sampling temperature.
+        top_p: Nucleus sampling threshold.
+        top_k: Top-k sampling cutoff; zero disables filtering.
+        seed: Optional reproducibility seed. Segments use successive seeds.
+        batch_size: Backend generation batch-size hint.
+
+    Returns:
+        Generated token IDs for each prompt, excluding the prompt and end
+        token. After reaching the minimum, generation continues until the
+        model samples end or exhausts max_new_tokens.
+
+    Raises:
+        ValueError: Invalid budget or unequal/empty prompts.
+        RuntimeError: A completion exhausts its token cap before meeting
+            the requested minimum, or the backend stops while constrained.
+    """
+    if min_new_contacts is not None and (
+        not isinstance(min_new_contacts, int) or min_new_contacts < 0
+    ):
+        raise ValueError("min_new_contacts must be a non-negative integer or None.")
+    tokenizer = backend.tokenizer
+    stop_id = _token_id(tokenizer, END_TOKEN)
+    sampling: dict[str, Any] = dict(
+        temperature=temperature, top_p=top_p, top_k=top_k,
+        stop_token_id=stop_id, batch_size=batch_size,
+    )
+    if not min_new_contacts:
+        return backend.sample_completions(
+            prefix_token_ids_batch, max_new_tokens=max_new_tokens, seed=seed,
+            **sampling,
+        )
+    if max_new_tokens < 3 * min_new_contacts:
+        raise ValueError(
+            f"min_new_contacts={min_new_contacts} needs at least "
+            f"{3 * min_new_contacts} new tokens; max_new_tokens={max_new_tokens}."
+        )
+    if not prefix_token_ids_batch:
+        return []
+    lengths = {len(prefix) for prefix in prefix_token_ids_batch}
+    if len(lengths) != 1 or 0 in lengths:
+        raise ValueError("sample_contacts requires non-empty, equal-length prompts.")
+    contact_id = _token_id(tokenizer, CONTACT_TOKEN)
+    position_ids = {
+        _token_id(tokenizer, position_token(p))
+        for p in range(NUM_POSITION_INDICES)
+    }
+    completions: list[list[int]] = [[] for _ in prefix_token_ids_batch]
+    pending = list(range(len(completions)))
+    call_index = 0
+    while pending:
+        groups: dict[tuple[int, int, bool], list[int]] = defaultdict(list)
+        for row in pending:
+            tokens = completions[row]
+            count, partial = _contact_progress(tokens, contact_id, position_ids)
+            remaining = max_new_tokens - len(tokens)
+            constrained = count < min_new_contacts
+            needed = 3 * (min_new_contacts - count) - partial if constrained else 0
+            if constrained and remaining < needed:
+                raise RuntimeError(
+                    f"Completion {row} emitted {count}/{min_new_contacts} new "
+                    f"contacts within max_new_tokens={max_new_tokens}; increase "
+                    "the token budget."
+                )
+            if remaining:
+                chunk = needed if constrained else remaining
+                groups[(len(tokens), chunk, constrained)].append(row)
+        pending = []
+        for (_, chunk, constrained), rows in groups.items():
+            prompts = [prefix_token_ids_batch[row] + completions[row] for row in rows]
+            outputs = backend.sample_completions(
+                prompts, max_new_tokens=chunk,
+                min_new_tokens=chunk if constrained else 0,
+                seed=None if seed is None else seed + call_index,
+                **sampling,
+            )
+            call_index += 1
+            for row, output in zip(rows, outputs, strict=True):
+                if constrained and (len(output) != chunk or stop_id in output):
+                    raise RuntimeError(
+                        f"Backend stopped completion {row} before its contact "
+                        "minimum despite EOS suppression."
+                    )
+                completions[row].extend(output)
+                if constrained:
+                    pending.append(row)
+    return completions

--- a/marinfold/marinfold/inference/_mlx.py
+++ b/marinfold/marinfold/inference/_mlx.py
@@ -143,6 +143,7 @@ class MlxBackend:
         prefix_token_ids_batch: list[list[int]],
         *,
         max_new_tokens: int,
+        min_new_tokens: int = 0,
         temperature: float = 1.0,
         top_p: float = 0.95,
         top_k: int = 50,

--- a/marinfold/marinfold/inference/_transformers.py
+++ b/marinfold/marinfold/inference/_transformers.py
@@ -247,6 +247,7 @@ class TransformersBackend:
         prefix_token_ids_batch: list[list[int]],
         *,
         max_new_tokens: int,
+        min_new_tokens: int = 0,
         temperature: float = 1.0,
         top_p: float = 0.95,
         top_k: int = 50,
@@ -254,6 +255,8 @@ class TransformersBackend:
         seed: int | None = None,
         batch_size: int | None = None,
     ) -> list[list[int]]:
+        if not 0 <= min_new_tokens <= max_new_tokens:
+            raise ValueError("min_new_tokens must be between 0 and max_new_tokens.")
         if not prefix_token_ids_batch:
             return []
         lengths = {len(p) for p in prefix_token_ids_batch}
@@ -284,6 +287,11 @@ class TransformersBackend:
             gen_kwargs["top_k"] = top_k
         if stop_token_id is not None:
             gen_kwargs["eos_token_id"] = stop_token_id
+        if min_new_tokens:
+            gen_kwargs["min_new_tokens"] = min_new_tokens
+            # A checkpoint's forced terminal token must not override the
+            # minimum when a constrained segment reaches its token cap.
+            gen_kwargs["forced_eos_token_id"] = None
 
         chunk_size = batch_size or self._tail_batch_size
         results: list[list[int]] = []

--- a/marinfold/marinfold/inference/_vllm.py
+++ b/marinfold/marinfold/inference/_vllm.py
@@ -158,6 +158,7 @@ class VllmBackend:
         prefix_token_ids_batch: list[list[int]],
         *,
         max_new_tokens: int,
+        min_new_tokens: int = 0,
         temperature: float = 1.0,
         top_p: float = 0.95,
         top_k: int = 50,
@@ -165,6 +166,8 @@ class VllmBackend:
         seed: int | None = None,
         batch_size: int | None = None,
     ) -> list[list[int]]:
+        if not 0 <= min_new_tokens <= max_new_tokens:
+            raise ValueError("min_new_tokens must be between 0 and max_new_tokens.")
         if not prefix_token_ids_batch:
             return []
         # vLLM samples natively: one SamplingParams, all prompts in one
@@ -178,6 +181,7 @@ class VllmBackend:
             top_p=top_p,
             top_k=top_k if (top_k and top_k > 0) else -1,
             max_tokens=max_new_tokens,
+            min_tokens=min_new_tokens,
             stop_token_ids=[stop_token_id] if stop_token_id is not None else None,
             seed=seed,
             n=1,

--- a/marinfold/marinfold/inference/core.py
+++ b/marinfold/marinfold/inference/core.py
@@ -152,6 +152,7 @@ class Backend(Protocol):
         prefix_token_ids_batch: list[list[int]],
         *,
         max_new_tokens: int,
+        min_new_tokens: int = 0,
         temperature: float = 1.0,
         top_p: float = 0.95,
         top_k: int = 50,
@@ -171,6 +172,9 @@ class Backend(Protocol):
                 length — callers rolling out one protein pass document
                 realizations whose prefixes are the same length. May be empty.
             max_new_tokens: Hard cap on generated tokens per row.
+            min_new_tokens: Block the stop/EOS token until this many new
+                tokens have been emitted, ignoring the prompt. Must be in
+                [0, max_new_tokens]. Zero preserves normal stopping.
             temperature / top_p / top_k: sampling controls; ``top_k <= 0``
                 disables top-k filtering.
             stop_token_id: stop a row's generation at this token (excluded

--- a/marinfold/tests/document_structures/contacts_v1/test_inference.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_inference.py
@@ -78,6 +78,7 @@ class _PlantedBackend:
         return out
 
     def sample_completions(self, prefix_token_ids_batch, *, max_new_tokens,
+                           min_new_tokens=0,
                            temperature=1.0, top_p=0.95, top_k=50,
                            stop_token_id=None, seed=None, batch_size=None):
         """Emit each prefix's planted contacts, in *that* realization's tokens.
@@ -299,6 +300,18 @@ def test_score_matrix_rejects_unknown_method():
     cfg = inf.InferenceConfig(model="/x", method="bogus")
     with pytest.raises(ValueError, match="pairwise|rollout"):
         inf._score_matrix(object(), s, cfg)
+
+
+def test_rollout_contact_minimum_reaches_sampler():
+    structure = inf.structure_from_sequence(_SEQ, entry_id="demo")
+    positions = inf._prefix_and_positions(structure, entry_id="demo")[1]
+    backend = _PlantedBackend(_tokenizer(), positions, planted=[(0, 12)])
+    cfg = inf.InferenceConfig(
+        model="/stub", method="rollout", n_rollouts=2, min_new_contacts=1,
+    )
+    scores, length = inf._rollout_score_matrix(backend, structure, cfg)
+    assert length == len(_SEQ)
+    assert scores[0, 12] >= 2
 
 
 def test_predict_rollout_votes_and_ranks(monkeypatch):

--- a/marinfold/tests/document_structures/contacts_v1/test_sampling.py
+++ b/marinfold/tests/document_structures/contacts_v1/test_sampling.py
@@ -1,0 +1,116 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise EOS gating against a scripted sampler that prefers early EOS."""
+
+import pytest
+
+from marinfold import build_tokenizer
+from marinfold.document_structures.contacts_v1 import sample_contacts
+from marinfold.document_structures.contacts_v1.vocab import all_domain_tokens
+
+
+class ScriptedBackend:
+    def __init__(self, prompts: list[str], streams: list[str], *, early_end: bool = True):
+        self.tokenizer = build_tokenizer(all_domain_tokens())
+        self.prompts = [self.encode(prompt) for prompt in prompts]
+        self.streams = [self.encode(stream) for stream in streams]
+        self.early_end = early_end
+        self.calls: list[dict] = []
+
+    def encode(self, text: str) -> list[int]:
+        return self.tokenizer.encode(text, add_special_tokens=False)
+
+    def sample_completions(self, prompts: list[list[int]], **kwargs) -> list[list[int]]:
+        self.calls.append(kwargs)
+        minimum = kwargs.get("min_new_tokens", 0)
+        maximum = kwargs["max_new_tokens"]
+        outputs = []
+        for prompt in prompts:
+            row = next(i for i, base in enumerate(self.prompts) if prompt[:len(base)] == base)
+            offset = len(prompt) - len(self.prompts[row])
+            if not minimum and self.early_end:
+                outputs.append([])
+                continue
+            output = self.streams[row][offset:offset + maximum]
+            stop_id = kwargs["stop_token_id"]
+            if stop_id in output:
+                output = output[:output.index(stop_id)]
+            outputs.append(output)
+        return outputs
+
+
+def test_thirty_new_contacts_excludes_ten_prompt_contacts() -> None:
+    contact = "<contact> <p0> <p10> "
+    backend = ScriptedBackend(["<begin_statements> " + contact * 10], [contact * 40])
+    before = [list(prompt) for prompt in backend.prompts]
+    result = sample_contacts(
+        backend, backend.prompts, max_new_tokens=150, min_new_contacts=30,
+    )
+    assert result == [backend.encode(contact * 30)]
+    assert backend.prompts == before
+    assert [call["min_new_tokens"] for call in backend.calls] == [90, 0]
+
+
+@pytest.mark.parametrize("minimum", [None, 0])
+def test_default_allows_immediate_end_in_one_unchanged_call(minimum: int | None) -> None:
+    backend = ScriptedBackend(["<begin_statements>"], ["<contact> <p0> <p10>"])
+    assert sample_contacts(
+        backend, backend.prompts, max_new_tokens=20, min_new_contacts=minimum, seed=42,
+    ) == [[]]
+    assert len(backend.calls) == 1
+    assert "min_new_tokens" not in backend.calls[0]
+    assert backend.calls[0]["seed"] == 42
+
+
+def test_think_malformed_and_partial_contacts_have_independent_row_budgets() -> None:
+    streams = [
+        "<think> <contact> <p0> <p10> <contact> <p1> <p11>",
+        "<contact> <think> <p0> <retract> <p0> <p10> "
+        "<contact> <p2> <p12> <contact> <p3> <p13>",
+    ]
+    backend = ScriptedBackend(["<p0> <begin_statements>", "<p1> <begin_statements>"], streams)
+    result = sample_contacts(backend, backend.prompts, max_new_tokens=30, min_new_contacts=2)
+    assert result == [backend.encode(stream) for stream in streams]
+
+
+def test_minimum_does_not_force_stopping_at_budget() -> None:
+    stream = "<contact> <p0> <p10> <contact> <p1> <p11> <end>"
+    backend = ScriptedBackend(["<begin_statements>"], [stream], early_end=False)
+    result = sample_contacts(backend, backend.prompts, max_new_tokens=20, min_new_contacts=1)
+    assert result == [backend.encode(stream)[:-1]]
+
+
+@pytest.mark.parametrize("minimum", [-1, 1.5])
+def test_invalid_minimum_rejected_before_sampling(minimum: int) -> None:
+    backend = ScriptedBackend(["<begin_statements>"], [""])
+    with pytest.raises(ValueError, match="non-negative integer"):
+        sample_contacts(backend, backend.prompts, max_new_tokens=20, min_new_contacts=minimum)
+    assert not backend.calls
+
+
+def test_impossible_token_budget_rejected_before_sampling() -> None:
+    backend = ScriptedBackend(["<begin_statements>"], [""])
+    with pytest.raises(ValueError, match="at least 90"):
+        sample_contacts(backend, backend.prompts, max_new_tokens=89, min_new_contacts=30)
+    assert not backend.calls
+
+
+def test_token_cap_reports_unmet_minimum() -> None:
+    backend = ScriptedBackend(["<begin_statements>"], ["<think> " * 12])
+    with pytest.raises(RuntimeError, match="0/2 new contacts"):
+        sample_contacts(backend, backend.prompts, max_new_tokens=12, min_new_contacts=2)
+
+
+def test_minimum_can_exactly_fill_token_cap() -> None:
+    stream = "<contact> <p0> <p10>"
+    backend = ScriptedBackend(["<begin_statements>"], [stream])
+    assert sample_contacts(
+        backend, backend.prompts, max_new_tokens=3, min_new_contacts=1,
+    ) == [backend.encode(stream)]
+
+
+def test_backend_early_stop_is_an_error() -> None:
+    backend = ScriptedBackend(["<begin_statements>"], ["<end>"])
+    with pytest.raises(RuntimeError, match="despite EOS suppression"):
+        sample_contacts(backend, backend.prompts, max_new_tokens=10, min_new_contacts=1)

--- a/marinfold/tests/test_contact_budget_cli.py
+++ b/marinfold/tests/test_contact_budget_cli.py
@@ -1,0 +1,53 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from marinfold import cli
+from marinfold.document_structures import contacts_v1, contacts_and_distances_v1
+from marinfold.document_structures.contacts_v1.cli import (
+    _inference_config, build_parser,
+)
+
+
+@pytest.mark.parametrize("command", ["infer", "evaluate"])
+def test_top_level_contact_budget_config(command: str) -> None:
+    args = cli.build_parser().parse_args([
+        command, "--input", "example.cif", "--out", "out.json",
+        "--method", "rollout", "--n-rollouts", "2", "--min-new-contacts", "30",
+    ])
+    cfg = cli._make_inference_config(contacts_v1, None, args)
+    assert cfg.method == "rollout"
+    assert cfg.n_rollouts == 2
+    assert cfg.min_new_contacts == 30
+
+
+def test_per_structure_contact_budget_config(tmp_path) -> None:
+    args = build_parser().parse_args([
+        "infer", "--model", str(tmp_path), "--input-sequence", "ACDEFGHIK",
+        "--out", "out.json", "--method", "rollout", "--min-new-contacts", "30",
+    ])
+    assert _inference_config(args).min_new_contacts == 30
+
+
+def test_default_config_unchanged() -> None:
+    args = cli.build_parser().parse_args([
+        "infer", "--input-sequence", "ACDEFGHIK", "--out", "out.json",
+    ])
+    cfg = cli._make_inference_config(contacts_v1, None, args)
+    assert cfg.method == "pairwise"
+    assert cfg.min_new_contacts is None
+
+
+def test_pairwise_rejects_contact_budget() -> None:
+    with pytest.raises(ValueError, match="method='rollout'"):
+        contacts_v1.InferenceConfig(model=None, min_new_contacts=30)
+
+
+def test_other_document_structure_rejects_contact_budget() -> None:
+    args = cli.build_parser().parse_args([
+        "infer", "--input-sequence", "ACDEFGHIK", "--out", "out.json",
+        "--min-new-contacts", "30",
+    ])
+    with pytest.raises(SystemExit, match="not supported"):
+        cli._make_inference_config(contacts_and_distances_v1, None, args)

--- a/marinfold/tests/test_contact_budget_cli.py
+++ b/marinfold/tests/test_contact_budget_cli.py
@@ -4,16 +4,17 @@
 import pytest
 
 from marinfold import cli
-from marinfold.document_structures import contacts_v1, contacts_and_distances_v1
+from marinfold.document_structures import contacts_v1
 from marinfold.document_structures.contacts_v1.cli import (
     _inference_config, build_parser,
 )
 
 
 @pytest.mark.parametrize("command", ["infer", "evaluate"])
-def test_top_level_contact_budget_config(command: str) -> None:
-    args = cli.build_parser().parse_args([
+def test_top_level_contact_budget_config(command: str, tmp_path) -> None:
+    args = cli.parse_args([
         command, "--input", "example.cif", "--out", "out.json",
+        "--model", str(tmp_path), "--document-structure", "contacts-v1",
         "--method", "rollout", "--n-rollouts", "2", "--min-new-contacts", "30",
     ])
     cfg = cli._make_inference_config(contacts_v1, None, args)
@@ -44,10 +45,33 @@ def test_pairwise_rejects_contact_budget() -> None:
         contacts_v1.InferenceConfig(model=None, min_new_contacts=30)
 
 
-def test_other_document_structure_rejects_contact_budget() -> None:
-    args = cli.build_parser().parse_args([
-        "infer", "--input-sequence", "ACDEFGHIK", "--out", "out.json",
-        "--min-new-contacts", "30",
+def test_other_document_structure_rejects_contact_budget(tmp_path, capsys) -> None:
+    with pytest.raises(SystemExit) as error:
+        cli.parse_args([
+            "infer", "--input-sequence", "ACDEFGHIK", "--out", "out.json",
+            "--model", str(tmp_path), "--document-structure", "contacts-and-distances-v1",
+            "--min-new-contacts", "30",
+        ])
+    assert error.value.code == 2
+    assert "unrecognized arguments: --min-new-contacts" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("structure, exposes_budget", [
+    ("contacts-v1", True), ("contacts-and-distances-v1", False),
+])
+def test_selected_format_controls_help(structure, exposes_budget, tmp_path, capsys) -> None:
+    with pytest.raises(SystemExit) as error:
+        cli.main([
+            "infer", "--model", str(tmp_path), "--document-structure", structure, "--help",
+        ])
+    assert error.value.code == 0
+    assert ("--min-new-contacts" in capsys.readouterr().out) == exposes_budget
+
+
+@pytest.mark.parametrize("model_args", [[], ["--model", "contacts-v1-exp75-1.5B"]])
+def test_nickname_selects_format_arguments(model_args: list[str]) -> None:
+    args = cli.parse_args([
+        "infer", *model_args, "--input-sequence", "ACDEFGHIK", "--out", "out.json",
+        "--method", "rollout", "--min-new-contacts", "30",
     ])
-    with pytest.raises(SystemExit, match="not supported"):
-        cli._make_inference_config(contacts_and_distances_v1, None, args)
+    assert args.min_new_contacts == 30

--- a/marinfold/tests/test_transformers.py
+++ b/marinfold/tests/test_transformers.py
@@ -6,6 +6,9 @@ import pytest
 torch = pytest.importorskip("torch")
 
 from marinfold.inference._transformers import _resolve_dtype  # noqa: E402
+from marinfold.inference._transformers import TransformersBackend  # noqa: E402
+from marinfold import build_tokenizer  # noqa: E402
+from transformers import GPT2Config, GPT2LMHeadModel  # noqa: E402
 
 
 def test_bfloat16_resolves_to_torch_bfloat16() -> None:
@@ -29,3 +32,30 @@ def test_transformers_reexports_shared_tokenizer_loader() -> None:
     from marinfold.inference._transformers import _load_tokenizer
 
     assert _load_tokenizer is load_tokenizer
+
+
+def test_sample_minimum_suppresses_preferred_eos_only_for_new_tokens(tmp_path) -> None:
+    tokenizer = build_tokenizer(["<start>", "<end>", "<other>"])
+    stop_id = tokenizer.convert_tokens_to_ids("<end>")
+    model = GPT2LMHeadModel(GPT2Config(
+        vocab_size=len(tokenizer), n_positions=32, n_embd=32, n_layer=1, n_head=1,
+        eos_token_id=stop_id, bos_token_id=None,
+    ))
+    # A real CPU model with constant logits: EOS overwhelmingly dominates,
+    # so the constrained path must mask it before sampling.
+    with torch.no_grad():
+        for parameter in model.parameters():
+            parameter.zero_()
+        model.transformer.ln_f.bias.fill_(1.0)
+        model.lm_head.weight[stop_id].fill_(1.0)
+    model.save_pretrained(tmp_path)
+    tokenizer.save_pretrained(tmp_path)
+    backend = TransformersBackend(tmp_path, device="cpu", dtype="float32")
+    prompts = [[tokenizer.convert_tokens_to_ids("<start>")] * 10] * 2
+    common = dict(max_new_tokens=8, stop_token_id=stop_id, seed=42, batch_size=1)
+    assert backend.sample_completions(prompts, **common) == [[], []]
+    constrained = backend.sample_completions(prompts, min_new_tokens=3, **common)
+    assert [len(row) for row in constrained] == [3, 3]
+    assert all(stop_id not in row for row in constrained)
+    with pytest.raises(ValueError, match="min_new_tokens"):
+        backend.sample_completions(prompts, min_new_tokens=9, **common)


### PR DESCRIPTION
Contacts-v1 sampling can end before a caller has enough additional contact statements. Add optional `min_new_contacts` to `sample_contacts` and rollout `InferenceConfig`, plus `--min-new-contacts` on both CLI entry points. A prompt with 10 contacts and a minimum of 30 now suppresses `<end>` until 30 complete additional contact statements have been emitted, then resumes normal stopping. Omitting the option preserves the existing sampling path and default pairwise CLI behavior.

Inference arguments are registered by the selected document-format implementation, so other formats neither advertise nor accept contacts-only flags.

The contact sampler counts generated triples only and uses the backends' native minimum-token EOS masking in bounded segments. Segment lengths account for partial triples, so think tokens and malformed statements cannot satisfy the contact budget or postpone re-enabling EOS past the threshold. Duplicate statements count; retractions do not subtract from the emitted count. Impossible or unmet token budgets raise explicitly. The raw notebook sampler accepts existing prompted contacts; CLI rollout predictions remain aggregate contact-score maps.

Validation: the full package suite passed on the final commit with 456 tests, 2 skipped, and 17 network tests excluded (`uv run --python 3.11 --locked --extra transformers --extra contacts-v1 pytest -m 'not network'`). Coverage includes 10 prompted/30 generated contacts, default early stopping, generation beyond the minimum, independent batch rows, partial/malformed statements, token-cap failures, CLI routing, and a real tiny Transformers model on CPU that strongly prefers EOS. No vLLM GPU run was performed.

Budgeted sampling can require multiple generation calls and prefix prefills, particularly for outputs with many non-contact tokens. The default path remains a single backend call.
